### PR TITLE
Update character, background and desk on reload theme changing resolution

### DIFF
--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -12,37 +12,36 @@ AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_
 {
     ao_app = p_ao_app;
 
-    m_movie = new QMovie(this);
+    m_reader = new QMovie(this);
 
     m_frame_timer = new QTimer(this);
     m_frame_timer->setSingleShot(true);
 
-    connect(m_movie, SIGNAL(frameChanged(int)), this, SLOT(on_frame_changed(int)));
+    connect(m_reader, SIGNAL(frameChanged(int)), this, SLOT(on_frame_changed(int)));
     connect(m_frame_timer, SIGNAL(timeout()), this, SLOT(timer_done()));
 }
 
-void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix, bool show)
+void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix, bool p_visible)
 {
-    QString gif_path;
-    QStringList f_vec;
+    QString target_path;
     QStringList f_paths{
-        ao_app->get_character_path(p_char) + emote_prefix + p_emote.toLower(), // .gif
-        ao_app->get_character_path(p_char) + p_emote.toLower(),                // .png
-        ao_app->get_theme_variant_path() + "placeholder",                      // .gif
-        ao_app->get_theme_path() + "placeholder",                              // .gif
-        ao_app->get_default_theme_path() + "placeholder"                       // .gif
+        ao_app->get_character_path(p_char) + p_emote_prefix + p_emote.toLower(), // .gif
+        ao_app->get_character_path(p_char) + p_emote.toLower(),                  // .png
+        ao_app->get_theme_variant_path() + "placeholder",                        // .gif
+        ao_app->get_theme_path() + "placeholder",                                // .gif
+        ao_app->get_default_theme_path() + "placeholder"                         // .gif
     };
 
     for (auto &f_file : f_paths)
     {
         bool found = false;
-        for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"})
+        for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
         {
             QString fullPath = f_file + ext;
             found            = file_exists(fullPath);
             if (found)
             {
-                gif_path = fullPath;
+                target_path = fullPath;
                 break;
             }
         }
@@ -50,41 +49,32 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix, bo
         if (found)
             break;
     }
-    shown = show;
-    filename = gif_path;
-    refresh();
-}
 
-void AOCharMovie::refresh()
-{
-    m_movie->stop();
-    m_movie->setFileName(filename);
-
-    QImageReader *reader = new QImageReader(filename);
+    show();
+    if (!p_visible)
+        hide();
 
     movie_frames.clear();
-    QImage f_image = reader->read();
-    while (!f_image.isNull())
-    {
-        if (m_flipped)
-            movie_frames.append(f_image.mirrored(true, false));
-        else
-            movie_frames.append(f_image);
-        f_image = reader->read();
+    QImageReader *reader = new QImageReader(target_path);
+    for (int i = 0; i < reader->imageCount(); ++i)
+    { // optimize can be better, but I'll just keep it like that for now
+        QImage f_image = reader->read();
+        if (m_mirror)
+            f_image = f_image.mirrored(true, false);
+        movie_frames.append(f_image);
     }
     delete reader;
 
-    show();
-    if (!shown)
-        hide();
-
-    m_movie->start();
+    m_reader->stop();
+    this->clear();
+    m_reader->setFileName(target_path);
+    m_reader->start();
 }
 
 bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
 {
     QString f_file_path = ao_app->get_character_path(p_char) + p_emote.toLower();
-    bool f_file_exist = false;
+    bool f_file_exist   = false;
 
     { // figure out what extension the animation is using
         QString f_source_path = ao_app->get_character_path(p_char) + p_emote.toLower();
@@ -93,7 +83,7 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
             QString f_target_path = f_source_path + i_ext;
             if (file_exists(f_target_path))
             {
-                f_file_path = f_target_path;
+                f_file_path  = f_target_path;
                 f_file_exist = true;
                 break;
             }
@@ -103,51 +93,58 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
     // play if it exist
     if (f_file_exist)
     {
-        m_movie->stop();
+        m_reader->stop();
         this->clear();
-        play_once = true;
-        m_movie->setFileName(f_file_path);
+        m_play_once = true;
+        m_reader->setFileName(f_file_path);
         play(p_char, p_emote, "", show);
     }
 
     return f_file_exist;
 }
 
-void AOCharMovie::play_talking(QString p_char, QString p_emote, bool show)
+void AOCharMovie::play_talking(QString p_char, QString p_emote, bool p_visible)
 {
     QString gif_path = ao_app->get_character_path(p_char) + "(b)" + p_emote.toLower();
 
-    m_movie->stop();
+    m_reader->stop();
     this->clear();
-    play_once = false;
-    m_movie->setFileName(gif_path);
-    play(p_char, p_emote, "(b)", show);
+    m_play_once = false;
+    m_reader->setFileName(gif_path);
+    play(p_char, p_emote, "(b)", p_visible);
 }
 
-void AOCharMovie::play_idle(QString p_char, QString p_emote, bool show)
+void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
 {
     QString gif_path = ao_app->get_character_path(p_char) + "(a)" + p_emote.toLower();
 
     this->clear();
-    m_movie->stop();
-    play_once = false;
-    m_movie->setFileName(gif_path);
-    play(p_char, p_emote, "(a)", show);
+    m_reader->stop();
+    m_play_once = false;
+    m_reader->setFileName(gif_path);
+    play(p_char, p_emote, "(a)", p_visible);
+}
+
+void AOCharMovie::set_mirror_enabled(bool p_enable)
+{
+    m_mirror = p_enable;
 }
 
 void AOCharMovie::stop()
 {
     //for all intents and purposes, stopping is the same as hiding. at no point do we want a frozen gif to display
-    m_movie->stop();
+    m_reader->stop();
     m_frame_timer->stop();
     this->hide();
 }
 
-void AOCharMovie::combo_resize(int w, int h)
+void AOCharMovie::combo_resize(QSize p_size)
 {
-    QSize f_size(w, h);
-    this->resize(f_size);
-    m_movie->setScaledSize(f_size);
+    resize(p_size);
+    m_reader->stop();
+    m_frame_timer->stop();
+    m_reader->setScaledSize(p_size);
+    m_reader->start();
 }
 
 void AOCharMovie::on_frame_changed(int p_frame_num)
@@ -155,20 +152,20 @@ void AOCharMovie::on_frame_changed(int p_frame_num)
     if (movie_frames.size() > p_frame_num)
     {
         AOPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(p_frame_num));
-        this->setPixmap(f_pixmap.scaleToSize(this->size()));
+        this->setPixmap(f_pixmap.scale_to_size(this->size()));
     }
 
     // pre-anim only
-    if (play_once)
+    if (m_play_once)
     {
-        int f_frame_count = m_movie->frameCount();
+        int f_frame_count = m_reader->frameCount();
         if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1))
         {
-            int f_frame_delay = m_movie->nextFrameDelay();
+            int f_frame_delay = m_reader->nextFrameDelay();
             if (f_frame_delay < 0)
                 f_frame_delay = 0;
             m_frame_timer->start(f_frame_delay);
-            m_movie->stop();
+            m_reader->stop();
         }
     }
 }

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -50,11 +50,17 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix, bo
         if (found)
             break;
     }
+    shown = show;
+    filename = gif_path;
+    refresh();
+}
 
+void AOCharMovie::refresh()
+{
     m_movie->stop();
-    m_movie->setFileName(gif_path);
+    m_movie->setFileName(filename);
 
-    QImageReader *reader = new QImageReader(gif_path);
+    QImageReader *reader = new QImageReader(filename);
 
     movie_frames.clear();
     QImage f_image = reader->read();
@@ -68,9 +74,9 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix, bo
     }
     delete reader;
 
-    this->show();
-    if (!show)
-        this->hide();
+    show();
+    if (!shown)
+        hide();
 
     m_movie->start();
 }

--- a/aocharmovie.h
+++ b/aocharmovie.h
@@ -20,9 +20,9 @@ public:
   bool play_pre(QString p_char, QString p_emote, bool show);
   void play_talking(QString p_char, QString p_emote, bool show);
   void play_idle(QString p_char, QString p_emote, bool show);
-
   void set_flipped(bool p_flipped) {m_flipped = p_flipped;}
 
+  void refresh();
   void stop();
 
   void combo_resize(int w, int h);
@@ -39,6 +39,8 @@ private:
   bool m_flipped = false;
 
   bool play_once = true;
+  bool shown = true;
+  QString filename = "";
 
 signals:
   void done();

--- a/aocharmovie.h
+++ b/aocharmovie.h
@@ -1,53 +1,45 @@
 #ifndef AOCHARMOVIE_H
 #define AOCHARMOVIE_H
 
-#include <QMovie>
-#include <QLabel>
-#include <QTimer>
-
 #include "aopixmap.h"
+
+#include <QLabel>
+#include <QMovie>
+#include <QTimer>
 
 class AOApplication;
 
 class AOCharMovie : public QLabel
 {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app);
+    AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app);
 
-  void play(QString p_char, QString p_emote, QString emote_prefix, bool show);
-  bool play_pre(QString p_char, QString p_emote, bool show);
-  void play_talking(QString p_char, QString p_emote, bool show);
-  void play_idle(QString p_char, QString p_emote, bool show);
-  void set_flipped(bool p_flipped) {m_flipped = p_flipped;}
-
-  void refresh();
-  void stop();
-
-  void combo_resize(int w, int h);
+    void play(QString p_char, QString p_emote, QString emote_prefix, bool show);
+    bool play_pre(QString p_char, QString p_emote, bool show);
+    void play_talking(QString p_char, QString p_emote, bool show);
+    void play_idle(QString p_char, QString p_emote, bool show);
+    void set_mirror_enabled(bool p_enable);
+    void combo_resize(QSize p_size);
+    void stop();
 
 private:
-  AOApplication *ao_app = nullptr;
+    AOApplication *ao_app = nullptr;
 
-  QMovie *m_movie;
-  QVector<QImage> movie_frames;
-  QTimer *m_frame_timer;
+    QMovie *m_reader;
+    QVector<QImage> movie_frames;
+    QTimer *m_frame_timer;
 
-  const int time_mod = 62;
-
-  bool m_flipped = false;
-
-  bool play_once = true;
-  bool shown = true;
-  QString filename = "";
+    bool m_mirror    = false;
+    bool m_play_once = false;
 
 signals:
-  void done();
+    void done();
 
 private slots:
-  void on_frame_changed(int n_frame);
-  void timer_done();
+    void on_frame_changed(int n_frame);
+    void timer_done();
 };
 
 #endif // AOCHARMOVIE_H

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -44,7 +44,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
-  evidence_icon->setPixmap(f_pixmap.scaleToSize(evidence_icon->size()));
+  evidence_icon->setPixmap(f_pixmap.scale_to_size(evidence_icon->size()));
 
   QString f_path = ao_app->get_image_path(gif_name);
   evidence_movie->setFileName(f_path);

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -13,7 +13,7 @@ void AOImage::set_image(QString p_image)
 {
   QString f_path = ao_app->get_image_path(p_image);
   AOPixmap f_pixmap(f_path);
-  this->setPixmap(f_pixmap.scaleToSize(size()));
+  this->setPixmap(f_pixmap.scale_to_size(size()));
 
   // Store final path if the path exists
   if (file_exists(f_path))
@@ -34,7 +34,7 @@ void AOImage::set_image_from_path(QString p_path)
     final_path = default_path;
 
   AOPixmap f_pixmap(final_path);
-  this->setPixmap(f_pixmap.scaleToSize(size()));
+  this->setPixmap(f_pixmap.scale_to_size(size()));
 
   // Store final path if the path exists
   if (file_exists(final_path))

--- a/aopixmap.cpp
+++ b/aopixmap.cpp
@@ -4,8 +4,7 @@ AOPixmap::AOPixmap(QPixmap p_pixmap) : m_pixmap(p_pixmap)
 {
     if (m_pixmap.isNull())
     {
-        m_pixmap = QPixmap(1, 1);
-        m_pixmap.fill(Qt::transparent);
+        clear();
     }
 }
 
@@ -14,7 +13,13 @@ AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path))
 
 }
 
-QPixmap AOPixmap::scaleToSize(QSize p_size)
+void AOPixmap::clear()
+{
+    m_pixmap = QPixmap(1, 1);
+    m_pixmap.fill(Qt::transparent);
+}
+
+QPixmap AOPixmap::scale_to_size(QSize p_size)
 {
     bool f_is_pixmap_larger = m_pixmap.width() > p_size.width() || m_pixmap.height() > p_size.height();
     return m_pixmap.scaled(p_size, Qt::IgnoreAspectRatio, f_is_pixmap_larger ? Qt::SmoothTransformation : Qt::FastTransformation);

--- a/aopixmap.h
+++ b/aopixmap.h
@@ -6,10 +6,12 @@
 class AOPixmap
 {
 public:
-    AOPixmap(QPixmap p_pixmap);
+    AOPixmap(QPixmap p_pixmap = QPixmap());
     AOPixmap(QString p_file_path);
 
-    QPixmap scaleToSize(QSize p_size);
+    void clear();
+
+    QPixmap scale_to_size(QSize p_size);
 
 private:
     QPixmap m_pixmap;

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -33,6 +33,14 @@ void AOScene::set_image(QString p_image)
     // do not update the movie if we're using the same file
     if (m_movie && m_movie->fileName() == target_path)
         return;
+    filename = target_path;
+    refresh();
+}
+
+void AOScene::refresh()
+{
+    if (filename.isEmpty())
+        return;
 
     // clear previous
     this->clear();
@@ -43,7 +51,7 @@ void AOScene::set_image(QString p_image)
     // create new movie to run
     m_movie = new QMovie(this);
     setMovie(m_movie);
-    m_movie->setFileName(target_path);
+    m_movie->setFileName(filename);
     m_movie->setScaledSize(size());
     m_movie->start();
 }

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -6,10 +6,10 @@
 #include <QDebug>
 #include <QMovie>
 
-AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app)
-    : QLabel(parent)
+AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent), ao_app(p_ao_app)
 {
-    ao_app = p_ao_app;
+    m_reader = new QMovie(this);
+    setMovie(m_reader);
 }
 
 void AOScene::set_image(QString p_image)
@@ -31,27 +31,17 @@ void AOScene::set_image(QString p_image)
     }
 
     // do not update the movie if we're using the same file
-    if (m_movie && m_movie->fileName() == target_path)
+    if (m_reader->fileName() == target_path)
         return;
-    filename = target_path;
-    refresh();
+    m_reader->stop();
+    m_reader->setFileName(target_path);
+    m_reader->start();
 }
 
-void AOScene::refresh()
+void AOScene::combo_resize(QSize p_size)
 {
-    if (filename.isEmpty())
-        return;
-
-    // clear previous
-    this->clear();
-
-    // delete current movie
-    delete m_movie;
-
-    // create new movie to run
-    m_movie = new QMovie(this);
-    setMovie(m_movie);
-    m_movie->setFileName(filename);
-    m_movie->setScaledSize(size());
-    m_movie->start();
+    resize(p_size);
+    m_reader->stop();
+    m_reader->setScaledSize(p_size);
+    m_reader->start();
 }

--- a/aoscene.h
+++ b/aoscene.h
@@ -14,10 +14,12 @@ public:
     explicit AOScene(QWidget *parent, AOApplication *p_ao_app);
 
     void set_image(QString p_image);
+    void refresh();
 
 private:
     AOApplication *ao_app = nullptr;
     QMovie *m_movie       = nullptr;
+    QString filename = "";
 };
 
 #endif // AOSCENE_H

--- a/aoscene.h
+++ b/aoscene.h
@@ -11,15 +11,14 @@ class AOScene : public QLabel
     Q_OBJECT
 
 public:
-    explicit AOScene(QWidget *parent, AOApplication *p_ao_app);
+    AOScene(QWidget *parent, AOApplication *p_ao_app);
 
     void set_image(QString p_image);
-    void refresh();
+    void combo_resize(QSize p_size);
 
 private:
     AOApplication *ao_app = nullptr;
-    QMovie *m_movie       = nullptr;
-    QString filename = "";
+    QMovie *m_reader      = nullptr;
 };
 
 #endif // AOSCENE_H

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -869,9 +869,9 @@ void Courtroom::handle_chatmessage_2() // handles IC
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
 
   if (ao_app->flipping_enabled && m_chatmessage[FLIP].toInt() == 1)
-    ui_vp_player_char->set_flipped(true);
+    ui_vp_player_char->set_mirror_enabled(true);
   else
-    ui_vp_player_char->set_flipped(false);
+    ui_vp_player_char->set_mirror_enabled(false);
 
   switch (emote_mod)
   {

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -573,6 +573,10 @@ void Courtroom::set_widgets()
 
   ui_vp_player_char->move(0, 0);
   ui_vp_player_char->combo_resize(ui_viewport->width(), ui_viewport->height());
+  if (ui_vp_player_char->size() != original_viewport_size)
+  {
+    ui_vp_player_char->refresh();
+  }
 
   //the AO2 desk element
   ui_vp_desk->move(0, 0);

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -562,6 +562,7 @@ void Courtroom::set_widgets()
 
   ui_vp_background->move(0, 0);
   ui_vp_background->resize(ui_viewport->width(), ui_viewport->height());
+  ui_vp_background->refresh();
 
   ui_vp_speedlines->move(0, 0);
   ui_vp_speedlines->combo_resize(ui_viewport->width(), ui_viewport->height());
@@ -572,6 +573,7 @@ void Courtroom::set_widgets()
   //the AO2 desk element
   ui_vp_desk->move(0, 0);
   ui_vp_desk->resize(ui_viewport->width(), ui_viewport->height());
+  ui_vp_desk->refresh();
 
   ui_vp_evidence_display->move(0, 0);
   ui_vp_evidence_display->resize(ui_viewport->width(), ui_viewport->height());

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -558,33 +558,20 @@ void Courtroom::set_widgets()
   ui_background->resize(m_courtroom_width, m_courtroom_height);
   ui_background->set_image("courtroombackground.png");
 
-  QSize original_viewport_size = ui_viewport->size();
   set_size_and_pos(ui_viewport, "viewport");
 
   ui_vp_background->move(0, 0);
-  ui_vp_background->resize(ui_viewport->width(), ui_viewport->height());
-  if (ui_vp_background->size() != original_viewport_size)
-  {
-    ui_vp_background->refresh();
-  }
+  ui_vp_background->combo_resize(ui_viewport->size());
 
   ui_vp_speedlines->move(0, 0);
   ui_vp_speedlines->combo_resize(ui_viewport->width(), ui_viewport->height());
 
   ui_vp_player_char->move(0, 0);
-  ui_vp_player_char->combo_resize(ui_viewport->width(), ui_viewport->height());
-  if (ui_vp_player_char->size() != original_viewport_size)
-  {
-    ui_vp_player_char->refresh();
-  }
+  ui_vp_player_char->combo_resize(ui_viewport->size());
 
   //the AO2 desk element
   ui_vp_desk->move(0, 0);
-  ui_vp_desk->resize(ui_viewport->width(), ui_viewport->height());
-  if (ui_vp_desk->size() != original_viewport_size)
-  {
-    ui_vp_desk->refresh();
-  }
+  ui_vp_desk->combo_resize(ui_viewport->size());
 
   ui_vp_evidence_display->move(0, 0);
   ui_vp_evidence_display->resize(ui_viewport->width(), ui_viewport->height());

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -558,11 +558,15 @@ void Courtroom::set_widgets()
   ui_background->resize(m_courtroom_width, m_courtroom_height);
   ui_background->set_image("courtroombackground.png");
 
+  QSize original_viewport_size = ui_viewport->size();
   set_size_and_pos(ui_viewport, "viewport");
 
   ui_vp_background->move(0, 0);
   ui_vp_background->resize(ui_viewport->width(), ui_viewport->height());
-  ui_vp_background->refresh();
+  if (ui_vp_background->size() != original_viewport_size)
+  {
+    ui_vp_background->refresh();
+  }
 
   ui_vp_speedlines->move(0, 0);
   ui_vp_speedlines->combo_resize(ui_viewport->width(), ui_viewport->height());
@@ -573,7 +577,10 @@ void Courtroom::set_widgets()
   //the AO2 desk element
   ui_vp_desk->move(0, 0);
   ui_vp_desk->resize(ui_viewport->width(), ui_viewport->height());
-  ui_vp_desk->refresh();
+  if (ui_vp_desk->size() != original_viewport_size)
+  {
+    ui_vp_desk->refresh();
+  }
 
   ui_vp_evidence_display->move(0, 0);
   ui_vp_evidence_display->resize(ui_viewport->width(), ui_viewport->height());


### PR DESCRIPTION
Previously if a reload theme changed viewport, the old assets would display on screen until another person spoke IC, which led either to awkwardly hidden assets (due to viewport size shrinking) or awkwardly bordered assets (due to viewport size increasing)