### PR TITLE
Fix Linux case-sensitivity issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle : LLVM 
+BreakBeforeBraces : Allman
+AllowShortBlocksOnASingleLine : Never
+AllowShortCaseLabelsOnASingleLine : false
+AllowShortFunctionsOnASingleLine : None
+AllowShortIfStatementsOnASingleLine : Never
+AllowShortLambdasOnASingleLine : None
+AllowShortLoopsOnASingleLine : false
+# AllowShortEnumsOnASingleLine : false

--- a/aoabstractplayer.cpp
+++ b/aoabstractplayer.cpp
@@ -5,7 +5,10 @@ AOAbstractPlayer::AOAbstractPlayer(QObject *p_parent, AOApplication *p_ao_app)
 {
 }
 
-int AOAbstractPlayer::get_volume() { return m_volume; }
+int AOAbstractPlayer::get_volume()
+{
+  return m_volume;
+}
 
 void AOAbstractPlayer::set_volume(int p_volume)
 {

--- a/aoabstractplayer.cpp
+++ b/aoabstractplayer.cpp
@@ -1,8 +1,9 @@
 #include "aoabstractplayer.h"
 
 AOAbstractPlayer::AOAbstractPlayer(QObject *p_parent, AOApplication *p_ao_app)
-  : QObject(p_parent), ao_app(p_ao_app)
-{}
+    : QObject(p_parent), ao_app(p_ao_app)
+{
+}
 
 int AOAbstractPlayer::get_volume()
 {

--- a/aoabstractplayer.cpp
+++ b/aoabstractplayer.cpp
@@ -5,10 +5,7 @@ AOAbstractPlayer::AOAbstractPlayer(QObject *p_parent, AOApplication *p_ao_app)
 {
 }
 
-int AOAbstractPlayer::get_volume()
-{
-  return m_volume;
-}
+int AOAbstractPlayer::get_volume() { return m_volume; }
 
 void AOAbstractPlayer::set_volume(int p_volume)
 {

--- a/aoabstractplayer.h
+++ b/aoabstractplayer.h
@@ -25,7 +25,7 @@ signals:
   void new_volume(int p_volume);
 
 protected:
-  AOApplication* ao_app = nullptr;
+  AOApplication *ao_app = nullptr;
 
 private:
   int m_volume = 0;

--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -124,11 +124,20 @@ void AOApplication::set_theme_variant(QString p_variant)
   emit reload_theme();
 }
 
-void AOApplication::on_config_theme_changed() { emit reload_theme(); }
+void AOApplication::on_config_theme_changed()
+{
+  emit reload_theme();
+}
 
-void AOApplication::on_config_reload_theme_requested() { emit reload_theme(); }
+void AOApplication::on_config_reload_theme_requested()
+{
+  emit reload_theme();
+}
 
-void AOApplication::on_config_theme_variant_changed() { emit reload_theme(); }
+void AOApplication::on_config_theme_variant_changed()
+{
+  emit reload_theme();
+}
 
 void AOApplication::set_favorite_list()
 {
@@ -177,7 +186,10 @@ bool AOApplication::get_chatlog_scrolldown()
   return config->log_goes_downward_enabled();
 }
 
-int AOApplication::get_chatlog_max_lines() { return config->log_max_lines(); }
+int AOApplication::get_chatlog_max_lines()
+{
+  return config->log_max_lines();
+}
 
 int AOApplication::get_chat_tick_interval()
 {
@@ -263,6 +275,12 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
   }
 }
 
-void AOApplication::on_courtroom_closing() { config_panel->hide(); }
+void AOApplication::on_courtroom_closing()
+{
+  config_panel->hide();
+}
 
-void AOApplication::on_courtroom_destroyed() { config_panel->hide(); }
+void AOApplication::on_courtroom_destroyed()
+{
+  config_panel->hide();
+}

--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -1,32 +1,37 @@
 #include "aoapplication.h"
 
-#include "lobby.h"
 #include "courtroom.h"
-#include "networkmanager.h"
 #include "debug_functions.h"
+#include "lobby.h"
+#include "networkmanager.h"
 
 #include "aoconfig.h"
 #include "aoconfigpanel.h"
 
 #include <QDebug>
-#include <QRect>
 #include <QDesktopWidget>
+#include <QRect>
 
 AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
-    discord = new AttorneyOnline::Discord();
+  discord = new AttorneyOnline::Discord();
 
-    net_manager = new NetworkManager(this);
-    connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)), SLOT(ms_connect_finished(bool, bool)));
+  net_manager = new NetworkManager(this);
+  connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)),
+          SLOT(ms_connect_finished(bool, bool)));
 
-    config = new AOConfig(this);
-    connect(config, SIGNAL(theme_changed(QString)), this, SLOT(on_config_theme_changed()));
-    connect(config, SIGNAL(theme_variant_changed(QString)), this, SLOT(on_config_theme_variant_changed()));
+  config = new AOConfig(this);
+  connect(config, SIGNAL(theme_changed(QString)), this,
+          SLOT(on_config_theme_changed()));
+  connect(config, SIGNAL(theme_variant_changed(QString)), this,
+          SLOT(on_config_theme_variant_changed()));
 
-    config_panel = new AOConfigPanel;
-    connect(config_panel, SIGNAL(reload_theme()), this, SLOT(on_config_reload_theme_requested()));
-    connect(this, SIGNAL(reload_theme()), config_panel, SLOT(on_config_reload_theme_requested()));
-    config_panel->hide();
+  config_panel = new AOConfigPanel;
+  connect(config_panel, SIGNAL(reload_theme()), this,
+          SLOT(on_config_reload_theme_requested()));
+  connect(this, SIGNAL(reload_theme()), config_panel,
+          SLOT(on_config_reload_theme_requested()));
+  config_panel->hide();
 }
 
 AOApplication::~AOApplication()
@@ -49,8 +54,8 @@ void AOApplication::construct_lobby()
   lobby_constructed = true;
 
   QRect screenGeometry = QApplication::desktop()->screenGeometry();
-  int x = (screenGeometry.width()-w_lobby->width()) / 2;
-  int y = (screenGeometry.height()-w_lobby->height()) / 2;
+  int x = (screenGeometry.width() - w_lobby->width()) / 2;
+  int y = (screenGeometry.height() - w_lobby->height()) / 2;
   w_lobby->move(x, y);
 
   discord->state_lobby();
@@ -60,7 +65,7 @@ void AOApplication::construct_lobby()
 
 void AOApplication::destruct_lobby()
 {
-  if(!lobby_constructed)
+  if (!lobby_constructed)
   {
     qDebug() << "W: lobby was attempted destructed when it did not exist";
     return;
@@ -80,61 +85,63 @@ void AOApplication::construct_courtroom()
 
   w_courtroom = new Courtroom(this);
   connect(w_courtroom, SIGNAL(closing()), this, SLOT(on_courtroom_closing()));
-  connect(w_courtroom, SIGNAL(destroyed()), this, SLOT(on_courtroom_destroyed()));
+  connect(w_courtroom, SIGNAL(destroyed()), this,
+          SLOT(on_courtroom_destroyed()));
   courtroom_constructed = true;
 
   QRect screenGeometry = QApplication::desktop()->screenGeometry();
-  int x = (screenGeometry.width()-w_courtroom->width()) / 2;
-  int y = (screenGeometry.height()-w_courtroom->height()) / 2;
+  int x = (screenGeometry.width() - w_courtroom->width()) / 2;
+  int y = (screenGeometry.height() - w_courtroom->height()) / 2;
   w_courtroom->move(x, y);
 }
 
 void AOApplication::destruct_courtroom()
 {
-    // destruct courtroom
-    if (courtroom_constructed)
-    {
-        delete w_courtroom;
-        courtroom_constructed = false;
-    }
-    else
-    {
-        qDebug() << "W: courtroom was attempted destructed when it did not exist";
-    }
+  // destruct courtroom
+  if (courtroom_constructed)
+  {
+    delete w_courtroom;
+    courtroom_constructed = false;
+  }
+  else
+  {
+    qDebug() << "W: courtroom was attempted destructed when it did not exist";
+  }
 
-    // gracefully close our connection to the current server
-    net_manager->disconnect_from_server();
+  // gracefully close our connection to the current server
+  net_manager->disconnect_from_server();
 }
 
 QString AOApplication::get_version_string()
 {
-    return QString::number(RELEASE) + "." + QString::number(MAJOR_VERSION) + "." + QString::number(MINOR_VERSION);
+  return QString::number(RELEASE) + "." + QString::number(MAJOR_VERSION) + "." +
+         QString::number(MINOR_VERSION);
 }
 
 void AOApplication::set_theme_variant(QString p_variant)
 {
-    config->set_theme_variant(p_variant);
-    emit reload_theme();
+  config->set_theme_variant(p_variant);
+  emit reload_theme();
 }
 
 void AOApplication::on_config_theme_changed()
 {
-    emit reload_theme();
+  emit reload_theme();
 }
 
 void AOApplication::on_config_reload_theme_requested()
 {
-    emit reload_theme();
+  emit reload_theme();
 }
 
 void AOApplication::on_config_theme_variant_changed()
 {
-    emit reload_theme();
+  emit reload_theme();
 }
 
 void AOApplication::set_favorite_list()
 {
-    favorite_list = read_serverlist_txt();
+  favorite_list = read_serverlist_txt();
 }
 
 QString AOApplication::get_current_char()
@@ -147,67 +154,67 @@ QString AOApplication::get_current_char()
 
 void AOApplication::toggle_config_panel()
 {
-    config_panel->setVisible(!config_panel->isVisible());
-    if (config_panel->isVisible())
-    {
-        QRect screenGeometry = QApplication::desktop()->screenGeometry();
-        int x = (screenGeometry.width()-config_panel->width()) / 2;
-        int y = (screenGeometry.height()-config_panel->height()) / 2;
-        config_panel->setFocus();
-        config_panel->raise();
-        config_panel->move(x, y);
-    }
+  config_panel->setVisible(!config_panel->isVisible());
+  if (config_panel->isVisible())
+  {
+    QRect screenGeometry = QApplication::desktop()->screenGeometry();
+    int x = (screenGeometry.width() - config_panel->width()) / 2;
+    int y = (screenGeometry.height() - config_panel->height()) / 2;
+    config_panel->setFocus();
+    config_panel->raise();
+    config_panel->move(x, y);
+  }
 }
 
 bool AOApplication::get_always_pre_enabled()
 {
-    return config->always_pre_enabled();
+  return config->always_pre_enabled();
 }
 
 bool AOApplication::get_first_person_enabled()
 {
-    return config->get_bool("first_person", false);
+  return config->get_bool("first_person", false);
 }
 
 bool AOApplication::get_server_alerts_enabled()
 {
-    return config->server_alerts_enabled();
+  return config->server_alerts_enabled();
 }
 
 bool AOApplication::get_chatlog_scrolldown()
 {
-    return config->log_goes_downward_enabled();
+  return config->log_goes_downward_enabled();
 }
 
 int AOApplication::get_chatlog_max_lines()
 {
-    return config->log_max_lines();
+  return config->log_max_lines();
 }
 
 int AOApplication::get_chat_tick_interval()
 {
-    return config->chat_tick_interval();
+  return config->chat_tick_interval();
 }
 
 bool AOApplication::get_chatlog_newline()
 {
-    return config->log_uses_newline_enabled();
+  return config->log_uses_newline_enabled();
 }
 
 bool AOApplication::get_enable_logging_enabled()
 {
-    return config->log_is_recording_enabled();
+  return config->log_is_recording_enabled();
 }
 
 bool AOApplication::get_music_change_log_enabled()
 {
-    return config->log_music_enabled();
+  return config->log_music_enabled();
 }
 
 void AOApplication::add_favorite_server(int p_server)
 {
-    if (p_server < 0 || p_server >= server_list.size())
-        return;
+  if (p_server < 0 || p_server >= server_list.size())
+    return;
 
   server_type fav_server = server_list.at(p_server);
 
@@ -220,11 +227,11 @@ void AOApplication::add_favorite_server(int p_server)
 
 void AOApplication::server_disconnected()
 {
-    if (!courtroom_constructed)
-        return;
-    call_notice("Disconnected from server.");
-    construct_lobby();
-    destruct_courtroom();
+  if (!courtroom_constructed)
+    return;
+  call_notice("Disconnected from server.");
+  construct_lobby();
+  destruct_courtroom();
 }
 
 void AOApplication::loading_cancelled()
@@ -249,26 +256,31 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
     }
     else if (will_retry)
     {
-      w_lobby->append_error("Error connecting to master server. Will try again in "
-                          + QString::number(net_manager->ms_reconnect_delay_ms / 1000.f) + " seconds.");
+      w_lobby->append_error(
+          "Error connecting to master server. Will try again in " +
+          QString::number(net_manager->ms_reconnect_delay_ms / 1000.f) +
+          " seconds.");
     }
     else
     {
       call_error("There was an error connecting to the master server.\n"
-                 "We deploy multiple master servers to mitigate any possible downtime, "
-                 "but the client appears to have exhausted all possible methods of finding "
+                 "We deploy multiple master servers to mitigate any possible "
+                 "downtime, "
+                 "but the client appears to have exhausted all possible "
+                 "methods of finding "
                  "and connecting to one.\n"
-                 "Please check your Internet connection and firewall, and please try again.");
+                 "Please check your Internet connection and firewall, and "
+                 "please try again.");
     }
   }
 }
 
 void AOApplication::on_courtroom_closing()
 {
-    config_panel->hide();
+  config_panel->hide();
 }
 
 void AOApplication::on_courtroom_destroyed()
 {
-    config_panel->hide();
+  config_panel->hide();
 }

--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -124,20 +124,11 @@ void AOApplication::set_theme_variant(QString p_variant)
   emit reload_theme();
 }
 
-void AOApplication::on_config_theme_changed()
-{
-  emit reload_theme();
-}
+void AOApplication::on_config_theme_changed() { emit reload_theme(); }
 
-void AOApplication::on_config_reload_theme_requested()
-{
-  emit reload_theme();
-}
+void AOApplication::on_config_reload_theme_requested() { emit reload_theme(); }
 
-void AOApplication::on_config_theme_variant_changed()
-{
-  emit reload_theme();
-}
+void AOApplication::on_config_theme_variant_changed() { emit reload_theme(); }
 
 void AOApplication::set_favorite_list()
 {
@@ -186,10 +177,7 @@ bool AOApplication::get_chatlog_scrolldown()
   return config->log_goes_downward_enabled();
 }
 
-int AOApplication::get_chatlog_max_lines()
-{
-  return config->log_max_lines();
-}
+int AOApplication::get_chatlog_max_lines() { return config->log_max_lines(); }
 
 int AOApplication::get_chat_tick_interval()
 {
@@ -275,12 +263,6 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
   }
 }
 
-void AOApplication::on_courtroom_closing()
-{
-  config_panel->hide();
-}
+void AOApplication::on_courtroom_closing() { config_panel->hide(); }
 
-void AOApplication::on_courtroom_destroyed()
-{
-  config_panel->hide();
-}
+void AOApplication::on_courtroom_destroyed() { config_panel->hide(); }

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -15,7 +15,8 @@ class Courtroom;
 class AOConfig;
 class AOConfigPanel;
 
-class AOApplication : public QApplication {
+class AOApplication : public QApplication
+{
   Q_OBJECT
 
 public:

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -17,309 +17,329 @@ class AOConfigPanel;
 
 class AOApplication : public QApplication
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOApplication(int &argc, char **argv);
-    ~AOApplication();
+  AOApplication(int &argc, char **argv);
+  ~AOApplication();
+
+  NetworkManager *net_manager = nullptr;
+  Lobby *w_lobby = nullptr;
+  Courtroom *w_courtroom = nullptr;
+  AttorneyOnline::Discord *discord = nullptr;
+  AOConfig *config = nullptr;
+  AOConfigPanel *config_panel = nullptr;
+
+  bool lobby_constructed = false;
+  bool courtroom_constructed = false;
+
+  void construct_lobby();
+  void destruct_lobby();
+
+  void construct_courtroom();
+  void destruct_courtroom();
+
+  void ms_packet_received(AOPacket *p_packet);
+  void server_packet_received(AOPacket *p_packet);
+
+  void send_ms_packet(AOPacket *p_packet);
+  void send_server_packet(AOPacket *p_packet, bool encoded = true);
+
+  /////////////////server metadata//////////////////
+
+  unsigned int s_decryptor = 5;
+  bool encryption_needed = true;
+
+  bool yellow_text_enabled = false;
+  bool prezoom_enabled = false;
+  bool flipping_enabled = false;
+  bool custom_objection_enabled = false;
+  bool improved_loading_enabled = false;
+  bool desk_mod_enabled = false;
+  bool evidence_enabled = false;
+
+  ///////////////loading info///////////////////
+
+  // player number, it's hardly used but might be needed for some old servers
+  int s_pv = 0;
+
+  QString server_software = "";
+
+  int char_list_size = 0;
+  int loaded_chars = 0;
+  int evidence_list_size = 0;
+  int loaded_evidence = 0;
+  int music_list_size = 0;
+  int loaded_music = 0;
 
-    NetworkManager *net_manager      = nullptr;
-    Lobby *w_lobby                   = nullptr;
-    Courtroom *w_courtroom           = nullptr;
-    AttorneyOnline::Discord *discord = nullptr;
-    AOConfig *config                 = nullptr;
-    AOConfigPanel *config_panel      = nullptr;
+  bool courtroom_loaded = false;
 
-    bool lobby_constructed     = false;
-    bool courtroom_constructed = false;
+  //////////////////versioning///////////////
 
-    void construct_lobby();
-    void destruct_lobby();
+  int get_release()
+  {
+    return RELEASE;
+  }
+  int get_major_version()
+  {
+    return MAJOR_VERSION;
+  }
+  int get_minor_version()
+  {
+    return MINOR_VERSION;
+  }
+  QString get_version_string();
 
-    void construct_courtroom();
-    void destruct_courtroom();
+  ///////////////////////////////////////////
 
-    void ms_packet_received(AOPacket *p_packet);
-    void server_packet_received(AOPacket *p_packet);
+  void set_favorite_list();
+  QVector<server_type> &get_favorite_list()
+  {
+    return favorite_list;
+  }
+  void add_favorite_server(int p_server);
 
-    void send_ms_packet(AOPacket *p_packet);
-    void send_server_packet(AOPacket *p_packet, bool encoded = true);
+  void set_server_list();
+  QVector<server_type> &get_server_list()
+  {
+    return server_list;
+  }
 
-    /////////////////server metadata//////////////////
+  // reads the theme from config.ini and sets it accordingly
+  void set_theme_name(QString p_name);
 
-    unsigned int s_decryptor = 5;
-    bool encryption_needed   = true;
+  // Returns the character the player has currently selected
+  QString get_current_char();
 
-    bool yellow_text_enabled      = false;
-    bool prezoom_enabled          = false;
-    bool flipping_enabled         = false;
-    bool custom_objection_enabled = false;
-    bool improved_loading_enabled = false;
-    bool desk_mod_enabled         = false;
-    bool evidence_enabled         = false;
+  // implementation in path_functions.cpp
+  QString get_base_path();
+  QString get_data_path();
+  QString get_theme_path();
+  QString get_theme_variant_path();
+  QString get_default_theme_path();
+  QString get_character_path(QString p_character);
+  QString get_demothings_path();
+  QString get_sounds_path();
+  QString get_music_path(QString p_song);
+  QString get_background_path();
+  QString get_default_background_path();
+  QString get_evidence_path();
 
-    ///////////////loading info///////////////////
+  ////// Functions for accessing the config panel //////
 
-    //player number, it's hardly used but might be needed for some old servers
-    int s_pv = 0;
+  void toggle_config_panel();
 
-    QString server_software = "";
+  ////// Functions for reading and writing files //////
+  // Implementations file_functions.cpp
 
-    int char_list_size     = 0;
-    int loaded_chars       = 0;
-    int evidence_list_size = 0;
-    int loaded_evidence    = 0;
-    int music_list_size    = 0;
-    int loaded_music       = 0;
+  // Returns text from note file
+  QString read_note(QString filename);
 
-    bool courtroom_loaded = false;
+  // Reads the theme from config.ini and loads it into the current_theme
+  // variable
+  QString get_theme();
 
-    //////////////////versioning///////////////
+  // Reads the theme variant from config.ini and loads it into the current theme
+  // variant variable
+  QString get_theme_variant();
 
-    int get_release() { return RELEASE; }
-    int get_major_version() { return MAJOR_VERSION; }
-    int get_minor_version() { return MINOR_VERSION; }
-    QString get_version_string();
+  // Returns the blip rate from config.ini
+  int read_blip_rate();
 
-    ///////////////////////////////////////////
+  // returns whatever we want newlines or ':' to be appended in front of names
+  // in the ic chat log
+  bool read_chatlog_newline();
 
-    void set_favorite_list();
-    QVector<server_type> &get_favorite_list() { return favorite_list; }
-    void add_favorite_server(int p_server);
+  // returns the user name
+  QString get_username();
 
-    void set_server_list();
-    QVector<server_type> &get_server_list() { return server_list; }
+  // returns a list of call words
+  QStringList get_callwords();
 
-    //reads the theme from config.ini and sets it accordingly
-    void set_theme_name(QString p_name);
+  // returns whatever preanimations should always play or not
+  bool get_always_pre_enabled();
 
-    //Returns the character the player has currently selected
-    QString get_current_char();
+  // returns whatever the client should simulate first person dialog
+  bool get_first_person_enabled();
 
-    //implementation in path_functions.cpp
-    QString get_base_path();
-    QString get_data_path();
-    QString get_theme_path();
-    QString get_theme_variant_path();
-    QString get_default_theme_path();
-    QString get_character_path(QString p_character);
-    QString get_demothings_path();
-    QString get_sounds_path();
-    QString get_music_path(QString p_song);
-    QString get_background_path();
-    QString get_default_background_path();
-    QString get_evidence_path();
+  // returns whether server alerts (ones that trigger a client alert other than
+  // callwords) should actually tigger a server alert or not
+  bool get_server_alerts_enabled();
 
-    ////// Functions for accessing the config panel //////
+  // returns if chatlog goes downward
+  bool get_chatlog_scrolldown();
 
-    void toggle_config_panel();
+  int get_chatlog_max_lines();
 
-    ////// Functions for reading and writing files //////
-    // Implementations file_functions.cpp
+  int get_chat_tick_interval();
 
-    //Returns text from note file
-    QString read_note(QString filename);
+  bool get_chatlog_newline();
 
-    //Reads the theme from config.ini and loads it into the current_theme variable
-    QString get_theme();
+  bool get_enable_logging_enabled();
 
-    //Reads the theme variant from config.ini and loads it into the current theme variant variable
-    QString get_theme_variant();
+  // Returns the value of default_sfx in config.ini
+  int get_default_sfx();
 
-    //Returns the blip rate from config.ini
-    int read_blip_rate();
+  // Returns the value of default_music in config.ini
+  int get_default_music();
 
-    // returns whatever we want newlines or ':' to be appended in front of names
-    // in the ic chat log
-    bool read_chatlog_newline();
+  // returns whatever music is logged within the chatlog
+  bool get_music_change_log_enabled();
 
-    // returns the user name
-    QString get_username();
+  // Returns the value of default_blip in config.ini
+  int get_default_blip();
 
-    // returns a list of call words
-    QStringList get_callwords();
+  // Returns true if blank blips is enabled in config.ini and false otherwise
+  bool get_blank_blip();
 
-    // returns whatever preanimations should always play or not
-    bool get_always_pre_enabled();
+  // TODO document what this does
+  QStringList get_sfx_list();
 
-    // returns whatever the client should simulate first person dialog
-    bool get_first_person_enabled();
+  // Appends the argument string to serverlist.txt
+  void write_to_serverlist_txt(QString p_line);
 
-    // returns whether server alerts (ones that trigger a client alert other than callwords)
-    // should actually tigger a server alert or not
-    bool get_server_alerts_enabled();
+  // Writes to note file
+  void write_note(QString p_text, QString filename);
 
-    // returns if chatlog goes downward
-    bool get_chatlog_scrolldown();
+  // appends to note file
+  void append_note(QString p_line, QString filename);
 
-    int get_chatlog_max_lines();
+  // Overwrites config.ini with new theme
+  void write_theme(QString theme);
 
-    int get_chat_tick_interval();
+  // Set the theme variant
+  void set_theme_variant(QString m_theme_variant);
 
-    bool get_chatlog_newline();
+  // Returns the contents of serverlist.txt
+  QVector<server_type> read_serverlist_txt();
 
-    bool get_enable_logging_enabled();
+  // Returns the value of p_identifier in the design.ini file in p_design_path
+  QString read_design_ini(QString p_identifier, QString p_design_path);
 
-    //Returns the value of default_sfx in config.ini
-    int get_default_sfx();
+  // Returns the value of p_identifier from p_file in either a theme variant
+  // subfolder, a theme folder, or default theme folder
+  QString read_theme_ini(QString p_identifier, QString p_file);
 
-    //Returns the value of default_music in config.ini
-    int get_default_music();
+  // Helper function for returning an int in a file inside of the theme folder
+  int get_design_ini_value(QString p_identifier, QString p_design_file);
 
-    // returns whatever music is logged within the chatlog
-    bool get_music_change_log_enabled();
+  // Returns the coordinates of widget with p_identifier from p_file
+  QPoint get_button_spacing(QString p_identifier, QString p_file);
 
-    //Returns the value of default_blip in config.ini
-    int get_default_blip();
+  // Returns the dimensions of widget with specified identifier from p_file
+  pos_size_type get_element_dimensions(QString p_identifier, QString p_file);
 
-    //Returns true if blank blips is enabled in config.ini and false otherwise
-    bool get_blank_blip();
+  // Returns the value of font property p_identifier from p_file
+  int get_font_property(QString p_identifier, QString p_file);
 
-    // TODO document what this does
-    QStringList get_sfx_list();
+  // Returns the name of the font with p_identifier from p_file
+  QString get_font_name(QString p_identifier, QString p_file);
 
-    //Appends the argument string to serverlist.txt
-    void write_to_serverlist_txt(QString p_line);
+  // Returns the color with p_identifier from p_file
+  QColor get_color(QString p_identifier, QString p_file);
 
-    //Writes to note file
-    void write_note(QString p_text, QString filename);
+  // Returns the sfx with p_identifier from sounds.ini in the current theme path
+  QString get_sfx(QString p_identifier);
 
-    //appends to note file
-    void append_note(QString p_line, QString filename);
+  // Returns the value of p_search_line within target_tag and terminator_tag
+  QString read_char_ini(QString p_char, QString p_search_line,
+                        QString target_tag, QString terminator_tag);
 
-    //Overwrites config.ini with new theme
-    void write_theme(QString theme);
+  // Returns the text between target_tag and terminator_tag in p_file
+  QString get_stylesheet(QString target_tag, QString p_file);
 
-    //Set the theme variant
-    void set_theme_variant(QString m_theme_variant);
+  // Returns string list (characters, color) from p_file
+  QVector<QStringList> get_highlight_color();
 
-    //Returns the contents of serverlist.txt
-    QVector<server_type> read_serverlist_txt();
+  // Returns special button on cc_config according to index
+  QString get_spbutton(QString p_tag, int index);
 
-    //Returns the value of p_identifier in the design.ini file in p_design_path
-    QString read_design_ini(QString p_identifier, QString p_design_path);
+  // Returns effect on cc_config according to index
+  QStringList get_effect(int index);
 
-    //Returns the value of p_identifier from p_file in either a theme variant subfolder, a theme folder, or default theme folder
-    QString read_theme_ini(QString p_identifier, QString p_file);
+  // Returns wtce on cc_config according to index
+  QStringList get_wtce(int index);
 
-    //Helper function for returning an int in a file inside of the theme folder
-    int get_design_ini_value(QString p_identifier, QString p_design_file);
+  // Returns the side of the p_char character from that characters ini file
+  QString get_char_side(QString p_char);
 
-    //Returns the coordinates of widget with p_identifier from p_file
-    QPoint get_button_spacing(QString p_identifier, QString p_file);
+  // Returns the showname from the ini of p_char
+  QString get_showname(QString p_char);
 
-    //Returns the dimensions of widget with specified identifier from p_file
-    pos_size_type get_element_dimensions(QString p_identifier, QString p_file);
+  // Returns showname from showname.ini
+  QString read_showname(QString p_char);
 
-    //Returns the value of font property p_identifier from p_file
-    int get_font_property(QString p_identifier, QString p_file);
+  // Returns the value of chat from the specific p_char's ini file
+  QString get_chat(QString p_char);
 
-    //Returns the name of the font with p_identifier from p_file
-    QString get_font_name(QString p_identifier, QString p_file);
+  // Returns the value of shouts from the specified p_char's ini file
+  QString get_char_shouts(QString p_char);
 
-    //Returns the color with p_identifier from p_file
-    QColor get_color(QString p_identifier, QString p_file);
+  // Not in use
+  int get_text_delay(QString p_char, QString p_emote);
 
-    //Returns the sfx with p_identifier from sounds.ini in the current theme path
-    QString get_sfx(QString p_identifier);
+  // Returns the name of p_char
+  QString get_char_name(QString p_char);
 
-    //Returns the value of p_search_line within target_tag and terminator_tag
-    QString read_char_ini(QString p_char, QString p_search_line, QString target_tag, QString terminator_tag);
+  // Returns the total amount of emotes of p_char
+  int get_emote_number(QString p_char);
 
-    //Returns the text between target_tag and terminator_tag in p_file
-    QString get_stylesheet(QString target_tag, QString p_file);
+  // Returns the emote comment of p_char's p_emote
+  QString get_emote_comment(QString p_char, int p_emote);
 
-    //Returns string list (characters, color) from p_file
-    QVector<QStringList> get_highlight_color();
+  // Returns the base name of p_char's p_emote
+  QString get_emote(QString p_char, int p_emote);
 
-    //Returns special button on cc_config according to index
-    QString get_spbutton(QString p_tag, int index);
+  // Returns the preanimation name of p_char's p_emote
+  QString get_pre_emote(QString p_char, int p_emote);
 
-    //Returns effect on cc_config according to index
-    QStringList get_effect(int index);
+  // Returns x,y offset for effect p_effect
+  QStringList get_effect_offset(QString p_char, int p_effect);
 
-    //Returns wtce on cc_config according to index
-    QStringList get_wtce(int index);
+  // Returns overlay at p_effect in char_path/overlay
+  QStringList get_overlay(QString p_char, int p_effect);
 
-    //Returns the side of the p_char character from that characters ini file
-    QString get_char_side(QString p_char);
+  // Returns the sfx of p_char's p_emote
+  QString get_sfx_name(QString p_char, int p_emote);
 
-    //Returns the showname from the ini of p_char
-    QString get_showname(QString p_char);
+  // Not in use
+  int get_sfx_delay(QString p_char, int p_emote);
 
-    //Returns showname from showname.ini
-    QString read_showname(QString p_char);
+  // Returns the modifier for p_char's p_emote
+  int get_emote_mod(QString p_char, int p_emote);
 
-    //Returns the value of chat from the specific p_char's ini file
-    QString get_chat(QString p_char);
+  // Returns the desk modifier for p_char's p_emote
+  int get_desk_mod(QString p_char, int p_emote);
 
-    //Returns the value of shouts from the specified p_char's ini file
-    QString get_char_shouts(QString p_char);
+  // Returns p_char's gender
+  QString get_gender(QString p_char);
 
-    //Not in use
-    int get_text_delay(QString p_char, QString p_emote);
-
-    //Returns the name of p_char
-    QString get_char_name(QString p_char);
-
-    //Returns the total amount of emotes of p_char
-    int get_emote_number(QString p_char);
-
-    //Returns the emote comment of p_char's p_emote
-    QString get_emote_comment(QString p_char, int p_emote);
-
-    //Returns the base name of p_char's p_emote
-    QString get_emote(QString p_char, int p_emote);
-
-    //Returns the preanimation name of p_char's p_emote
-    QString get_pre_emote(QString p_char, int p_emote);
-
-    //Returns x,y offset for effect p_effect
-    QStringList get_effect_offset(QString p_char, int p_effect);
-
-    //Returns overlay at p_effect in char_path/overlay
-    QStringList get_overlay(QString p_char, int p_effect);
-
-    //Returns the sfx of p_char's p_emote
-    QString get_sfx_name(QString p_char, int p_emote);
-
-    //Not in use
-    int get_sfx_delay(QString p_char, int p_emote);
-
-    //Returns the modifier for p_char's p_emote
-    int get_emote_mod(QString p_char, int p_emote);
-
-    //Returns the desk modifier for p_char's p_emote
-    int get_desk_mod(QString p_char, int p_emote);
-
-    //Returns p_char's gender
-    QString get_gender(QString p_char);
-
-    //Get the location of p_image, which is either in a theme variant subfolder, a theme folder, or default theme folder
-    QString get_image_path(QString p_image);
+  // Get the location of p_image, which is either in a theme variant subfolder,
+  // a theme folder, or default theme folder
+  QString get_image_path(QString p_image);
 
 signals:
-    void reload_theme();
+  void reload_theme();
 
 private:
-    const int RELEASE       = 2;
-    const int MAJOR_VERSION = 4;
-    const int MINOR_VERSION = 8;
+  const int RELEASE = 2;
+  const int MAJOR_VERSION = 4;
+  const int MINOR_VERSION = 8;
 
-    QVector<server_type> server_list;
-    QVector<server_type> favorite_list;
+  QVector<server_type> server_list;
+  QVector<server_type> favorite_list;
 
 private slots:
-    void ms_connect_finished(bool connected, bool will_retry);
-    void on_courtroom_closing();
-    void on_courtroom_destroyed();
-    void on_config_theme_changed();
-    void on_config_reload_theme_requested();
-    void on_config_theme_variant_changed();
+  void ms_connect_finished(bool connected, bool will_retry);
+  void on_courtroom_closing();
+  void on_courtroom_destroyed();
+  void on_config_theme_changed();
+  void on_config_reload_theme_requested();
+  void on_config_theme_variant_changed();
 
 public slots:
-    void server_disconnected();
-    void loading_cancelled();
+  void server_disconnected();
+  void loading_cancelled();
 };
 
 #endif // AOAPPLICATION_H

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -76,19 +76,34 @@ public:
 
   //////////////////versioning///////////////
 
-  int get_release() { return RELEASE; }
-  int get_major_version() { return MAJOR_VERSION; }
-  int get_minor_version() { return MINOR_VERSION; }
+  int get_release()
+  {
+    return RELEASE;
+  }
+  int get_major_version()
+  {
+    return MAJOR_VERSION;
+  }
+  int get_minor_version()
+  {
+    return MINOR_VERSION;
+  }
   QString get_version_string();
 
   ///////////////////////////////////////////
 
   void set_favorite_list();
-  QVector<server_type> &get_favorite_list() { return favorite_list; }
+  QVector<server_type> &get_favorite_list()
+  {
+    return favorite_list;
+  }
   void add_favorite_server(int p_server);
 
   void set_server_list();
-  QVector<server_type> &get_server_list() { return server_list; }
+  QVector<server_type> &get_server_list()
+  {
+    return server_list;
+  }
 
   // reads the theme from config.ini and sets it accordingly
   void set_theme_name(QString p_name);

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -15,8 +15,7 @@ class Courtroom;
 class AOConfig;
 class AOConfigPanel;
 
-class AOApplication : public QApplication
-{
+class AOApplication : public QApplication {
   Q_OBJECT
 
 public:
@@ -76,34 +75,19 @@ public:
 
   //////////////////versioning///////////////
 
-  int get_release()
-  {
-    return RELEASE;
-  }
-  int get_major_version()
-  {
-    return MAJOR_VERSION;
-  }
-  int get_minor_version()
-  {
-    return MINOR_VERSION;
-  }
+  int get_release() { return RELEASE; }
+  int get_major_version() { return MAJOR_VERSION; }
+  int get_minor_version() { return MINOR_VERSION; }
   QString get_version_string();
 
   ///////////////////////////////////////////
 
   void set_favorite_list();
-  QVector<server_type> &get_favorite_list()
-  {
-    return favorite_list;
-  }
+  QVector<server_type> &get_favorite_list() { return favorite_list; }
   void add_favorite_server(int p_server);
 
   void set_server_list();
-  QVector<server_type> &get_server_list()
-  {
-    return server_list;
-  }
+  QVector<server_type> &get_server_list() { return server_list; }
 
   // reads the theme from config.ini and sets it accordingly
   void set_theme_name(QString p_name);
@@ -114,16 +98,47 @@ public:
   // implementation in path_functions.cpp
   QString get_base_path();
   QString get_data_path();
-  QString get_theme_path();
-  QString get_theme_variant_path();
-  QString get_default_theme_path();
-  QString get_character_path(QString p_character);
-  QString get_demothings_path();
-  QString get_sounds_path();
+  QString get_theme_path(QString p_file);
+  QString get_theme_variant_path(QString p_file);
+  QString get_default_theme_path(QString p_file);
+  QString get_character_path(QString p_character, QString p_file);
+  // QString get_demothings_path();
+  QString get_sounds_path(QString p_file);
   QString get_music_path(QString p_song);
-  QString get_background_path();
-  QString get_default_background_path();
-  QString get_evidence_path();
+  QString get_background_path(QString p_file);
+  QString get_default_background_path(QString p_file);
+  QString get_evidence_path(QString p_file);
+
+  /**
+   * @brief Searches for a file with any of the given extensions, and returns
+   * the first extension that actually matches to an existing file.
+   *
+   * @param p_file The path to the file, without extension.
+   * @param p_exts The potential extensions the file could have.
+   *
+   * @return The first extension with which a file exists, or an empty string,
+   * if not one does.
+   */
+  QString get_file_extension(QString p_file, QVector<QString> p_exts);
+
+  /**
+   * @brief Returns the 'correct' path for the file given as the parameter by
+   * trying to match the case of the actual path.
+   *
+   * @details This function is mostly used on case-sensitive file systems, like
+   * ext4, generally used on Linux. On FAT, there is no difference between
+   * "file" and "FILE". On ext4, those are two different files. This results in
+   * assets that are detected correctly on Windows not being detected on Linux.
+   *
+   * For this reason, the implementation of this function is system-dependent:
+   * on case-insensitive systems, it just returns the parameter itself.
+   *
+   * @param p_file The path whose casing must be checked against the actual
+   * directory structure.
+   *
+   * @return The parameter path with fixed casing.
+   */
+  QString get_case_sensitive_path(QString p_file);
 
   ////// Functions for accessing the config panel //////
 

--- a/aobasshandle.cpp
+++ b/aobasshandle.cpp
@@ -1,6 +1,8 @@
 #include "aobasshandle.h"
 
-AOBassHandle::AOBassHandle(QObject *p_parent) : QObject(p_parent) {}
+AOBassHandle::AOBassHandle(QObject *p_parent) : QObject(p_parent)
+{
+}
 
 AOBassHandle::AOBassHandle(QString p_file, bool p_suicide,
                            QObject *p_parent) noexcept(false)
@@ -34,7 +36,10 @@ void AOBassHandle::suicide()
   delete this;
 }
 
-QString AOBassHandle::get_file() { return m_file; }
+QString AOBassHandle::get_file()
+{
+  return m_file;
+}
 
 void AOBassHandle::set_file(QString p_file, bool p_suicide) noexcept(false)
 {
@@ -70,9 +75,15 @@ void AOBassHandle::set_volume(int p_volume)
   BASS_ChannelSetAttribute(m_handle, BASS_ATTRIB_VOL, p_volume / 100.0f);
 }
 
-void AOBassHandle::play() { BASS_ChannelPlay(m_handle, FALSE); }
+void AOBassHandle::play()
+{
+  BASS_ChannelPlay(m_handle, FALSE);
+}
 
-void AOBassHandle::stop() { BASS_ChannelStop(m_handle); }
+void AOBassHandle::stop()
+{
+  BASS_ChannelStop(m_handle);
+}
 
 void CALLBACK AOBassHandle::static_sync(HSYNC handle, DWORD channel, DWORD data,
                                         void *user)

--- a/aobasshandle.cpp
+++ b/aobasshandle.cpp
@@ -1,11 +1,12 @@
 #include "aobasshandle.h"
 
-AOBassHandle::AOBassHandle(QObject *p_parent)
-  : QObject(p_parent)
-{}
+AOBassHandle::AOBassHandle(QObject *p_parent) : QObject(p_parent)
+{
+}
 
-AOBassHandle::AOBassHandle(QString p_file, bool p_suicide, QObject *p_parent) noexcept(false)
-  : QObject(p_parent)
+AOBassHandle::AOBassHandle(QString p_file, bool p_suicide,
+                           QObject *p_parent) noexcept(false)
+    : QObject(p_parent)
 {
   set_file(p_file, p_suicide);
 }
@@ -48,11 +49,14 @@ void AOBassHandle::set_file(QString p_file, bool p_suicide) noexcept(false)
   m_file = p_file;
 
   // create a handle based on the file
-  m_handle = BASS_StreamCreateFile(FALSE, m_file.utf16(), 0, 0, BASS_UNICODE|BASS_ASYNCFILE);
+  m_handle = BASS_StreamCreateFile(FALSE, m_file.utf16(), 0, 0,
+                                   BASS_UNICODE | BASS_ASYNCFILE);
   if (!m_handle)
-    throw AOException(QString("%1 could not be initialized to play").arg(p_file));
+    throw AOException(
+        QString("%1 could not be initialized to play").arg(p_file));
 
-  m_sync = BASS_ChannelSetSync(m_handle, BASS_SYNC_END, 0, &AOBassHandle::static_sync, this);
+  m_sync = BASS_ChannelSetSync(m_handle, BASS_SYNC_END, 0,
+                               &AOBassHandle::static_sync, this);
   if (!m_sync)
   {
     // free stream since we can't sync
@@ -68,7 +72,7 @@ void AOBassHandle::set_file(QString p_file, bool p_suicide) noexcept(false)
 
 void AOBassHandle::set_volume(int p_volume)
 {
-  BASS_ChannelSetAttribute(m_handle, BASS_ATTRIB_VOL, p_volume/100.0f);
+  BASS_ChannelSetAttribute(m_handle, BASS_ATTRIB_VOL, p_volume / 100.0f);
 }
 
 void AOBassHandle::play()
@@ -81,9 +85,10 @@ void AOBassHandle::stop()
   BASS_ChannelStop(m_handle);
 }
 
-void CALLBACK AOBassHandle::static_sync(HSYNC handle, DWORD channel, DWORD data, void *user)
+void CALLBACK AOBassHandle::static_sync(HSYNC handle, DWORD channel, DWORD data,
+                                        void *user)
 {
-  if (auto self = static_cast<AOBassHandle*>(user))
+  if (auto self = static_cast<AOBassHandle *>(user))
   {
     self->sync(data);
   }

--- a/aobasshandle.cpp
+++ b/aobasshandle.cpp
@@ -1,8 +1,6 @@
 #include "aobasshandle.h"
 
-AOBassHandle::AOBassHandle(QObject *p_parent) : QObject(p_parent)
-{
-}
+AOBassHandle::AOBassHandle(QObject *p_parent) : QObject(p_parent) {}
 
 AOBassHandle::AOBassHandle(QString p_file, bool p_suicide,
                            QObject *p_parent) noexcept(false)
@@ -36,10 +34,7 @@ void AOBassHandle::suicide()
   delete this;
 }
 
-QString AOBassHandle::get_file()
-{
-  return m_file;
-}
+QString AOBassHandle::get_file() { return m_file; }
 
 void AOBassHandle::set_file(QString p_file, bool p_suicide) noexcept(false)
 {
@@ -75,15 +70,9 @@ void AOBassHandle::set_volume(int p_volume)
   BASS_ChannelSetAttribute(m_handle, BASS_ATTRIB_VOL, p_volume / 100.0f);
 }
 
-void AOBassHandle::play()
-{
-  BASS_ChannelPlay(m_handle, FALSE);
-}
+void AOBassHandle::play() { BASS_ChannelPlay(m_handle, FALSE); }
 
-void AOBassHandle::stop()
-{
-  BASS_ChannelStop(m_handle);
-}
+void AOBassHandle::stop() { BASS_ChannelStop(m_handle); }
 
 void CALLBACK AOBassHandle::static_sync(HSYNC handle, DWORD channel, DWORD data,
                                         void *user)

--- a/aobasshandle.h
+++ b/aobasshandle.h
@@ -19,14 +19,16 @@ class AOBassHandle : public QObject
 
 public:
   AOBassHandle(QObject *p_parent = nullptr);
-  AOBassHandle(QString p_file, bool p_suicide, QObject *p_parent = nullptr) noexcept(false);
+  AOBassHandle(QString p_file, bool p_suicide,
+               QObject *p_parent = nullptr) noexcept(false);
   ~AOBassHandle();
 
   QString get_file();
   void set_file(QString p_file, bool p_suicide = false) noexcept(false);
 
   // static
-  static void CALLBACK static_sync(HSYNC handle, DWORD channel, DWORD data, void *user);
+  static void CALLBACK static_sync(HSYNC handle, DWORD channel, DWORD data,
+                                   void *user);
 
 public slots:
   void play();
@@ -40,9 +42,9 @@ signals:
 
 private:
   QString m_file;
-  HSTREAM m_handle  = 0;
-  HSYNC   m_sync    = 0;
-  bool    m_suicide = false;
+  HSTREAM m_handle = 0;
+  HSYNC m_sync = 0;
+  bool m_suicide = false;
 
   void sync(DWORD data);
 

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -10,11 +10,12 @@ void AOBlipPlayer::set_blips(QString p_sfx)
 {
   QString f_path = ao_app->get_sounds_path() + p_sfx.toLower();
 
-  for (int n_stream = 0 ; n_stream < BLIP_COUNT ; ++n_stream)
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
   {
     BASS_StreamFree(m_stream_list[n_stream]);
 
-    m_stream_list[n_stream] = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_UNICODE | BASS_ASYNCFILE);
+    m_stream_list[n_stream] = BASS_StreamCreateFile(
+        FALSE, f_path.utf16(), 0, 0, BASS_UNICODE | BASS_ASYNCFILE);
   }
 
   set_volume(m_volume);
@@ -38,7 +39,7 @@ void AOBlipPlayer::set_volume(int p_value)
 
   float volume = p_value / 100.0f;
 
-  for (int n_stream = 0 ; n_stream < BLIP_COUNT ; ++n_stream)
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
   {
     BASS_ChannelSetAttribute(m_stream_list[n_stream], BASS_ATTRIB_VOL, volume);
   }

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -1,17 +1,14 @@
 #include "aoblipplayer.h"
 
-AOBlipPlayer::AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app)
-{
+AOBlipPlayer::AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app) {
   m_parent = parent;
   ao_app = p_ao_app;
 }
 
-void AOBlipPlayer::set_blips(QString p_sfx)
-{
-  QString f_path = ao_app->get_sounds_path() + p_sfx.toLower();
+void AOBlipPlayer::set_blips(QString p_sfx) {
+  QString f_path = ao_app->get_sounds_path(p_sfx);
 
-  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
-  {
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream) {
     BASS_StreamFree(m_stream_list[n_stream]);
 
     m_stream_list[n_stream] = BASS_StreamCreateFile(
@@ -21,8 +18,7 @@ void AOBlipPlayer::set_blips(QString p_sfx)
   set_volume(m_volume);
 }
 
-void AOBlipPlayer::blip_tick()
-{
+void AOBlipPlayer::blip_tick() {
   int f_cycle = m_cycle++;
 
   if (m_cycle == BLIP_COUNT)
@@ -33,14 +29,12 @@ void AOBlipPlayer::blip_tick()
   BASS_ChannelPlay(f_stream, false);
 }
 
-void AOBlipPlayer::set_volume(int p_value)
-{
+void AOBlipPlayer::set_volume(int p_value) {
   m_volume = p_value;
 
   float volume = p_value / 100.0f;
 
-  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
-  {
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream) {
     BASS_ChannelSetAttribute(m_stream_list[n_stream], BASS_ATTRIB_VOL, volume);
   }
 }

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -1,14 +1,17 @@
 #include "aoblipplayer.h"
 
-AOBlipPlayer::AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app) {
+AOBlipPlayer::AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app)
+{
   m_parent = parent;
   ao_app = p_ao_app;
 }
 
-void AOBlipPlayer::set_blips(QString p_sfx) {
+void AOBlipPlayer::set_blips(QString p_sfx)
+{
   QString f_path = ao_app->get_sounds_path(p_sfx);
 
-  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream) {
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
+  {
     BASS_StreamFree(m_stream_list[n_stream]);
 
     m_stream_list[n_stream] = BASS_StreamCreateFile(
@@ -18,7 +21,8 @@ void AOBlipPlayer::set_blips(QString p_sfx) {
   set_volume(m_volume);
 }
 
-void AOBlipPlayer::blip_tick() {
+void AOBlipPlayer::blip_tick()
+{
   int f_cycle = m_cycle++;
 
   if (m_cycle == BLIP_COUNT)
@@ -29,12 +33,14 @@ void AOBlipPlayer::blip_tick() {
   BASS_ChannelPlay(f_stream, false);
 }
 
-void AOBlipPlayer::set_volume(int p_value) {
+void AOBlipPlayer::set_volume(int p_value)
+{
   m_volume = p_value;
 
   float volume = p_value / 100.0f;
 
-  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream) {
+  for (int n_stream = 0; n_stream < BLIP_COUNT; ++n_stream)
+  {
     BASS_ChannelSetAttribute(m_stream_list[n_stream], BASS_ATTRIB_VOL, volume);
   }
 }

--- a/aoblipplayer.h
+++ b/aoblipplayer.h
@@ -1,12 +1,12 @@
 #ifndef AOBLIPPLAYER_H
 #define AOBLIPPLAYER_H
 
-#include "bass.h"
 #include "aoapplication.h"
+#include "bass.h"
 
+#include <QDebug>
 #include <QWidget>
 #include <string.h>
-#include <QDebug>
 
 const int BLIP_COUNT = 5;
 

--- a/aobutton.cpp
+++ b/aobutton.cpp
@@ -5,7 +5,8 @@
 
 #include <QDebug>
 
-AOButton::AOButton(QWidget *parent, AOApplication *p_ao_app) : QPushButton(parent)
+AOButton::AOButton(QWidget *parent, AOApplication *p_ao_app)
+    : QPushButton(parent)
 {
   ao_app = p_ao_app;
 }
@@ -20,8 +21,10 @@ void AOButton::set_image(QString p_image)
   if (file_exists(image_path))
   {
     if (file_exists(hover_image_path))
-      this->setStyleSheet("QPushButton {border-image:url(\"" + image_path + "\");}"
-                          "QPushButton:hover {border-image:url(\"" + hover_image_path + "\");}");
+      this->setStyleSheet("QPushButton {border-image:url(\"" + image_path +
+                          "\");}"
+                          "QPushButton:hover {border-image:url(\"" +
+                          hover_image_path + "\");}");
     else
       this->setStyleSheet("border-image:url(\"" + image_path + "\")");
   }

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -4,62 +4,67 @@
 
 #include <QFile>
 
-AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos, int y_pos) : QPushButton(parent)
+AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
+                           int y_pos)
+    : QPushButton(parent)
 {
-    ao_app = p_ao_app;
+  ao_app = p_ao_app;
 
-    this->resize(60, 60);
-    this->move(x_pos, y_pos);
+  this->resize(60, 60);
+  this->move(x_pos, y_pos);
 
-    ui_taken = new AOImage(this, ao_app);
-    ui_taken->resize(60, 60);
-    ui_taken->set_image("char_taken.png");
-    ui_taken->setAttribute(Qt::WA_TransparentForMouseEvents);
-    ui_taken->hide();
+  ui_taken = new AOImage(this, ao_app);
+  ui_taken->resize(60, 60);
+  ui_taken->set_image("char_taken.png");
+  ui_taken->setAttribute(Qt::WA_TransparentForMouseEvents);
+  ui_taken->hide();
 }
 
 void AOCharButton::reset()
 {
-    ui_taken->hide();
+  ui_taken->hide();
 }
 
 void AOCharButton::set_taken()
 {
-    ui_taken->show();
+  ui_taken->show();
 }
 
 void AOCharButton::set_image(QString p_character)
 {
-    QString image_path  = ao_app->get_character_path(p_character) + "char_icon.png";
-    QString legacy_path = ao_app->get_demothings_path() + p_character.toLower() + "_char_icon.png";
-    QString alt_path    = ao_app->get_demothings_path() + p_character.toLower() + "_off.png";
+  QString image_path =
+      ao_app->get_character_path(p_character) + "char_icon.png";
+  QString legacy_path =
+      ao_app->get_demothings_path() + p_character.toLower() + "_char_icon.png";
+  QString alt_path =
+      ao_app->get_demothings_path() + p_character.toLower() + "_off.png";
 
-    this->setText("");
+  this->setText("");
 
-    if (file_exists(image_path))
-        this->setStyleSheet("border-image:url(\"" + image_path + "\")");
-    else if (file_exists(legacy_path))
-    {
-        this->setStyleSheet("border-image:url(\"" + legacy_path + "\")");
-        //ninja optimization
-        QFile::copy(legacy_path, image_path);
-    }
-    else
-    {
-        this->setStyleSheet("border-image:url()");
-        this->setText(p_character);
-    }
+  if (file_exists(image_path))
+    this->setStyleSheet("border-image:url(\"" + image_path + "\")");
+  else if (file_exists(legacy_path))
+  {
+    this->setStyleSheet("border-image:url(\"" + legacy_path + "\")");
+    // ninja optimization
+    QFile::copy(legacy_path, image_path);
+  }
+  else
+  {
+    this->setStyleSheet("border-image:url()");
+    this->setText(p_character);
+  }
 }
 
 void AOCharButton::enterEvent(QEvent *e)
 {
-    setFlat(false);
-    QPushButton::enterEvent(e);
-    emit mouse_entered(this);
+  setFlat(false);
+  QPushButton::enterEvent(e);
+  emit mouse_entered(this);
 }
 
 void AOCharButton::leaveEvent(QEvent *e)
 {
-    QPushButton::leaveEvent(e);
-    emit mouse_left();
+  QPushButton::leaveEvent(e);
+  emit mouse_left();
 }

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -20,9 +20,15 @@ AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
   ui_taken->hide();
 }
 
-void AOCharButton::reset() { ui_taken->hide(); }
+void AOCharButton::reset()
+{
+  ui_taken->hide();
+}
 
-void AOCharButton::set_taken() { ui_taken->show(); }
+void AOCharButton::set_taken()
+{
+  ui_taken->show();
+}
 
 void AOCharButton::set_image(QString p_character)
 {

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -6,8 +6,7 @@
 
 AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
                            int y_pos)
-    : QPushButton(parent)
-{
+    : QPushButton(parent) {
   ao_app = p_ao_app;
 
   this->resize(60, 60);
@@ -20,51 +19,38 @@ AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
   ui_taken->hide();
 }
 
-void AOCharButton::reset()
-{
-  ui_taken->hide();
-}
+void AOCharButton::reset() { ui_taken->hide(); }
 
-void AOCharButton::set_taken()
-{
-  ui_taken->show();
-}
+void AOCharButton::set_taken() { ui_taken->show(); }
 
-void AOCharButton::set_image(QString p_character)
-{
-  QString image_path =
-      ao_app->get_character_path(p_character) + "char_icon.png";
-  QString legacy_path =
-      ao_app->get_demothings_path() + p_character.toLower() + "_char_icon.png";
-  QString alt_path =
-      ao_app->get_demothings_path() + p_character.toLower() + "_off.png";
+void AOCharButton::set_image(QString p_character) {
+  QString image_path = ao_app->get_character_path(p_character, "char_icon.png");
+  // QString legacy_path = ao_app->get_demothings_path() + p_character.toLower()
+  // + "_char_icon.png"; QString alt_path = ao_app->get_demothings_path() +
+  // p_character.toLower() + "_off.png";
 
   this->setText("");
 
   if (file_exists(image_path))
     this->setStyleSheet("border-image:url(\"" + image_path + "\")");
-  else if (file_exists(legacy_path))
-  {
-    this->setStyleSheet("border-image:url(\"" + legacy_path + "\")");
-    // ninja optimization
-    QFile::copy(legacy_path, image_path);
-  }
-  else
-  {
+  // else if (file_exists(legacy_path)) {
+  //  this->setStyleSheet("border-image:url(\"" + legacy_path + "\")");
+  //  // ninja optimization
+  //  QFile::copy(legacy_path, image_path);
+  //}
+  else {
     this->setStyleSheet("border-image:url()");
     this->setText(p_character);
   }
 }
 
-void AOCharButton::enterEvent(QEvent *e)
-{
+void AOCharButton::enterEvent(QEvent *e) {
   setFlat(false);
   QPushButton::enterEvent(e);
   emit mouse_entered(this);
 }
 
-void AOCharButton::leaveEvent(QEvent *e)
-{
+void AOCharButton::leaveEvent(QEvent *e) {
   QPushButton::leaveEvent(e);
   emit mouse_left();
 }

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -6,7 +6,8 @@
 
 AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
                            int y_pos)
-    : QPushButton(parent) {
+    : QPushButton(parent)
+{
   ao_app = p_ao_app;
 
   this->resize(60, 60);
@@ -23,7 +24,8 @@ void AOCharButton::reset() { ui_taken->hide(); }
 
 void AOCharButton::set_taken() { ui_taken->show(); }
 
-void AOCharButton::set_image(QString p_character) {
+void AOCharButton::set_image(QString p_character)
+{
   QString image_path = ao_app->get_character_path(p_character, "char_icon.png");
   // QString legacy_path = ao_app->get_demothings_path() + p_character.toLower()
   // + "_char_icon.png"; QString alt_path = ao_app->get_demothings_path() +
@@ -38,19 +40,22 @@ void AOCharButton::set_image(QString p_character) {
   //  // ninja optimization
   //  QFile::copy(legacy_path, image_path);
   //}
-  else {
+  else
+  {
     this->setStyleSheet("border-image:url()");
     this->setText(p_character);
   }
 }
 
-void AOCharButton::enterEvent(QEvent *e) {
+void AOCharButton::enterEvent(QEvent *e)
+{
   setFlat(false);
   QPushButton::enterEvent(e);
   emit mouse_entered(this);
 }
 
-void AOCharButton::leaveEvent(QEvent *e) {
+void AOCharButton::leaveEvent(QEvent *e)
+{
   QPushButton::leaveEvent(e);
   emit mouse_left();
 }

--- a/aocharbutton.h
+++ b/aocharbutton.h
@@ -10,26 +10,26 @@
 
 class AOCharButton : public QPushButton
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos, int y_pos);
-    AOApplication *ao_app = nullptr;
+  AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos, int y_pos);
+  AOApplication *ao_app = nullptr;
 
-    void reset();
-    void set_taken();
-    void set_image(QString p_character);
+  void reset();
+  void set_taken();
+  void set_image(QString p_character);
 
 signals:
-    void mouse_entered(AOCharButton *p_caller);
-    void mouse_left();
+  void mouse_entered(AOCharButton *p_caller);
+  void mouse_left();
 
 private:
-    AOImage *ui_taken      = nullptr;
+  AOImage *ui_taken = nullptr;
 
 protected:
-    void enterEvent(QEvent *e);
-    void leaveEvent(QEvent *e);
+  void enterEvent(QEvent *e);
+  void leaveEvent(QEvent *e);
 };
 
 #endif // AOCHARBUTTON_H

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -8,169 +8,177 @@
 #include <QDebug>
 #include <QImageReader>
 
-AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app)
+    : QLabel(p_parent)
 {
-    ao_app = p_ao_app;
+  ao_app = p_ao_app;
 
-    m_reader = new QMovie(this);
+  m_reader = new QMovie(this);
 
-    m_frame_timer = new QTimer(this);
-    m_frame_timer->setSingleShot(true);
+  m_frame_timer = new QTimer(this);
+  m_frame_timer->setSingleShot(true);
 
-    connect(m_reader, SIGNAL(frameChanged(int)), this, SLOT(on_frame_changed(int)));
-    connect(m_frame_timer, SIGNAL(timeout()), this, SLOT(timer_done()));
+  connect(m_reader, SIGNAL(frameChanged(int)), this,
+          SLOT(on_frame_changed(int)));
+  connect(m_frame_timer, SIGNAL(timeout()), this, SLOT(timer_done()));
 }
 
-void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix, bool p_visible)
+void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
+                       bool p_visible)
 {
-    QString target_path;
-    QStringList f_paths{
-        ao_app->get_character_path(p_char) + p_emote_prefix + p_emote.toLower(), // .gif
-        ao_app->get_character_path(p_char) + p_emote.toLower(),                  // .png
-        ao_app->get_theme_variant_path() + "placeholder",                        // .gif
-        ao_app->get_theme_path() + "placeholder",                                // .gif
-        ao_app->get_default_theme_path() + "placeholder"                         // .gif
-    };
+  QString target_path;
+  QStringList f_paths{
+      ao_app->get_character_path(p_char) + p_emote_prefix +
+          p_emote.toLower(),                                  // .gif
+      ao_app->get_character_path(p_char) + p_emote.toLower(), // .png
+      ao_app->get_theme_variant_path() + "placeholder",       // .gif
+      ao_app->get_theme_path() + "placeholder",               // .gif
+      ao_app->get_default_theme_path() + "placeholder"        // .gif
+  };
 
-    for (auto &f_file : f_paths)
+  for (auto &f_file : f_paths)
+  {
+    bool found = false;
+    for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
     {
-        bool found = false;
-        for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
-        {
-            QString fullPath = f_file + ext;
-            found            = file_exists(fullPath);
-            if (found)
-            {
-                target_path = fullPath;
-                break;
-            }
-        }
-
-        if (found)
-            break;
+      QString fullPath = f_file + ext;
+      found = file_exists(fullPath);
+      if (found)
+      {
+        target_path = fullPath;
+        break;
+      }
     }
 
-    show();
-    if (!p_visible)
-        hide();
+    if (found)
+      break;
+  }
 
-    movie_frames.clear();
-    QImageReader *reader = new QImageReader(target_path);
-    for (int i = 0; i < reader->imageCount(); ++i)
-    { // optimize can be better, but I'll just keep it like that for now
-        QImage f_image = reader->read();
-        if (m_mirror)
-            f_image = f_image.mirrored(true, false);
-        movie_frames.append(f_image);
-    }
-    delete reader;
+  show();
+  if (!p_visible)
+    hide();
 
-    m_reader->stop();
-    this->clear();
-    m_reader->setFileName(target_path);
-    m_reader->start();
+  movie_frames.clear();
+  QImageReader *reader = new QImageReader(target_path);
+  for (int i = 0; i < reader->imageCount(); ++i)
+  { // optimize can be better, but I'll just keep it like that for now
+    QImage f_image = reader->read();
+    if (m_mirror)
+      f_image = f_image.mirrored(true, false);
+    movie_frames.append(f_image);
+  }
+  delete reader;
+
+  m_reader->stop();
+  this->clear();
+  m_reader->setFileName(target_path);
+  m_reader->start();
 }
 
 bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
 {
-    QString f_file_path = ao_app->get_character_path(p_char) + p_emote.toLower();
-    bool f_file_exist   = false;
+  QString f_file_path = ao_app->get_character_path(p_char) + p_emote.toLower();
+  bool f_file_exist = false;
 
-    { // figure out what extension the animation is using
-        QString f_source_path = ao_app->get_character_path(p_char) + p_emote.toLower();
-        for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"})
-        {
-            QString f_target_path = f_source_path + i_ext;
-            if (file_exists(f_target_path))
-            {
-                f_file_path  = f_target_path;
-                f_file_exist = true;
-                break;
-            }
-        }
-    }
-
-    // play if it exist
-    if (f_file_exist)
+  { // figure out what extension the animation is using
+    QString f_source_path =
+        ao_app->get_character_path(p_char) + p_emote.toLower();
+    for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"})
     {
-        m_reader->stop();
-        this->clear();
-        m_play_once = true;
-        m_reader->setFileName(f_file_path);
-        play(p_char, p_emote, "", show);
+      QString f_target_path = f_source_path + i_ext;
+      if (file_exists(f_target_path))
+      {
+        f_file_path = f_target_path;
+        f_file_exist = true;
+        break;
+      }
     }
+  }
 
-    return f_file_exist;
+  // play if it exist
+  if (f_file_exist)
+  {
+    m_reader->stop();
+    this->clear();
+    m_play_once = true;
+    m_reader->setFileName(f_file_path);
+    play(p_char, p_emote, "", show);
+  }
+
+  return f_file_exist;
 }
 
 void AOCharMovie::play_talking(QString p_char, QString p_emote, bool p_visible)
 {
-    QString gif_path = ao_app->get_character_path(p_char) + "(b)" + p_emote.toLower();
+  QString gif_path =
+      ao_app->get_character_path(p_char) + "(b)" + p_emote.toLower();
 
-    m_reader->stop();
-    this->clear();
-    m_play_once = false;
-    m_reader->setFileName(gif_path);
-    play(p_char, p_emote, "(b)", p_visible);
+  m_reader->stop();
+  this->clear();
+  m_play_once = false;
+  m_reader->setFileName(gif_path);
+  play(p_char, p_emote, "(b)", p_visible);
 }
 
 void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
 {
-    QString gif_path = ao_app->get_character_path(p_char) + "(a)" + p_emote.toLower();
+  QString gif_path =
+      ao_app->get_character_path(p_char) + "(a)" + p_emote.toLower();
 
-    this->clear();
-    m_reader->stop();
-    m_play_once = false;
-    m_reader->setFileName(gif_path);
-    play(p_char, p_emote, "(a)", p_visible);
+  this->clear();
+  m_reader->stop();
+  m_play_once = false;
+  m_reader->setFileName(gif_path);
+  play(p_char, p_emote, "(a)", p_visible);
 }
 
 void AOCharMovie::set_mirror_enabled(bool p_enable)
 {
-    m_mirror = p_enable;
+  m_mirror = p_enable;
 }
 
 void AOCharMovie::stop()
 {
-    //for all intents and purposes, stopping is the same as hiding. at no point do we want a frozen gif to display
-    m_reader->stop();
-    m_frame_timer->stop();
-    this->hide();
+  // for all intents and purposes, stopping is the same as hiding. at no point
+  // do we want a frozen gif to display
+  m_reader->stop();
+  m_frame_timer->stop();
+  this->hide();
 }
 
 void AOCharMovie::combo_resize(QSize p_size)
 {
-    resize(p_size);
-    m_reader->stop();
-    m_frame_timer->stop();
-    m_reader->setScaledSize(p_size);
-    m_reader->start();
+  resize(p_size);
+  m_reader->stop();
+  m_frame_timer->stop();
+  m_reader->setScaledSize(p_size);
+  m_reader->start();
 }
 
 void AOCharMovie::on_frame_changed(int p_frame_num)
 {
-    if (movie_frames.size() > p_frame_num)
-    {
-        AOPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(p_frame_num));
-        this->setPixmap(f_pixmap.scale_to_size(this->size()));
-    }
+  if (movie_frames.size() > p_frame_num)
+  {
+    AOPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(p_frame_num));
+    this->setPixmap(f_pixmap.scale_to_size(this->size()));
+  }
 
-    // pre-anim only
-    if (m_play_once)
+  // pre-anim only
+  if (m_play_once)
+  {
+    int f_frame_count = m_reader->frameCount();
+    if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1))
     {
-        int f_frame_count = m_reader->frameCount();
-        if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1))
-        {
-            int f_frame_delay = m_reader->nextFrameDelay();
-            if (f_frame_delay < 0)
-                f_frame_delay = 0;
-            m_frame_timer->start(f_frame_delay);
-            m_reader->stop();
-        }
+      int f_frame_delay = m_reader->nextFrameDelay();
+      if (f_frame_delay < 0)
+        f_frame_delay = 0;
+      m_frame_timer->start(f_frame_delay);
+      m_reader->stop();
     }
+  }
 }
 
 void AOCharMovie::timer_done()
 {
-    done();
+  done();
 }

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -9,8 +9,7 @@
 #include <QImageReader>
 
 AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app)
-    : QLabel(p_parent)
-{
+    : QLabel(p_parent) {
   ao_app = p_ao_app;
 
   m_reader = new QMovie(this);
@@ -24,27 +23,22 @@ AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app)
 }
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
-                       bool p_visible)
-{
+                       bool p_visible) {
   QString target_path;
   QStringList f_paths{
-      ao_app->get_character_path(p_char) + p_emote_prefix +
-          p_emote.toLower(),                                  // .gif
-      ao_app->get_character_path(p_char) + p_emote.toLower(), // .png
-      ao_app->get_theme_variant_path() + "placeholder",       // .gif
-      ao_app->get_theme_path() + "placeholder",               // .gif
-      ao_app->get_default_theme_path() + "placeholder"        // .gif
+      ao_app->get_character_path(p_char, p_emote_prefix + p_emote), // .gif
+      ao_app->get_character_path(p_char, p_emote),                  // .png
+      ao_app->get_theme_variant_path("placeholder"),                // .gif
+      ao_app->get_theme_path("placeholder"),                        // .gif
+      ao_app->get_default_theme_path("placeholder")                 // .gif
   };
 
-  for (auto &f_file : f_paths)
-  {
+  for (auto &f_file : f_paths) {
     bool found = false;
-    for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
-    {
+    for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"}) {
       QString fullPath = f_file + ext;
       found = file_exists(fullPath);
-      if (found)
-      {
+      if (found) {
         target_path = fullPath;
         break;
       }
@@ -60,8 +54,8 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
 
   movie_frames.clear();
   QImageReader *reader = new QImageReader(target_path);
-  for (int i = 0; i < reader->imageCount(); ++i)
-  { // optimize can be better, but I'll just keep it like that for now
+  for (int i = 0; i < reader->imageCount();
+       ++i) { // optimize can be better, but I'll just keep it like that for now
     QImage f_image = reader->read();
     if (m_mirror)
       f_image = f_image.mirrored(true, false);
@@ -75,19 +69,15 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
   m_reader->start();
 }
 
-bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
-{
-  QString f_file_path = ao_app->get_character_path(p_char) + p_emote.toLower();
+bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show) {
+  QString f_file_path = ao_app->get_character_path(p_char, p_emote);
   bool f_file_exist = false;
 
   { // figure out what extension the animation is using
-    QString f_source_path =
-        ao_app->get_character_path(p_char) + p_emote.toLower();
-    for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"})
-    {
+    QString f_source_path = ao_app->get_character_path(p_char, p_emote);
+    for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"}) {
       QString f_target_path = f_source_path + i_ext;
-      if (file_exists(f_target_path))
-      {
+      if (file_exists(f_target_path)) {
         f_file_path = f_target_path;
         f_file_exist = true;
         break;
@@ -96,8 +86,7 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
   }
 
   // play if it exist
-  if (f_file_exist)
-  {
+  if (f_file_exist) {
     m_reader->stop();
     this->clear();
     m_play_once = true;
@@ -108,10 +97,9 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
   return f_file_exist;
 }
 
-void AOCharMovie::play_talking(QString p_char, QString p_emote, bool p_visible)
-{
-  QString gif_path =
-      ao_app->get_character_path(p_char) + "(b)" + p_emote.toLower();
+void AOCharMovie::play_talking(QString p_char, QString p_emote,
+                               bool p_visible) {
+  QString gif_path = ao_app->get_character_path(p_char, "(b)" + p_emote);
 
   m_reader->stop();
   this->clear();
@@ -120,10 +108,8 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote, bool p_visible)
   play(p_char, p_emote, "(b)", p_visible);
 }
 
-void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
-{
-  QString gif_path =
-      ao_app->get_character_path(p_char) + "(a)" + p_emote.toLower();
+void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible) {
+  QString gif_path = ao_app->get_character_path(p_char, "(a)" + p_emote);
 
   this->clear();
   m_reader->stop();
@@ -132,13 +118,9 @@ void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
   play(p_char, p_emote, "(a)", p_visible);
 }
 
-void AOCharMovie::set_mirror_enabled(bool p_enable)
-{
-  m_mirror = p_enable;
-}
+void AOCharMovie::set_mirror_enabled(bool p_enable) { m_mirror = p_enable; }
 
-void AOCharMovie::stop()
-{
+void AOCharMovie::stop() {
   // for all intents and purposes, stopping is the same as hiding. at no point
   // do we want a frozen gif to display
   m_reader->stop();
@@ -146,8 +128,7 @@ void AOCharMovie::stop()
   this->hide();
 }
 
-void AOCharMovie::combo_resize(QSize p_size)
-{
+void AOCharMovie::combo_resize(QSize p_size) {
   resize(p_size);
   m_reader->stop();
   m_frame_timer->stop();
@@ -155,20 +136,16 @@ void AOCharMovie::combo_resize(QSize p_size)
   m_reader->start();
 }
 
-void AOCharMovie::on_frame_changed(int p_frame_num)
-{
-  if (movie_frames.size() > p_frame_num)
-  {
+void AOCharMovie::on_frame_changed(int p_frame_num) {
+  if (movie_frames.size() > p_frame_num) {
     AOPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(p_frame_num));
     this->setPixmap(f_pixmap.scale_to_size(this->size()));
   }
 
   // pre-anim only
-  if (m_play_once)
-  {
+  if (m_play_once) {
     int f_frame_count = m_reader->frameCount();
-    if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1))
-    {
+    if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1)) {
       int f_frame_delay = m_reader->nextFrameDelay();
       if (f_frame_delay < 0)
         f_frame_delay = 0;
@@ -178,7 +155,4 @@ void AOCharMovie::on_frame_changed(int p_frame_num)
   }
 }
 
-void AOCharMovie::timer_done()
-{
-  done();
-}
+void AOCharMovie::timer_done() { done(); }

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -9,7 +9,8 @@
 #include <QImageReader>
 
 AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app)
-    : QLabel(p_parent) {
+    : QLabel(p_parent)
+{
   ao_app = p_ao_app;
 
   m_reader = new QMovie(this);
@@ -23,7 +24,8 @@ AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app)
 }
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
-                       bool p_visible) {
+                       bool p_visible)
+{
   QString target_path;
   QStringList f_paths{
       ao_app->get_character_path(p_char, p_emote_prefix + p_emote), // .gif
@@ -33,12 +35,15 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
       ao_app->get_default_theme_path("placeholder")                 // .gif
   };
 
-  for (auto &f_file : f_paths) {
+  for (auto &f_file : f_paths)
+  {
     bool found = false;
-    for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"}) {
+    for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
+    {
       QString fullPath = f_file + ext;
       found = file_exists(fullPath);
-      if (found) {
+      if (found)
+      {
         target_path = fullPath;
         break;
       }
@@ -54,8 +59,8 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
 
   movie_frames.clear();
   QImageReader *reader = new QImageReader(target_path);
-  for (int i = 0; i < reader->imageCount();
-       ++i) { // optimize can be better, but I'll just keep it like that for now
+  for (int i = 0; i < reader->imageCount(); ++i)
+  { // optimize can be better, but I'll just keep it like that for now
     QImage f_image = reader->read();
     if (m_mirror)
       f_image = f_image.mirrored(true, false);
@@ -69,15 +74,18 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
   m_reader->start();
 }
 
-bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show) {
+bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
+{
   QString f_file_path = ao_app->get_character_path(p_char, p_emote);
   bool f_file_exist = false;
 
   { // figure out what extension the animation is using
     QString f_source_path = ao_app->get_character_path(p_char, p_emote);
-    for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"}) {
+    for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"})
+    {
       QString f_target_path = f_source_path + i_ext;
-      if (file_exists(f_target_path)) {
+      if (file_exists(f_target_path))
+      {
         f_file_path = f_target_path;
         f_file_exist = true;
         break;
@@ -86,7 +94,8 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show) {
   }
 
   // play if it exist
-  if (f_file_exist) {
+  if (f_file_exist)
+  {
     m_reader->stop();
     this->clear();
     m_play_once = true;
@@ -97,8 +106,8 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show) {
   return f_file_exist;
 }
 
-void AOCharMovie::play_talking(QString p_char, QString p_emote,
-                               bool p_visible) {
+void AOCharMovie::play_talking(QString p_char, QString p_emote, bool p_visible)
+{
   QString gif_path = ao_app->get_character_path(p_char, "(b)" + p_emote);
 
   m_reader->stop();
@@ -108,7 +117,8 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote,
   play(p_char, p_emote, "(b)", p_visible);
 }
 
-void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible) {
+void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
+{
   QString gif_path = ao_app->get_character_path(p_char, "(a)" + p_emote);
 
   this->clear();
@@ -120,7 +130,8 @@ void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible) {
 
 void AOCharMovie::set_mirror_enabled(bool p_enable) { m_mirror = p_enable; }
 
-void AOCharMovie::stop() {
+void AOCharMovie::stop()
+{
   // for all intents and purposes, stopping is the same as hiding. at no point
   // do we want a frozen gif to display
   m_reader->stop();
@@ -128,7 +139,8 @@ void AOCharMovie::stop() {
   this->hide();
 }
 
-void AOCharMovie::combo_resize(QSize p_size) {
+void AOCharMovie::combo_resize(QSize p_size)
+{
   resize(p_size);
   m_reader->stop();
   m_frame_timer->stop();
@@ -136,16 +148,20 @@ void AOCharMovie::combo_resize(QSize p_size) {
   m_reader->start();
 }
 
-void AOCharMovie::on_frame_changed(int p_frame_num) {
-  if (movie_frames.size() > p_frame_num) {
+void AOCharMovie::on_frame_changed(int p_frame_num)
+{
+  if (movie_frames.size() > p_frame_num)
+  {
     AOPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(p_frame_num));
     this->setPixmap(f_pixmap.scale_to_size(this->size()));
   }
 
   // pre-anim only
-  if (m_play_once) {
+  if (m_play_once)
+  {
     int f_frame_count = m_reader->frameCount();
-    if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1)) {
+    if (f_frame_count == 0 || p_frame_num == (f_frame_count - 1))
+    {
       int f_frame_delay = m_reader->nextFrameDelay();
       if (f_frame_delay < 0)
         f_frame_delay = 0;

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -128,7 +128,10 @@ void AOCharMovie::play_idle(QString p_char, QString p_emote, bool p_visible)
   play(p_char, p_emote, "(a)", p_visible);
 }
 
-void AOCharMovie::set_mirror_enabled(bool p_enable) { m_mirror = p_enable; }
+void AOCharMovie::set_mirror_enabled(bool p_enable)
+{
+  m_mirror = p_enable;
+}
 
 void AOCharMovie::stop()
 {
@@ -171,4 +174,7 @@ void AOCharMovie::on_frame_changed(int p_frame_num)
   }
 }
 
-void AOCharMovie::timer_done() { done(); }
+void AOCharMovie::timer_done()
+{
+  done();
+}

--- a/aocharmovie.h
+++ b/aocharmovie.h
@@ -11,35 +11,35 @@ class AOApplication;
 
 class AOCharMovie : public QLabel
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app);
+  AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app);
 
-    void play(QString p_char, QString p_emote, QString emote_prefix, bool show);
-    bool play_pre(QString p_char, QString p_emote, bool show);
-    void play_talking(QString p_char, QString p_emote, bool show);
-    void play_idle(QString p_char, QString p_emote, bool show);
-    void set_mirror_enabled(bool p_enable);
-    void combo_resize(QSize p_size);
-    void stop();
+  void play(QString p_char, QString p_emote, QString emote_prefix, bool show);
+  bool play_pre(QString p_char, QString p_emote, bool show);
+  void play_talking(QString p_char, QString p_emote, bool show);
+  void play_idle(QString p_char, QString p_emote, bool show);
+  void set_mirror_enabled(bool p_enable);
+  void combo_resize(QSize p_size);
+  void stop();
 
 private:
-    AOApplication *ao_app = nullptr;
+  AOApplication *ao_app = nullptr;
 
-    QMovie *m_reader;
-    QVector<QImage> movie_frames;
-    QTimer *m_frame_timer;
+  QMovie *m_reader;
+  QVector<QImage> movie_frames;
+  QTimer *m_frame_timer;
 
-    bool m_mirror    = false;
-    bool m_play_once = false;
+  bool m_mirror = false;
+  bool m_play_once = false;
 
 signals:
-    void done();
+  void done();
 
 private slots:
-    void on_frame_changed(int n_frame);
-    void timer_done();
+  void on_frame_changed(int n_frame);
+  void timer_done();
 };
 
 #endif // AOCHARMOVIE_H

--- a/aoconfig.cpp
+++ b/aoconfig.cpp
@@ -12,224 +12,228 @@
 */
 class AOConfigPrivate : public QObject
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    friend AOConfig;
+  friend AOConfig;
 
-    QSettings cfg;
-    // hate me more
-    QVector<QObject *> parents;
+  QSettings cfg;
+  // hate me more
+  QVector<QObject *> parents;
 
-    // data
-    QString username;
-    QString callwords;
-    QString theme;
-    QString theme_variant;
-    bool always_pre;
-    int chat_tick_interval;
-    bool server_alerts;
-    int log_max_lines;
-    bool log_goes_downward;
-    bool log_uses_newline;
-    bool log_music;
-    bool log_is_recording;
-    int effects_volume;
-    int system_volume;
-    int music_volume;
-    int blips_volume;
-    int blip_rate;
-    bool blank_blips;
+  // data
+  QString username;
+  QString callwords;
+  QString theme;
+  QString theme_variant;
+  bool always_pre;
+  int chat_tick_interval;
+  bool server_alerts;
+  int log_max_lines;
+  bool log_goes_downward;
+  bool log_uses_newline;
+  bool log_music;
+  bool log_is_recording;
+  int effects_volume;
+  int system_volume;
+  int music_volume;
+  int blips_volume;
+  int blip_rate;
+  bool blank_blips;
 
 public:
-    AOConfigPrivate() : QObject(qApp), cfg(QDir::currentPath() + "/base/config.ini", QSettings::IniFormat)
-    {
-        read_file();
-    }
-    ~AOConfigPrivate()
-    {
-        save_file();
-    }
+  AOConfigPrivate()
+      : QObject(qApp),
+        cfg(QDir::currentPath() + "/base/config.ini", QSettings::IniFormat)
+  {
+    read_file();
+  }
+  ~AOConfigPrivate()
+  {
+    save_file();
+  }
 
-    // setters
+  // setters
 public slots:
-    void set_username(QString p_string)
-    {
-        if (username == p_string)
-            return;
-        username = p_string;
-        invoke_parents("username_changed", Q_ARG(QString, p_string));
-    }
-    void set_callwords(QString p_string)
-    {
-        if (callwords == p_string)
-            return;
-        callwords = p_string;
-        invoke_parents("callwords_changed", Q_ARG(QString, p_string));
-    }
-    void set_theme(QString p_string)
-    {
-        if (theme == p_string)
-            return;
-        theme = p_string;
-        invoke_parents("theme_changed", Q_ARG(QString, p_string));
-    }
-    void set_theme_variant(QString p_string)
-    {
-        if (theme_variant == p_string)
-            return;
-        theme_variant = p_string;
-        invoke_parents("theme_variant_changed", Q_ARG(QString, p_string));
-    }
-    void set_always_pre(bool p_enabled)
-    {
-        if (always_pre == p_enabled)
-            return;
-        always_pre = p_enabled;
-        invoke_parents("always_pre_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_chat_tick_interval(int p_number)
-    {
-        if (chat_tick_interval == p_number)
-            return;
-        chat_tick_interval = p_number;
-        invoke_parents("chat_tick_interval_changed", Q_ARG(int, p_number));
-    }
-    void set_server_alerts(bool p_enabled)
-    {
-        if (server_alerts == p_enabled)
-            return;
-        server_alerts = p_enabled;
-        invoke_parents("server_alerts_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_log_max_lines(int p_number)
-    {
-        if (log_max_lines == p_number)
-            return;
-        log_max_lines = p_number;
-        invoke_parents("log_max_lines_changed", Q_ARG(int, p_number));
-    }
-    void set_log_goes_downward(bool p_enabled)
-    {
-        if (log_goes_downward == p_enabled)
-            return;
-        log_goes_downward = p_enabled;
-        invoke_parents("log_goes_downward_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_log_uses_newline(bool p_enabled)
-    {
-        if (log_uses_newline == p_enabled)
-            return;
-        log_uses_newline = p_enabled;
-        invoke_parents("log_uses_newline_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_log_music(bool p_enabled)
-    {
-        if (log_music == p_enabled)
-            return;
-        log_music = p_enabled;
-        invoke_parents("log_music_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_log_is_recording(bool p_enabled)
-    {
-        if (log_is_recording == p_enabled)
-            return;
-        log_is_recording = p_enabled;
-        invoke_parents("log_is_recording_changed", Q_ARG(bool, p_enabled));
-    }
-    void set_effects_volume(int p_number)
-    {
-        if (effects_volume == p_number)
-            return;
-        effects_volume = p_number;
-        invoke_parents("effects_volume_changed", Q_ARG(int, p_number));
-    }
-    void set_system_volume(int p_number)
-    {
-        if (system_volume == p_number)
-            return;
-        system_volume = p_number;
-        invoke_parents("system_volume_changed", Q_ARG(int, p_number));
-    }
-    void set_music_volume(int p_number)
-    {
-        if (music_volume == p_number)
-            return;
-        music_volume = p_number;
-        invoke_parents("music_volume_changed", Q_ARG(int, p_number));
-    }
-    void set_blips_volume(int p_number)
-    {
-        if (blips_volume == p_number)
-            return;
-        blips_volume = p_number;
-        invoke_parents("blips_volume_changed", Q_ARG(int, p_number));
-    }
-    void set_blip_rate(int p_number)
-    {
-        if (blip_rate == p_number)
-            return;
-        blip_rate = p_number;
-        invoke_parents("blip_rate_changed", Q_ARG(int, p_number));
-    }
-    void set_blank_blips(bool p_enabled)
-    {
-        if (blank_blips == p_enabled)
-            return;
-        blank_blips = p_enabled;
-        invoke_parents("blank_blips_changed", Q_ARG(bool, p_enabled));
-    }
-    void read_file()
-    {
-        username           = cfg.value("username").toString();
-        callwords          = cfg.value("callwords").toString();
-        theme              = cfg.value("theme", "default").toString();
-        theme_variant      = cfg.value("theme_variant", "").toString();
-        always_pre         = cfg.value("always_pre", true).toBool();
-        chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
-        server_alerts      = cfg.value("server_alerts", true).toBool();
-        log_max_lines      = cfg.value("chatlog_limit", 200).toInt();
-        log_goes_downward  = cfg.value("chatlog_scrolldown", true).toBool();
-        log_uses_newline   = cfg.value("chatlog_newline", false).toBool();
-        log_music          = cfg.value("music_change_log", true).toBool();
-        log_is_recording   = cfg.value("enable_logging", true).toBool();
-        effects_volume     = cfg.value("default_sfx", 50).toInt();
-        system_volume      = cfg.value("default_system", 50).toInt();
-        music_volume       = cfg.value("default_music", 50).toInt();
-        blips_volume       = cfg.value("default_blip", 50).toInt();
-        blip_rate          = cfg.value("blip_rate", 1000000000).toInt();
-        blank_blips        = cfg.value("blank_blips").toBool();
-    }
-    void save_file()
-    {
-        cfg.setValue("username", username);
-        cfg.setValue("callwords", callwords);
-        cfg.setValue("theme", theme);
-        cfg.setValue("theme_variant", theme_variant);
-        cfg.setValue("always_pre", always_pre);
-        cfg.setValue("chat_tick_interval", chat_tick_interval);
-        cfg.setValue("server_alerts", server_alerts);
-        cfg.setValue("chatlog_limit", log_max_lines);
-        cfg.setValue("chatlog_scrolldown", log_goes_downward);
-        cfg.setValue("chatlog_newline", log_uses_newline);
-        cfg.setValue("music_change_log", log_music);
-        cfg.setValue("enable_logging", log_is_recording);
-        cfg.setValue("default_sfx", effects_volume);
-        cfg.setValue("default_system", system_volume);
-        cfg.setValue("default_music", music_volume);
-        cfg.setValue("default_blip", blips_volume);
-        cfg.setValue("blip_rate", blip_rate);
-        cfg.setValue("blank_blips", blank_blips);
-        cfg.sync();
-    }
+  void set_username(QString p_string)
+  {
+    if (username == p_string)
+      return;
+    username = p_string;
+    invoke_parents("username_changed", Q_ARG(QString, p_string));
+  }
+  void set_callwords(QString p_string)
+  {
+    if (callwords == p_string)
+      return;
+    callwords = p_string;
+    invoke_parents("callwords_changed", Q_ARG(QString, p_string));
+  }
+  void set_theme(QString p_string)
+  {
+    if (theme == p_string)
+      return;
+    theme = p_string;
+    invoke_parents("theme_changed", Q_ARG(QString, p_string));
+  }
+  void set_theme_variant(QString p_string)
+  {
+    if (theme_variant == p_string)
+      return;
+    theme_variant = p_string;
+    invoke_parents("theme_variant_changed", Q_ARG(QString, p_string));
+  }
+  void set_always_pre(bool p_enabled)
+  {
+    if (always_pre == p_enabled)
+      return;
+    always_pre = p_enabled;
+    invoke_parents("always_pre_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_chat_tick_interval(int p_number)
+  {
+    if (chat_tick_interval == p_number)
+      return;
+    chat_tick_interval = p_number;
+    invoke_parents("chat_tick_interval_changed", Q_ARG(int, p_number));
+  }
+  void set_server_alerts(bool p_enabled)
+  {
+    if (server_alerts == p_enabled)
+      return;
+    server_alerts = p_enabled;
+    invoke_parents("server_alerts_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_log_max_lines(int p_number)
+  {
+    if (log_max_lines == p_number)
+      return;
+    log_max_lines = p_number;
+    invoke_parents("log_max_lines_changed", Q_ARG(int, p_number));
+  }
+  void set_log_goes_downward(bool p_enabled)
+  {
+    if (log_goes_downward == p_enabled)
+      return;
+    log_goes_downward = p_enabled;
+    invoke_parents("log_goes_downward_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_log_uses_newline(bool p_enabled)
+  {
+    if (log_uses_newline == p_enabled)
+      return;
+    log_uses_newline = p_enabled;
+    invoke_parents("log_uses_newline_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_log_music(bool p_enabled)
+  {
+    if (log_music == p_enabled)
+      return;
+    log_music = p_enabled;
+    invoke_parents("log_music_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_log_is_recording(bool p_enabled)
+  {
+    if (log_is_recording == p_enabled)
+      return;
+    log_is_recording = p_enabled;
+    invoke_parents("log_is_recording_changed", Q_ARG(bool, p_enabled));
+  }
+  void set_effects_volume(int p_number)
+  {
+    if (effects_volume == p_number)
+      return;
+    effects_volume = p_number;
+    invoke_parents("effects_volume_changed", Q_ARG(int, p_number));
+  }
+  void set_system_volume(int p_number)
+  {
+    if (system_volume == p_number)
+      return;
+    system_volume = p_number;
+    invoke_parents("system_volume_changed", Q_ARG(int, p_number));
+  }
+  void set_music_volume(int p_number)
+  {
+    if (music_volume == p_number)
+      return;
+    music_volume = p_number;
+    invoke_parents("music_volume_changed", Q_ARG(int, p_number));
+  }
+  void set_blips_volume(int p_number)
+  {
+    if (blips_volume == p_number)
+      return;
+    blips_volume = p_number;
+    invoke_parents("blips_volume_changed", Q_ARG(int, p_number));
+  }
+  void set_blip_rate(int p_number)
+  {
+    if (blip_rate == p_number)
+      return;
+    blip_rate = p_number;
+    invoke_parents("blip_rate_changed", Q_ARG(int, p_number));
+  }
+  void set_blank_blips(bool p_enabled)
+  {
+    if (blank_blips == p_enabled)
+      return;
+    blank_blips = p_enabled;
+    invoke_parents("blank_blips_changed", Q_ARG(bool, p_enabled));
+  }
+  void read_file()
+  {
+    username = cfg.value("username").toString();
+    callwords = cfg.value("callwords").toString();
+    theme = cfg.value("theme", "default").toString();
+    theme_variant = cfg.value("theme_variant", "").toString();
+    always_pre = cfg.value("always_pre", true).toBool();
+    chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
+    server_alerts = cfg.value("server_alerts", true).toBool();
+    log_max_lines = cfg.value("chatlog_limit", 200).toInt();
+    log_goes_downward = cfg.value("chatlog_scrolldown", true).toBool();
+    log_uses_newline = cfg.value("chatlog_newline", false).toBool();
+    log_music = cfg.value("music_change_log", true).toBool();
+    log_is_recording = cfg.value("enable_logging", true).toBool();
+    effects_volume = cfg.value("default_sfx", 50).toInt();
+    system_volume = cfg.value("default_system", 50).toInt();
+    music_volume = cfg.value("default_music", 50).toInt();
+    blips_volume = cfg.value("default_blip", 50).toInt();
+    blip_rate = cfg.value("blip_rate", 1000000000).toInt();
+    blank_blips = cfg.value("blank_blips").toBool();
+  }
+  void save_file()
+  {
+    cfg.setValue("username", username);
+    cfg.setValue("callwords", callwords);
+    cfg.setValue("theme", theme);
+    cfg.setValue("theme_variant", theme_variant);
+    cfg.setValue("always_pre", always_pre);
+    cfg.setValue("chat_tick_interval", chat_tick_interval);
+    cfg.setValue("server_alerts", server_alerts);
+    cfg.setValue("chatlog_limit", log_max_lines);
+    cfg.setValue("chatlog_scrolldown", log_goes_downward);
+    cfg.setValue("chatlog_newline", log_uses_newline);
+    cfg.setValue("music_change_log", log_music);
+    cfg.setValue("enable_logging", log_is_recording);
+    cfg.setValue("default_sfx", effects_volume);
+    cfg.setValue("default_system", system_volume);
+    cfg.setValue("default_music", music_volume);
+    cfg.setValue("default_blip", blips_volume);
+    cfg.setValue("blip_rate", blip_rate);
+    cfg.setValue("blank_blips", blank_blips);
+    cfg.sync();
+  }
 
 private:
-    void invoke_parents(QString p_method_name, QGenericArgument p_arg1 = QGenericArgument(nullptr))
+  void invoke_parents(QString p_method_name,
+                      QGenericArgument p_arg1 = QGenericArgument(nullptr))
+  {
+    for (QObject *i_parent : parents)
     {
-        for (QObject *i_parent : parents)
-        {
-            QMetaObject::invokeMethod(i_parent, p_method_name.toStdString().c_str(), p_arg1);
-        }
+      QMetaObject::invokeMethod(i_parent, p_method_name.toStdString().c_str(),
+                                p_arg1);
     }
+  }
 };
 
 /*!
@@ -239,255 +243,255 @@ static AOConfigPrivate *d = nullptr;
 
 AOConfig::AOConfig(QObject *p_parent) : QObject(p_parent)
 {
-    // init if not created yet
-    if (d == nullptr)
-    {
-        d = new AOConfigPrivate;
-    }
+  // init if not created yet
+  if (d == nullptr)
+  {
+    d = new AOConfigPrivate;
+  }
 
-    // ao2 is the pinnacle of thread security
-    d->parents.append(this);
+  // ao2 is the pinnacle of thread security
+  d->parents.append(this);
 }
 
 AOConfig::~AOConfig()
 {
-    // totally safe!
-    d->parents.removeAll(this);
+  // totally safe!
+  d->parents.removeAll(this);
 }
 
 QString AOConfig::get_string(QString p_name, QString p_default)
 {
-    return d->cfg.value(p_name, p_default).toString();
+  return d->cfg.value(p_name, p_default).toString();
 }
 
 bool AOConfig::get_bool(QString p_name, bool p_default)
 {
-    return d->cfg.value(p_name, p_default).toBool();
+  return d->cfg.value(p_name, p_default).toBool();
 }
 
 int AOConfig::get_number(QString p_name, int p_default)
 {
-    return d->cfg.value(p_name, p_default).toInt();
+  return d->cfg.value(p_name, p_default).toInt();
 }
 
 QString AOConfig::username()
 {
-    return d->username;
+  return d->username;
 }
 
 QString AOConfig::callwords()
 {
-    return d->callwords;
+  return d->callwords;
 }
 
 QString AOConfig::theme()
 {
-    return d->theme;
+  return d->theme;
 }
 
 QString AOConfig::theme_variant()
 {
-    return d->theme_variant;
+  return d->theme_variant;
 }
 
 bool AOConfig::always_pre_enabled()
 {
-    return d->always_pre;
+  return d->always_pre;
 }
 
 int AOConfig::chat_tick_interval()
 {
-    return d->chat_tick_interval;
+  return d->chat_tick_interval;
 }
 
 bool AOConfig::server_alerts_enabled()
 {
-    return d->server_alerts;
+  return d->server_alerts;
 }
 
 int AOConfig::log_max_lines()
 {
-    return d->log_max_lines;
+  return d->log_max_lines;
 }
 
 bool AOConfig::log_goes_downward_enabled()
 {
-    return d->log_goes_downward;
+  return d->log_goes_downward;
 }
 
 bool AOConfig::log_uses_newline_enabled()
 {
-    return d->log_uses_newline;
+  return d->log_uses_newline;
 }
 
 bool AOConfig::log_music_enabled()
 {
-    return d->log_music;
+  return d->log_music;
 }
 
 bool AOConfig::log_is_recording_enabled()
 {
-    return d->log_is_recording;
+  return d->log_is_recording;
 }
 
 int AOConfig::effects_volume()
 {
-    return d->effects_volume;
+  return d->effects_volume;
 }
 
 int AOConfig::system_volume()
 {
-    return d->system_volume;
+  return d->system_volume;
 }
 
 int AOConfig::music_volume()
 {
-    return d->music_volume;
+  return d->music_volume;
 }
 
 int AOConfig::blips_volume()
 {
-    return d->blips_volume;
+  return d->blips_volume;
 }
 
 int AOConfig::blip_rate()
 {
-    return d->blip_rate;
+  return d->blip_rate;
 }
 
 bool AOConfig::blank_blips_enabled()
 {
-    return d->blank_blips;
+  return d->blank_blips;
 }
 
 void AOConfig::set_username(QString p_string)
 {
-    d->set_username(p_string);
+  d->set_username(p_string);
 }
 
 void AOConfig::set_callwords(QString p_string)
 {
-    d->set_callwords(p_string);
+  d->set_callwords(p_string);
 }
 
 void AOConfig::set_theme(QString p_string)
 {
-    d->set_theme(p_string);
+  d->set_theme(p_string);
 }
 
 void AOConfig::set_theme_variant(QString p_string)
 {
-    d->set_theme_variant(p_string);
+  d->set_theme_variant(p_string);
 }
 
 void AOConfig::set_always_pre(int p_state)
 {
-    set_always_pre(p_state == Qt::Checked);
+  set_always_pre(p_state == Qt::Checked);
 }
 
 void AOConfig::set_always_pre(bool p_enabled)
 {
-    d->set_always_pre(p_enabled);
+  d->set_always_pre(p_enabled);
 }
 
 void AOConfig::set_chat_tick_interval(int p_number)
 {
-    d->set_chat_tick_interval(p_number);
+  d->set_chat_tick_interval(p_number);
 }
 
 void AOConfig::set_server_alerts(int p_state)
 {
-    set_server_alerts(p_state == Qt::Checked);
+  set_server_alerts(p_state == Qt::Checked);
 }
 
 void AOConfig::set_server_alerts(bool p_enabled)
 {
-    d->set_server_alerts(p_enabled);
+  d->set_server_alerts(p_enabled);
 }
 
 void AOConfig::set_log_max_lines(int p_number)
 {
-    d->set_log_max_lines(p_number);
+  d->set_log_max_lines(p_number);
 }
 
 void AOConfig::set_log_goes_downward(bool p_enabled)
 {
-    d->set_log_goes_downward(p_enabled);
+  d->set_log_goes_downward(p_enabled);
 }
 
 void AOConfig::set_log_goes_downward(int p_state)
 {
-    set_log_goes_downward(p_state == Qt::Checked);
+  set_log_goes_downward(p_state == Qt::Checked);
 }
 
 void AOConfig::set_log_uses_newline(bool p_enabled)
 {
-    d->set_log_uses_newline(p_enabled);
+  d->set_log_uses_newline(p_enabled);
 }
 
 void AOConfig::set_log_uses_newline(int p_state)
 {
-    set_log_uses_newline(p_state == Qt::Checked);
+  set_log_uses_newline(p_state == Qt::Checked);
 }
 
 void AOConfig::set_log_music(bool p_enabled)
 {
-    d->set_log_music(p_enabled);
+  d->set_log_music(p_enabled);
 }
 
 void AOConfig::set_log_music(int p_state)
 {
-    set_log_music(p_state == Qt::Checked);
+  set_log_music(p_state == Qt::Checked);
 }
 
 void AOConfig::set_log_is_recording(bool p_enabled)
 {
-    d->set_log_is_recording(p_enabled);
+  d->set_log_is_recording(p_enabled);
 }
 
 void AOConfig::set_log_is_recording(int p_state)
 {
-    set_log_is_recording(p_state == Qt::Checked);
+  set_log_is_recording(p_state == Qt::Checked);
 }
 
 void AOConfig::set_effects_volume(int p_number)
 {
-    d->set_effects_volume(p_number);
+  d->set_effects_volume(p_number);
 }
 
 void AOConfig::set_system_volume(int p_number)
 {
-    d->set_system_volume(p_number);
+  d->set_system_volume(p_number);
 }
 
 void AOConfig::set_music_volume(int p_number)
 {
-    d->set_music_volume(p_number);
+  d->set_music_volume(p_number);
 }
 
 void AOConfig::set_blips_volume(int p_number)
 {
-    d->set_blips_volume(p_number);
+  d->set_blips_volume(p_number);
 }
 
 void AOConfig::set_blip_rate(int p_number)
 {
-    d->set_blip_rate(p_number);
+  d->set_blip_rate(p_number);
 }
 
 void AOConfig::set_blank_blips(bool p_enabled)
 {
-    d->set_blank_blips(p_enabled);
+  d->set_blank_blips(p_enabled);
 }
 
 void AOConfig::set_blank_blips(int p_state)
 {
-    set_blank_blips(p_state == Qt::Checked);
+  set_blank_blips(p_state == Qt::Checked);
 }
 
 void AOConfig::save_file()
 {
-    d->save_file();
+  d->save_file();
 }
 
 // moc

--- a/aoconfig.cpp
+++ b/aoconfig.cpp
@@ -47,7 +47,10 @@ public:
   {
     read_file();
   }
-  ~AOConfigPrivate() { save_file(); }
+  ~AOConfigPrivate()
+  {
+    save_file();
+  }
 
   // setters
 public slots:
@@ -271,47 +274,110 @@ int AOConfig::get_number(QString p_name, int p_default)
   return d->cfg.value(p_name, p_default).toInt();
 }
 
-QString AOConfig::username() { return d->username; }
+QString AOConfig::username()
+{
+  return d->username;
+}
 
-QString AOConfig::callwords() { return d->callwords; }
+QString AOConfig::callwords()
+{
+  return d->callwords;
+}
 
-QString AOConfig::theme() { return d->theme; }
+QString AOConfig::theme()
+{
+  return d->theme;
+}
 
-QString AOConfig::theme_variant() { return d->theme_variant; }
+QString AOConfig::theme_variant()
+{
+  return d->theme_variant;
+}
 
-bool AOConfig::always_pre_enabled() { return d->always_pre; }
+bool AOConfig::always_pre_enabled()
+{
+  return d->always_pre;
+}
 
-int AOConfig::chat_tick_interval() { return d->chat_tick_interval; }
+int AOConfig::chat_tick_interval()
+{
+  return d->chat_tick_interval;
+}
 
-bool AOConfig::server_alerts_enabled() { return d->server_alerts; }
+bool AOConfig::server_alerts_enabled()
+{
+  return d->server_alerts;
+}
 
-int AOConfig::log_max_lines() { return d->log_max_lines; }
+int AOConfig::log_max_lines()
+{
+  return d->log_max_lines;
+}
 
-bool AOConfig::log_goes_downward_enabled() { return d->log_goes_downward; }
+bool AOConfig::log_goes_downward_enabled()
+{
+  return d->log_goes_downward;
+}
 
-bool AOConfig::log_uses_newline_enabled() { return d->log_uses_newline; }
+bool AOConfig::log_uses_newline_enabled()
+{
+  return d->log_uses_newline;
+}
 
-bool AOConfig::log_music_enabled() { return d->log_music; }
+bool AOConfig::log_music_enabled()
+{
+  return d->log_music;
+}
 
-bool AOConfig::log_is_recording_enabled() { return d->log_is_recording; }
+bool AOConfig::log_is_recording_enabled()
+{
+  return d->log_is_recording;
+}
 
-int AOConfig::effects_volume() { return d->effects_volume; }
+int AOConfig::effects_volume()
+{
+  return d->effects_volume;
+}
 
-int AOConfig::system_volume() { return d->system_volume; }
+int AOConfig::system_volume()
+{
+  return d->system_volume;
+}
 
-int AOConfig::music_volume() { return d->music_volume; }
+int AOConfig::music_volume()
+{
+  return d->music_volume;
+}
 
-int AOConfig::blips_volume() { return d->blips_volume; }
+int AOConfig::blips_volume()
+{
+  return d->blips_volume;
+}
 
-int AOConfig::blip_rate() { return d->blip_rate; }
+int AOConfig::blip_rate()
+{
+  return d->blip_rate;
+}
 
-bool AOConfig::blank_blips_enabled() { return d->blank_blips; }
+bool AOConfig::blank_blips_enabled()
+{
+  return d->blank_blips;
+}
 
-void AOConfig::set_username(QString p_string) { d->set_username(p_string); }
+void AOConfig::set_username(QString p_string)
+{
+  d->set_username(p_string);
+}
 
-void AOConfig::set_callwords(QString p_string) { d->set_callwords(p_string); }
+void AOConfig::set_callwords(QString p_string)
+{
+  d->set_callwords(p_string);
+}
 
-void AOConfig::set_theme(QString p_string) { d->set_theme(p_string); }
+void AOConfig::set_theme(QString p_string)
+{
+  d->set_theme(p_string);
+}
 
 void AOConfig::set_theme_variant(QString p_string)
 {
@@ -323,7 +389,10 @@ void AOConfig::set_always_pre(int p_state)
   set_always_pre(p_state == Qt::Checked);
 }
 
-void AOConfig::set_always_pre(bool p_enabled) { d->set_always_pre(p_enabled); }
+void AOConfig::set_always_pre(bool p_enabled)
+{
+  d->set_always_pre(p_enabled);
+}
 
 void AOConfig::set_chat_tick_interval(int p_number)
 {
@@ -365,7 +434,10 @@ void AOConfig::set_log_uses_newline(int p_state)
   set_log_uses_newline(p_state == Qt::Checked);
 }
 
-void AOConfig::set_log_music(bool p_enabled) { d->set_log_music(p_enabled); }
+void AOConfig::set_log_music(bool p_enabled)
+{
+  d->set_log_music(p_enabled);
+}
 
 void AOConfig::set_log_music(int p_state)
 {
@@ -392,11 +464,20 @@ void AOConfig::set_system_volume(int p_number)
   d->set_system_volume(p_number);
 }
 
-void AOConfig::set_music_volume(int p_number) { d->set_music_volume(p_number); }
+void AOConfig::set_music_volume(int p_number)
+{
+  d->set_music_volume(p_number);
+}
 
-void AOConfig::set_blips_volume(int p_number) { d->set_blips_volume(p_number); }
+void AOConfig::set_blips_volume(int p_number)
+{
+  d->set_blips_volume(p_number);
+}
 
-void AOConfig::set_blip_rate(int p_number) { d->set_blip_rate(p_number); }
+void AOConfig::set_blip_rate(int p_number)
+{
+  d->set_blip_rate(p_number);
+}
 
 void AOConfig::set_blank_blips(bool p_enabled)
 {
@@ -408,7 +489,10 @@ void AOConfig::set_blank_blips(int p_state)
   set_blank_blips(p_state == Qt::Checked);
 }
 
-void AOConfig::save_file() { d->save_file(); }
+void AOConfig::save_file()
+{
+  d->save_file();
+}
 
 // moc
 #include "aoconfig.moc"

--- a/aoconfig.cpp
+++ b/aoconfig.cpp
@@ -47,10 +47,7 @@ public:
   {
     read_file();
   }
-  ~AOConfigPrivate()
-  {
-    save_file();
-  }
+  ~AOConfigPrivate() { save_file(); }
 
   // setters
 public slots:
@@ -274,110 +271,47 @@ int AOConfig::get_number(QString p_name, int p_default)
   return d->cfg.value(p_name, p_default).toInt();
 }
 
-QString AOConfig::username()
-{
-  return d->username;
-}
+QString AOConfig::username() { return d->username; }
 
-QString AOConfig::callwords()
-{
-  return d->callwords;
-}
+QString AOConfig::callwords() { return d->callwords; }
 
-QString AOConfig::theme()
-{
-  return d->theme;
-}
+QString AOConfig::theme() { return d->theme; }
 
-QString AOConfig::theme_variant()
-{
-  return d->theme_variant;
-}
+QString AOConfig::theme_variant() { return d->theme_variant; }
 
-bool AOConfig::always_pre_enabled()
-{
-  return d->always_pre;
-}
+bool AOConfig::always_pre_enabled() { return d->always_pre; }
 
-int AOConfig::chat_tick_interval()
-{
-  return d->chat_tick_interval;
-}
+int AOConfig::chat_tick_interval() { return d->chat_tick_interval; }
 
-bool AOConfig::server_alerts_enabled()
-{
-  return d->server_alerts;
-}
+bool AOConfig::server_alerts_enabled() { return d->server_alerts; }
 
-int AOConfig::log_max_lines()
-{
-  return d->log_max_lines;
-}
+int AOConfig::log_max_lines() { return d->log_max_lines; }
 
-bool AOConfig::log_goes_downward_enabled()
-{
-  return d->log_goes_downward;
-}
+bool AOConfig::log_goes_downward_enabled() { return d->log_goes_downward; }
 
-bool AOConfig::log_uses_newline_enabled()
-{
-  return d->log_uses_newline;
-}
+bool AOConfig::log_uses_newline_enabled() { return d->log_uses_newline; }
 
-bool AOConfig::log_music_enabled()
-{
-  return d->log_music;
-}
+bool AOConfig::log_music_enabled() { return d->log_music; }
 
-bool AOConfig::log_is_recording_enabled()
-{
-  return d->log_is_recording;
-}
+bool AOConfig::log_is_recording_enabled() { return d->log_is_recording; }
 
-int AOConfig::effects_volume()
-{
-  return d->effects_volume;
-}
+int AOConfig::effects_volume() { return d->effects_volume; }
 
-int AOConfig::system_volume()
-{
-  return d->system_volume;
-}
+int AOConfig::system_volume() { return d->system_volume; }
 
-int AOConfig::music_volume()
-{
-  return d->music_volume;
-}
+int AOConfig::music_volume() { return d->music_volume; }
 
-int AOConfig::blips_volume()
-{
-  return d->blips_volume;
-}
+int AOConfig::blips_volume() { return d->blips_volume; }
 
-int AOConfig::blip_rate()
-{
-  return d->blip_rate;
-}
+int AOConfig::blip_rate() { return d->blip_rate; }
 
-bool AOConfig::blank_blips_enabled()
-{
-  return d->blank_blips;
-}
+bool AOConfig::blank_blips_enabled() { return d->blank_blips; }
 
-void AOConfig::set_username(QString p_string)
-{
-  d->set_username(p_string);
-}
+void AOConfig::set_username(QString p_string) { d->set_username(p_string); }
 
-void AOConfig::set_callwords(QString p_string)
-{
-  d->set_callwords(p_string);
-}
+void AOConfig::set_callwords(QString p_string) { d->set_callwords(p_string); }
 
-void AOConfig::set_theme(QString p_string)
-{
-  d->set_theme(p_string);
-}
+void AOConfig::set_theme(QString p_string) { d->set_theme(p_string); }
 
 void AOConfig::set_theme_variant(QString p_string)
 {
@@ -389,10 +323,7 @@ void AOConfig::set_always_pre(int p_state)
   set_always_pre(p_state == Qt::Checked);
 }
 
-void AOConfig::set_always_pre(bool p_enabled)
-{
-  d->set_always_pre(p_enabled);
-}
+void AOConfig::set_always_pre(bool p_enabled) { d->set_always_pre(p_enabled); }
 
 void AOConfig::set_chat_tick_interval(int p_number)
 {
@@ -434,10 +365,7 @@ void AOConfig::set_log_uses_newline(int p_state)
   set_log_uses_newline(p_state == Qt::Checked);
 }
 
-void AOConfig::set_log_music(bool p_enabled)
-{
-  d->set_log_music(p_enabled);
-}
+void AOConfig::set_log_music(bool p_enabled) { d->set_log_music(p_enabled); }
 
 void AOConfig::set_log_music(int p_state)
 {
@@ -464,20 +392,11 @@ void AOConfig::set_system_volume(int p_number)
   d->set_system_volume(p_number);
 }
 
-void AOConfig::set_music_volume(int p_number)
-{
-  d->set_music_volume(p_number);
-}
+void AOConfig::set_music_volume(int p_number) { d->set_music_volume(p_number); }
 
-void AOConfig::set_blips_volume(int p_number)
-{
-  d->set_blips_volume(p_number);
-}
+void AOConfig::set_blips_volume(int p_number) { d->set_blips_volume(p_number); }
 
-void AOConfig::set_blip_rate(int p_number)
-{
-  d->set_blip_rate(p_number);
-}
+void AOConfig::set_blip_rate(int p_number) { d->set_blip_rate(p_number); }
 
 void AOConfig::set_blank_blips(bool p_enabled)
 {
@@ -489,10 +408,7 @@ void AOConfig::set_blank_blips(int p_state)
   set_blank_blips(p_state == Qt::Checked);
 }
 
-void AOConfig::save_file()
-{
-  d->save_file();
-}
+void AOConfig::save_file() { d->save_file(); }
 
 // moc
 #include "aoconfig.moc"

--- a/aoconfig.h
+++ b/aoconfig.h
@@ -5,88 +5,88 @@
 
 class AOConfig : public QObject
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOConfig(QObject *p_parent = nullptr);
-    ~AOConfig();
+  AOConfig(QObject *p_parent = nullptr);
+  ~AOConfig();
 
-    // generic getters
-    QString get_string(QString p_name, QString p_default = nullptr);
-    bool get_bool(QString p_name, bool p_default = false);
-    int get_number(QString p_name, int p_default = 0);
+  // generic getters
+  QString get_string(QString p_name, QString p_default = nullptr);
+  bool get_bool(QString p_name, bool p_default = false);
+  int get_number(QString p_name, int p_default = 0);
 
-    // getters
-    QString username();
-    QString callwords();
-    QString theme();
-    QString theme_variant();
-    bool always_pre_enabled();
-    int chat_tick_interval();
-    bool server_alerts_enabled();
-    int log_max_lines();
-    bool log_goes_downward_enabled();
-    bool log_uses_newline_enabled();
-    bool log_music_enabled();
-    bool log_is_recording_enabled();
-    int effects_volume();
-    int system_volume();
-    int music_volume();
-    int blips_volume();
-    int blip_rate();
-    bool blank_blips_enabled();
+  // getters
+  QString username();
+  QString callwords();
+  QString theme();
+  QString theme_variant();
+  bool always_pre_enabled();
+  int chat_tick_interval();
+  bool server_alerts_enabled();
+  int log_max_lines();
+  bool log_goes_downward_enabled();
+  bool log_uses_newline_enabled();
+  bool log_music_enabled();
+  bool log_is_recording_enabled();
+  int effects_volume();
+  int system_volume();
+  int music_volume();
+  int blips_volume();
+  int blip_rate();
+  bool blank_blips_enabled();
 
-    // io
+  // io
 public slots:
-    void save_file();
+  void save_file();
 
-    // setters
+  // setters
 public slots:
-    void set_username(QString p_string);
-    void set_callwords(QString p_string);
-    void set_theme(QString p_string);
-    void set_theme_variant(QString p_string);
-    void set_always_pre(bool p_enabled);
-    void set_always_pre(int p_state);
-    void set_chat_tick_interval(int p_number);
-    void set_server_alerts(bool p_enabled);
-    void set_server_alerts(int p_state);
-    void set_log_max_lines(int p_number);
-    void set_log_goes_downward(bool p_enabled);
-    void set_log_goes_downward(int p_state);
-    void set_log_uses_newline(bool p_enabled);
-    void set_log_uses_newline(int p_state);
-    void set_log_music(bool p_enabled);
-    void set_log_music(int p_state);
-    void set_log_is_recording(bool p_enabled);
-    void set_log_is_recording(int p_state);
-    void set_effects_volume(int p_number);
-    void set_system_volume(int p_number);
-    void set_music_volume(int p_number);
-    void set_blips_volume(int p_number);
-    void set_blip_rate(int p_number);
-    void set_blank_blips(bool p_enabled);
-    void set_blank_blips(int p_state);
+  void set_username(QString p_string);
+  void set_callwords(QString p_string);
+  void set_theme(QString p_string);
+  void set_theme_variant(QString p_string);
+  void set_always_pre(bool p_enabled);
+  void set_always_pre(int p_state);
+  void set_chat_tick_interval(int p_number);
+  void set_server_alerts(bool p_enabled);
+  void set_server_alerts(int p_state);
+  void set_log_max_lines(int p_number);
+  void set_log_goes_downward(bool p_enabled);
+  void set_log_goes_downward(int p_state);
+  void set_log_uses_newline(bool p_enabled);
+  void set_log_uses_newline(int p_state);
+  void set_log_music(bool p_enabled);
+  void set_log_music(int p_state);
+  void set_log_is_recording(bool p_enabled);
+  void set_log_is_recording(int p_state);
+  void set_effects_volume(int p_number);
+  void set_system_volume(int p_number);
+  void set_music_volume(int p_number);
+  void set_blips_volume(int p_number);
+  void set_blip_rate(int p_number);
+  void set_blank_blips(bool p_enabled);
+  void set_blank_blips(int p_state);
 
-    // signals
+  // signals
 signals:
-    void username_changed(QString);
-    void callwords_changed(QString);
-    void theme_changed(QString);
-    void theme_variant_changed(QString);
-    void always_pre_changed(bool);
-    void chat_tick_interval_changed(int);
-    void log_max_lines_changed(int);
-    void log_goes_downward_changed(bool);
-    void log_uses_newline_changed(bool);
-    void log_music_changed(bool);
-    void log_is_recording_changed(bool);
-    void effects_volume_changed(int);
-    void system_volume_changed(int);
-    void music_volume_changed(int);
-    void blips_volume_changed(int);
-    void blip_rate_changed(int);
-    void blank_blips_changed(bool);
+  void username_changed(QString);
+  void callwords_changed(QString);
+  void theme_changed(QString);
+  void theme_variant_changed(QString);
+  void always_pre_changed(bool);
+  void chat_tick_interval_changed(int);
+  void log_max_lines_changed(int);
+  void log_goes_downward_changed(bool);
+  void log_uses_newline_changed(bool);
+  void log_music_changed(bool);
+  void log_is_recording_changed(bool);
+  void effects_volume_changed(int);
+  void system_volume_changed(int);
+  void music_volume_changed(int);
+  void blips_volume_changed(int);
+  void blip_rate_changed(int);
+  void blank_blips_changed(bool);
 };
 
 #endif // AOCONFIG_H

--- a/aoconfigpanel.cpp
+++ b/aoconfigpanel.cpp
@@ -3,201 +3,246 @@
 #include <QDebug>
 #include <QDir>
 
-AOConfigPanel::AOConfigPanel(QWidget *p_parent) : QWidget(p_parent), m_config(new AOConfig(this))
+AOConfigPanel::AOConfigPanel(QWidget *p_parent)
+    : QWidget(p_parent), m_config(new AOConfig(this))
 {
-    setWindowTitle(tr("Config"));
-    setWindowFlag(Qt::WindowMinMaxButtonsHint, false);
+  setWindowTitle(tr("Config"));
+  setWindowFlag(Qt::WindowMinMaxButtonsHint, false);
 
-    AOGuiLoader loader;
-    loader.load_from_file(":res/ui/config_panel.ui", this);
+  AOGuiLoader loader;
+  loader.load_from_file(":res/ui/config_panel.ui", this);
 
-    // tab
-    setFocusProxy(AO_GUI_WIDGET(QTabWidget, "tab_widget"));
+  // tab
+  setFocusProxy(AO_GUI_WIDGET(QTabWidget, "tab_widget"));
 
-    // save
-    w_save = AO_GUI_WIDGET(QPushButton, "save");
+  // save
+  w_save = AO_GUI_WIDGET(QPushButton, "save");
 
-    // general
-    w_username = AO_GUI_WIDGET(QLineEdit, "username");
-    w_callwords = AO_GUI_WIDGET(QLineEdit, "callwords");
-    w_theme = AO_GUI_WIDGET(QComboBox, "theme");
-    w_theme_variant = AO_GUI_WIDGET(QComboBox, "theme_variant");
-    w_reload_theme = AO_GUI_WIDGET(QPushButton, "theme_reload");
-    w_always_pre = AO_GUI_WIDGET(QCheckBox, "always_pre");
-    w_chat_tick_interval = AO_GUI_WIDGET(QSpinBox, "chat_tick_interval");
-    w_server_alerts = AO_GUI_WIDGET(QCheckBox, "server_alerts");
+  // general
+  w_username = AO_GUI_WIDGET(QLineEdit, "username");
+  w_callwords = AO_GUI_WIDGET(QLineEdit, "callwords");
+  w_theme = AO_GUI_WIDGET(QComboBox, "theme");
+  w_theme_variant = AO_GUI_WIDGET(QComboBox, "theme_variant");
+  w_reload_theme = AO_GUI_WIDGET(QPushButton, "theme_reload");
+  w_always_pre = AO_GUI_WIDGET(QCheckBox, "always_pre");
+  w_chat_tick_interval = AO_GUI_WIDGET(QSpinBox, "chat_tick_interval");
+  w_server_alerts = AO_GUI_WIDGET(QCheckBox, "server_alerts");
 
-    // IC Chatlog
-    w_log_max_lines = AO_GUI_WIDGET(QSpinBox, "log_length");
-    w_log_uses_newline = AO_GUI_WIDGET(QCheckBox, "log_newline");
-    w_log_goes_downward = AO_GUI_WIDGET(QCheckBox, "log_downward");
-    w_log_music = AO_GUI_WIDGET(QCheckBox, "log_music");
-    w_log_is_recording = AO_GUI_WIDGET(QCheckBox, "log_recording");
+  // IC Chatlog
+  w_log_max_lines = AO_GUI_WIDGET(QSpinBox, "log_length");
+  w_log_uses_newline = AO_GUI_WIDGET(QCheckBox, "log_newline");
+  w_log_goes_downward = AO_GUI_WIDGET(QCheckBox, "log_downward");
+  w_log_music = AO_GUI_WIDGET(QCheckBox, "log_music");
+  w_log_is_recording = AO_GUI_WIDGET(QCheckBox, "log_recording");
 
-    // audio
-    w_effects = AO_GUI_WIDGET(QSlider, "effects");
-    w_effects_value = AO_GUI_WIDGET(QLabel, "effects_value");
-    w_system = AO_GUI_WIDGET(QSlider, "system");
-    w_system_value = AO_GUI_WIDGET(QLabel, "system_value");
-    w_music = AO_GUI_WIDGET(QSlider, "music");
-    w_music_value = AO_GUI_WIDGET(QLabel, "music_value");
-    w_blips = AO_GUI_WIDGET(QSlider, "blips");
-    w_blips_value = AO_GUI_WIDGET(QLabel, "blips_value");
-    w_blip_rate = AO_GUI_WIDGET(QSpinBox, "blip_rate");
-    w_blank_blips = AO_GUI_WIDGET(QCheckBox, "blank_blips");
+  // audio
+  w_effects = AO_GUI_WIDGET(QSlider, "effects");
+  w_effects_value = AO_GUI_WIDGET(QLabel, "effects_value");
+  w_system = AO_GUI_WIDGET(QSlider, "system");
+  w_system_value = AO_GUI_WIDGET(QLabel, "system_value");
+  w_music = AO_GUI_WIDGET(QSlider, "music");
+  w_music_value = AO_GUI_WIDGET(QLabel, "music_value");
+  w_blips = AO_GUI_WIDGET(QSlider, "blips");
+  w_blips_value = AO_GUI_WIDGET(QLabel, "blips_value");
+  w_blip_rate = AO_GUI_WIDGET(QSpinBox, "blip_rate");
+  w_blank_blips = AO_GUI_WIDGET(QCheckBox, "blank_blips");
 
-    // themes
-    refresh_theme_list();
-    refresh_theme_variant_list();
+  // themes
+  refresh_theme_list();
+  refresh_theme_variant_list();
 
-    // input
-    connect(m_config, SIGNAL(username_changed(QString)), w_username, SLOT(setText(QString)));
-    connect(m_config, SIGNAL(callwords_changed(QString)), w_callwords, SLOT(setText(QString)));
-    connect(m_config, SIGNAL(theme_changed(QString)), w_theme, SLOT(setCurrentText(QString)));
-    connect(m_config, SIGNAL(theme_variant_changed(QString)), w_theme_variant, SLOT(setCurrentText(QString)));
-    connect(m_config, SIGNAL(always_pre_changed(bool)), w_always_pre, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(chat_tick_interval_changed(int)), w_chat_tick_interval, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(server_alerts_changed(bool)), w_server_alerts, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(log_max_lines_changed(int)), w_log_max_lines, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(log_goes_downward_changed(bool)), w_log_goes_downward, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(log_uses_newline_changed(bool)), w_log_uses_newline, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(log_music_changed(bool)), w_log_music, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(log_is_recording_changed(bool)), w_log_is_recording, SLOT(setChecked(bool)));
-    connect(m_config, SIGNAL(effects_volume_changed(int)), w_effects, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(system_volume_changed(int)), w_system, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(music_volume_changed(int)), w_music, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(blips_volume_changed(int)), w_blips, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(blip_rate_changed(int)), w_blip_rate, SLOT(setValue(int)));
-    connect(m_config, SIGNAL(blank_blips_changed(bool)), w_blank_blips, SLOT(setChecked(bool)));
+  // input
+  connect(m_config, SIGNAL(username_changed(QString)), w_username,
+          SLOT(setText(QString)));
+  connect(m_config, SIGNAL(callwords_changed(QString)), w_callwords,
+          SLOT(setText(QString)));
+  connect(m_config, SIGNAL(theme_changed(QString)), w_theme,
+          SLOT(setCurrentText(QString)));
+  connect(m_config, SIGNAL(theme_variant_changed(QString)), w_theme_variant,
+          SLOT(setCurrentText(QString)));
+  connect(m_config, SIGNAL(always_pre_changed(bool)), w_always_pre,
+          SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(chat_tick_interval_changed(int)),
+          w_chat_tick_interval, SLOT(setValue(int)));
+  connect(m_config, SIGNAL(server_alerts_changed(bool)), w_server_alerts,
+          SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(log_max_lines_changed(int)), w_log_max_lines,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(log_goes_downward_changed(bool)),
+          w_log_goes_downward, SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(log_uses_newline_changed(bool)), w_log_uses_newline,
+          SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(log_music_changed(bool)), w_log_music,
+          SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(log_is_recording_changed(bool)), w_log_is_recording,
+          SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(effects_volume_changed(int)), w_effects,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(system_volume_changed(int)), w_system,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(music_volume_changed(int)), w_music,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(blips_volume_changed(int)), w_blips,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(blip_rate_changed(int)), w_blip_rate,
+          SLOT(setValue(int)));
+  connect(m_config, SIGNAL(blank_blips_changed(bool)), w_blank_blips,
+          SLOT(setChecked(bool)));
 
-    // output
-    connect(w_save, SIGNAL(clicked()), m_config, SLOT(save_file()));
-    connect(w_username, SIGNAL(textEdited(QString)), m_config, SLOT(set_username(QString)));
-    connect(w_callwords, SIGNAL(textEdited(QString)), m_config, SLOT(set_callwords(QString)));
-    connect(w_theme, SIGNAL(currentIndexChanged(QString)), m_config, SLOT(set_theme(QString)));
-    connect(w_reload_theme, SIGNAL(clicked()), this, SLOT(on_reload_theme_clicked()));
-    connect(w_theme_variant, SIGNAL(currentIndexChanged(QString)), m_config, SLOT(set_theme_variant(QString)));
-    connect(w_always_pre, SIGNAL(stateChanged(int)), m_config, SLOT(set_always_pre(int)));
-    connect(w_chat_tick_interval, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_tick_interval(int)));
-    connect(w_server_alerts, SIGNAL(stateChanged(int)), m_config, SLOT(set_server_alerts(int)));
-    connect(w_log_max_lines, SIGNAL(valueChanged(int)), m_config, SLOT(set_log_max_lines(int)));
-    connect(w_log_goes_downward, SIGNAL(stateChanged(int)), m_config, SLOT(set_log_goes_downward(int)));
-    connect(w_log_uses_newline, SIGNAL(stateChanged(int)), m_config, SLOT(set_log_uses_newline(int)));
-    connect(w_log_music, SIGNAL(stateChanged(int)), m_config, SLOT(set_log_music(int)));
-    connect(w_log_is_recording, SIGNAL(stateChanged(int)), m_config, SLOT(set_log_is_recording(int)));
-    connect(w_effects, SIGNAL(valueChanged(int)), m_config, SLOT(set_effects_volume(int)));
-    connect(w_effects, SIGNAL(valueChanged(int)), this, SLOT(on_effects_value_changed(int)));
-    connect(w_system, SIGNAL(valueChanged(int)), m_config, SLOT(set_system_volume(int)));
-    connect(w_system, SIGNAL(valueChanged(int)), this, SLOT(on_system_value_changed(int)));
-    connect(w_music, SIGNAL(valueChanged(int)), m_config, SLOT(set_music_volume(int)));
-    connect(w_music, SIGNAL(valueChanged(int)), this, SLOT(on_music_value_changed(int)));
-    connect(w_blips, SIGNAL(valueChanged(int)), m_config, SLOT(set_blips_volume(int)));
-    connect(w_blips, SIGNAL(valueChanged(int)), this, SLOT(on_blips_value_changed(int)));
-    connect(w_blip_rate, SIGNAL(valueChanged(int)), m_config, SLOT(set_blip_rate(int)));
-    connect(w_blank_blips, SIGNAL(stateChanged(int)), m_config, SLOT(set_blank_blips(int)));
+  // output
+  connect(w_save, SIGNAL(clicked()), m_config, SLOT(save_file()));
+  connect(w_username, SIGNAL(textEdited(QString)), m_config,
+          SLOT(set_username(QString)));
+  connect(w_callwords, SIGNAL(textEdited(QString)), m_config,
+          SLOT(set_callwords(QString)));
+  connect(w_theme, SIGNAL(currentIndexChanged(QString)), m_config,
+          SLOT(set_theme(QString)));
+  connect(w_reload_theme, SIGNAL(clicked()), this,
+          SLOT(on_reload_theme_clicked()));
+  connect(w_theme_variant, SIGNAL(currentIndexChanged(QString)), m_config,
+          SLOT(set_theme_variant(QString)));
+  connect(w_always_pre, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_always_pre(int)));
+  connect(w_chat_tick_interval, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_chat_tick_interval(int)));
+  connect(w_server_alerts, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_server_alerts(int)));
+  connect(w_log_max_lines, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_log_max_lines(int)));
+  connect(w_log_goes_downward, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_log_goes_downward(int)));
+  connect(w_log_uses_newline, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_log_uses_newline(int)));
+  connect(w_log_music, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_log_music(int)));
+  connect(w_log_is_recording, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_log_is_recording(int)));
+  connect(w_effects, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_effects_volume(int)));
+  connect(w_effects, SIGNAL(valueChanged(int)), this,
+          SLOT(on_effects_value_changed(int)));
+  connect(w_system, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_system_volume(int)));
+  connect(w_system, SIGNAL(valueChanged(int)), this,
+          SLOT(on_system_value_changed(int)));
+  connect(w_music, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_music_volume(int)));
+  connect(w_music, SIGNAL(valueChanged(int)), this,
+          SLOT(on_music_value_changed(int)));
+  connect(w_blips, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_blips_volume(int)));
+  connect(w_blips, SIGNAL(valueChanged(int)), this,
+          SLOT(on_blips_value_changed(int)));
+  connect(w_blip_rate, SIGNAL(valueChanged(int)), m_config,
+          SLOT(set_blip_rate(int)));
+  connect(w_blank_blips, SIGNAL(stateChanged(int)), m_config,
+          SLOT(set_blank_blips(int)));
 
-    // set values
-    w_username->setText(m_config->username());
-    w_callwords->setText(m_config->callwords());
-    w_theme->setCurrentText(m_config->theme());
-    w_theme_variant->setCurrentText(m_config->theme_variant());
-    w_always_pre->setChecked(m_config->always_pre_enabled());
-    w_chat_tick_interval->setValue(m_config->chat_tick_interval());
-    w_server_alerts->setChecked(m_config->server_alerts_enabled());
-    w_log_max_lines->setValue(m_config->log_max_lines());
-    w_log_goes_downward->setChecked(m_config->log_goes_downward_enabled());
-    w_log_uses_newline->setChecked(m_config->log_uses_newline_enabled());
-    w_log_music->setChecked(m_config->log_music_enabled());
-    w_log_is_recording->setChecked(m_config->log_is_recording_enabled());
-    w_effects->setValue(m_config->effects_volume());
-    w_system->setValue(m_config->system_volume());
-    w_music->setValue(m_config->music_volume());
-    w_blips->setValue(m_config->blips_volume());
-    w_blip_rate->setValue(m_config->blip_rate());
-    w_blank_blips->setChecked(m_config->blank_blips_enabled());
+  // set values
+  w_username->setText(m_config->username());
+  w_callwords->setText(m_config->callwords());
+  w_theme->setCurrentText(m_config->theme());
+  w_theme_variant->setCurrentText(m_config->theme_variant());
+  w_always_pre->setChecked(m_config->always_pre_enabled());
+  w_chat_tick_interval->setValue(m_config->chat_tick_interval());
+  w_server_alerts->setChecked(m_config->server_alerts_enabled());
+  w_log_max_lines->setValue(m_config->log_max_lines());
+  w_log_goes_downward->setChecked(m_config->log_goes_downward_enabled());
+  w_log_uses_newline->setChecked(m_config->log_uses_newline_enabled());
+  w_log_music->setChecked(m_config->log_music_enabled());
+  w_log_is_recording->setChecked(m_config->log_is_recording_enabled());
+  w_effects->setValue(m_config->effects_volume());
+  w_system->setValue(m_config->system_volume());
+  w_music->setValue(m_config->music_volume());
+  w_blips->setValue(m_config->blips_volume());
+  w_blip_rate->setValue(m_config->blip_rate());
+  w_blank_blips->setChecked(m_config->blank_blips_enabled());
 }
 
 void AOConfigPanel::refresh_theme_list()
 {
-    const QString p_prev_text = w_theme->currentText();
+  const QString p_prev_text = w_theme->currentText();
 
-    // block signals
-    w_theme->blockSignals(true);
-    w_theme->clear();
+  // block signals
+  w_theme->blockSignals(true);
+  w_theme->clear();
 
-    // themes
-    for (QString i_folder : QDir(QDir::currentPath() + "/base/themes").entryList(QDir::Dirs))
-    {
-        if (i_folder == "." || i_folder == "..")
-            continue;
-        w_theme->addItem(i_folder);
-    }
+  // themes
+  for (QString i_folder :
+       QDir(QDir::currentPath() + "/base/themes").entryList(QDir::Dirs))
+  {
+    if (i_folder == "." || i_folder == "..")
+      continue;
+    w_theme->addItem(i_folder);
+  }
 
-    // restore previous selection
-    w_theme->setCurrentText(p_prev_text);
+  // restore previous selection
+  w_theme->setCurrentText(p_prev_text);
 
-    // unblock
-    w_theme->blockSignals(false);
+  // unblock
+  w_theme->blockSignals(false);
 }
 
 void AOConfigPanel::refresh_theme_variant_list()
 {
-    const QString p_prev_text = w_theme_variant->currentText();
+  const QString p_prev_text = w_theme_variant->currentText();
 
-    // block signals
-    w_theme_variant->blockSignals(true);
-    w_theme_variant->clear();
+  // block signals
+  w_theme_variant->blockSignals(true);
+  w_theme_variant->clear();
 
-    // add empty entry indicating no variant chosen
-    w_theme_variant->addItem("", "");
-    // themes
-    for (QString i_folder : QDir(QDir::currentPath() + "/base/themes/" +
-                                 m_config->theme() + "/variants/").entryList(QDir::Dirs))
-    {
-        if (i_folder == "." || i_folder == "..")
-            continue;
-        w_theme_variant->addItem(i_folder, i_folder);
-    }
+  // add empty entry indicating no variant chosen
+  w_theme_variant->addItem("", "");
+  // themes
+  for (QString i_folder : QDir(QDir::currentPath() + "/base/themes/" +
+                               m_config->theme() + "/variants/")
+                              .entryList(QDir::Dirs))
+  {
+    if (i_folder == "." || i_folder == "..")
+      continue;
+    w_theme_variant->addItem(i_folder, i_folder);
+  }
 
-    // if the current theme does not have a variant folder for the current folder, add the variant
-    // to the combobox anyway. Selecting it will not do anything
-    if (w_theme_variant->findText(m_config->theme_variant()) == -1)
-      w_theme_variant->addItem(m_config->theme_variant(), m_config->theme_variant());
-    // restore previous selection
-    w_theme_variant->setCurrentText(p_prev_text);
+  // if the current theme does not have a variant folder for the current folder,
+  // add the variant to the combobox anyway. Selecting it will not do anything
+  if (w_theme_variant->findText(m_config->theme_variant()) == -1)
+    w_theme_variant->addItem(m_config->theme_variant(),
+                             m_config->theme_variant());
+  // restore previous selection
+  w_theme_variant->setCurrentText(p_prev_text);
 
-    // unblock
-    w_theme_variant->blockSignals(false);
+  // unblock
+  w_theme_variant->blockSignals(false);
 }
 
 void AOConfigPanel::on_reload_theme_clicked()
 {
-    qDebug() << "reload theme clicked";
-    emit reload_theme();
+  qDebug() << "reload theme clicked";
+  emit reload_theme();
 }
 
 void AOConfigPanel::on_effects_value_changed(int p_num)
 {
-    w_effects_value->setText(QString::number(p_num) + "%");
+  w_effects_value->setText(QString::number(p_num) + "%");
 }
 
 void AOConfigPanel::on_system_value_changed(int p_num)
 {
-    w_system_value->setText(QString::number(p_num) + "%");
+  w_system_value->setText(QString::number(p_num) + "%");
 }
 
 void AOConfigPanel::on_music_value_changed(int p_num)
 {
-    w_music_value->setText(QString::number(p_num) + "%");
+  w_music_value->setText(QString::number(p_num) + "%");
 }
 
 void AOConfigPanel::on_blips_value_changed(int p_num)
 {
-    w_blips_value->setText(QString::number(p_num) + "%");
+  w_blips_value->setText(QString::number(p_num) + "%");
 }
 
 void AOConfigPanel::on_config_reload_theme_requested()
 {
-    refresh_theme_list();
-    refresh_theme_variant_list();
+  refresh_theme_list();
+  refresh_theme_variant_list();
 }

--- a/aoconfigpanel.h
+++ b/aoconfigpanel.h
@@ -1,76 +1,76 @@
 #ifndef AOCONFIGPANEL_H
 #define AOCONFIGPANEL_H
 // qt
-#include <QWidget>
-#include <QLineEdit>
-#include <QComboBox>
-#include <QPushButton>
-#include <QSpinBox>
 #include <QCheckBox>
-#include <QSlider>
-#include <QTabWidget>
+#include <QComboBox>
 #include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSlider>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QWidget>
 // src
-#include "aoguiloader.h"
 #include "aoconfig.h"
+#include "aoguiloader.h"
 
 class AOConfigPanel : public QWidget
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    AOConfig *m_config = nullptr;
+  AOConfig *m_config = nullptr;
 
-    // general
-    QLineEdit *w_username = nullptr;
-    QLineEdit *w_callwords = nullptr;
-    QComboBox *w_theme = nullptr;
-    QPushButton *w_reload_theme = nullptr;
-    QComboBox *w_theme_variant = nullptr;
-    QCheckBox *w_always_pre = nullptr;
-    QSpinBox *w_chat_tick_interval = nullptr;
-    QCheckBox *w_server_alerts = nullptr;
+  // general
+  QLineEdit *w_username = nullptr;
+  QLineEdit *w_callwords = nullptr;
+  QComboBox *w_theme = nullptr;
+  QPushButton *w_reload_theme = nullptr;
+  QComboBox *w_theme_variant = nullptr;
+  QCheckBox *w_always_pre = nullptr;
+  QSpinBox *w_chat_tick_interval = nullptr;
+  QCheckBox *w_server_alerts = nullptr;
 
-    // IC Chatlog
-    QSpinBox *w_log_max_lines = nullptr;
-    QCheckBox *w_log_uses_newline = nullptr;
-    QCheckBox *w_log_goes_downward = nullptr;
-    QCheckBox *w_log_music = nullptr;
-    QCheckBox *w_log_is_recording = nullptr;
+  // IC Chatlog
+  QSpinBox *w_log_max_lines = nullptr;
+  QCheckBox *w_log_uses_newline = nullptr;
+  QCheckBox *w_log_goes_downward = nullptr;
+  QCheckBox *w_log_music = nullptr;
+  QCheckBox *w_log_is_recording = nullptr;
 
-    // audio
-    QSlider *w_effects = nullptr;
-    QLabel *w_effects_value = nullptr;
-    QSlider *w_system = nullptr;
-    QLabel *w_system_value = nullptr;
-    QSlider *w_music = nullptr;
-    QLabel *w_music_value = nullptr;
-    QSlider *w_blips = nullptr;
-    QLabel *w_blips_value = nullptr;
-    QSpinBox *w_blip_rate = nullptr;
-    QCheckBox *w_blank_blips = nullptr;
+  // audio
+  QSlider *w_effects = nullptr;
+  QLabel *w_effects_value = nullptr;
+  QSlider *w_system = nullptr;
+  QLabel *w_system_value = nullptr;
+  QSlider *w_music = nullptr;
+  QLabel *w_music_value = nullptr;
+  QSlider *w_blips = nullptr;
+  QLabel *w_blips_value = nullptr;
+  QSpinBox *w_blip_rate = nullptr;
+  QCheckBox *w_blank_blips = nullptr;
 
-    // save
-    QPushButton *w_save = nullptr;
+  // save
+  QPushButton *w_save = nullptr;
 
 public:
-    AOConfigPanel(QWidget *p_parent = nullptr);
+  AOConfigPanel(QWidget *p_parent = nullptr);
 
 public slots:
-    void on_config_reload_theme_requested();
+  void on_config_reload_theme_requested();
 
 signals:
-    void reload_theme();
+  void reload_theme();
 
 private:
-    void refresh_theme_list();
-    void refresh_theme_variant_list();
+  void refresh_theme_list();
+  void refresh_theme_variant_list();
 
 private slots:
-    void on_reload_theme_clicked();
-    void on_effects_value_changed(int p_num);
-    void on_system_value_changed(int p_num);
-    void on_music_value_changed(int p_num);
-    void on_blips_value_changed(int p_num);
+  void on_reload_theme_clicked();
+  void on_effects_value_changed(int p_num);
+  void on_system_value_changed(int p_num);
+  void on_music_value_changed(int p_num);
+  void on_blips_value_changed(int p_num);
 };
 
 #endif // AOCONFIGPANEL_H

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -3,7 +3,9 @@
 #include "file_functions.h"
 #include <QDebug>
 
-AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y) : QPushButton(p_parent)
+AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
+                             int p_x, int p_y)
+    : QPushButton(p_parent)
 {
   ao_app = p_ao_app;
 
@@ -16,9 +18,13 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x
 void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
 {
   QString emotion_number = QString::number(p_emote + 1);
-  QString image_path = ao_app->get_character_path(p_char) + "emotions/ao2/button" + emotion_number + suffix;
-  QString alt_path = ao_app->get_character_path(p_char) + "emotions/button" + emotion_number + suffix;
-  QString hover_path = ao_app->get_character_path(p_char) + "emotions/hovers/button" + emotion_number + "_hover" + suffix;
+  QString image_path = ao_app->get_character_path(p_char) +
+                       "emotions/ao2/button" + emotion_number + suffix;
+  QString alt_path = ao_app->get_character_path(p_char) + "emotions/button" +
+                     emotion_number + suffix;
+  QString hover_path = ao_app->get_character_path(p_char) +
+                       "emotions/hovers/button" + emotion_number + "_hover" +
+                       suffix;
 
   if (file_exists(image_path))
   {
@@ -28,12 +34,15 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
   else if (file_exists(alt_path))
   {
     this->setText("");
-    if(file_exists(hover_path))
+    if (file_exists(hover_path))
     {
-      this->setStyleSheet("QPushButton {border-image:url(\"" + alt_path + "\");}"
-            "QPushButton:hover {border-image:url(\"" + hover_path + "\");}");
+      this->setStyleSheet("QPushButton {border-image:url(\"" + alt_path +
+                          "\");}"
+                          "QPushButton:hover {border-image:url(\"" +
+                          hover_path + "\");}");
     }
-    else this->setStyleSheet("border-image:url(\"" + alt_path + "\")");
+    else
+      this->setStyleSheet("border-image:url(\"" + alt_path + "\")");
   }
   else
   {

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -50,4 +50,7 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
   }
 }
 
-void AOEmoteButton::on_clicked() { emote_clicked(m_id); }
+void AOEmoteButton::on_clicked()
+{
+  emote_clicked(m_id);
+}

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -5,8 +5,7 @@
 
 AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
                              int p_x, int p_y)
-    : QPushButton(p_parent)
-{
+    : QPushButton(p_parent) {
   ao_app = p_ao_app;
 
   this->move(p_x, p_y);
@@ -15,43 +14,31 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
   connect(this, SIGNAL(clicked()), this, SLOT(on_clicked()));
 }
 
-void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
-{
+void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix) {
   QString emotion_number = QString::number(p_emote + 1);
-  QString image_path = ao_app->get_character_path(p_char) +
-                       "emotions/ao2/button" + emotion_number + suffix;
-  QString alt_path = ao_app->get_character_path(p_char) + "emotions/button" +
-                     emotion_number + suffix;
-  QString hover_path = ao_app->get_character_path(p_char) +
-                       "emotions/hovers/button" + emotion_number + "_hover" +
-                       suffix;
+  QString image_path = ao_app->get_character_path(
+      p_char, "emotions/ao2/button" + emotion_number + suffix);
+  QString alt_path = ao_app->get_character_path(
+      p_char, "emotions/button" + emotion_number + suffix);
+  QString hover_path = ao_app->get_character_path(
+      p_char, "emotions/hovers/button" + emotion_number + "_hover" + suffix);
 
-  if (file_exists(image_path))
-  {
+  if (file_exists(image_path)) {
     this->setText("");
     this->setStyleSheet("border-image:url(\"" + image_path + "\")");
-  }
-  else if (file_exists(alt_path))
-  {
+  } else if (file_exists(alt_path)) {
     this->setText("");
-    if (file_exists(hover_path))
-    {
+    if (file_exists(hover_path)) {
       this->setStyleSheet("QPushButton {border-image:url(\"" + alt_path +
                           "\");}"
                           "QPushButton:hover {border-image:url(\"" +
                           hover_path + "\");}");
-    }
-    else
+    } else
       this->setStyleSheet("border-image:url(\"" + alt_path + "\")");
-  }
-  else
-  {
+  } else {
     this->setText(ao_app->get_emote_comment(p_char, p_emote));
     this->setStyleSheet("border-image:url(\"\")");
   }
 }
 
-void AOEmoteButton::on_clicked()
-{
-  emote_clicked(m_id);
-}
+void AOEmoteButton::on_clicked() { emote_clicked(m_id); }

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -5,7 +5,8 @@
 
 AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
                              int p_x, int p_y)
-    : QPushButton(p_parent) {
+    : QPushButton(p_parent)
+{
   ao_app = p_ao_app;
 
   this->move(p_x, p_y);
@@ -14,7 +15,8 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
   connect(this, SIGNAL(clicked()), this, SLOT(on_clicked()));
 }
 
-void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix) {
+void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
+{
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path = ao_app->get_character_path(
       p_char, "emotions/ao2/button" + emotion_number + suffix);
@@ -23,19 +25,26 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix) {
   QString hover_path = ao_app->get_character_path(
       p_char, "emotions/hovers/button" + emotion_number + "_hover" + suffix);
 
-  if (file_exists(image_path)) {
+  if (file_exists(image_path))
+  {
     this->setText("");
     this->setStyleSheet("border-image:url(\"" + image_path + "\")");
-  } else if (file_exists(alt_path)) {
+  }
+  else if (file_exists(alt_path))
+  {
     this->setText("");
-    if (file_exists(hover_path)) {
+    if (file_exists(hover_path))
+    {
       this->setStyleSheet("QPushButton {border-image:url(\"" + alt_path +
                           "\");}"
                           "QPushButton:hover {border-image:url(\"" +
                           hover_path + "\");}");
-    } else
+    }
+    else
       this->setStyleSheet("border-image:url(\"" + alt_path + "\")");
-  } else {
+  }
+  else
+  {
     this->setText(ao_app->get_emote_comment(p_char, p_emote));
     this->setStyleSheet("border-image:url(\"\")");
   }

--- a/aoemotebutton.h
+++ b/aoemotebutton.h
@@ -14,8 +14,14 @@ public:
 
   void set_image(QString p_char, int p_emote, QString suffix);
 
-  void set_id(int p_id) { m_id = p_id; }
-  int get_id() { return m_id; }
+  void set_id(int p_id)
+  {
+    m_id = p_id;
+  }
+  int get_id()
+  {
+    return m_id;
+  }
 
 private:
   AOApplication *ao_app = nullptr;

--- a/aoemotebutton.h
+++ b/aoemotebutton.h
@@ -14,8 +14,14 @@ public:
 
   void set_image(QString p_char, int p_emote, QString suffix);
 
-  void set_id(int p_id) {m_id = p_id;}
-  int get_id() {return m_id;}
+  void set_id(int p_id)
+  {
+    m_id = p_id;
+  }
+  int get_id()
+  {
+    return m_id;
+  }
 
 private:
   AOApplication *ao_app = nullptr;

--- a/aoemotebutton.h
+++ b/aoemotebutton.h
@@ -14,14 +14,8 @@ public:
 
   void set_image(QString p_char, int p_emote, QString suffix);
 
-  void set_id(int p_id)
-  {
-    m_id = p_id;
-  }
-  int get_id()
-  {
-    return m_id;
-  }
+  void set_id(int p_id) { m_id = p_id; }
+  int get_id() { return m_id; }
 
 private:
   AOApplication *ao_app = nullptr;

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -4,7 +4,9 @@
 
 #include <QDebug>
 
-AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y) : QPushButton(p_parent)
+AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app,
+                                   int p_x, int p_y)
+    : QPushButton(p_parent)
 {
   ao_app = p_ao_app;
 
@@ -79,19 +81,19 @@ void AOEvidenceButton::mouseDoubleClickEvent(QMouseEvent *e)
 
 void AOEvidenceButton::dragLeaveEvent(QMouseEvent *e)
 {
-  //QWidget::dragLeaveEvent(e);
+  // QWidget::dragLeaveEvent(e);
 
   qDebug() << "drag leave event";
 }
 
 void AOEvidenceButton::dragEnterEvent(QMouseEvent *e)
 {
-  //QWidget::dragEnterEvent(e);
+  // QWidget::dragEnterEvent(e);
 
   qDebug() << "drag enter event";
 }
 
-void AOEvidenceButton::enterEvent(QEvent * e)
+void AOEvidenceButton::enterEvent(QEvent *e)
 {
   ui_selector->show();
 
@@ -101,7 +103,7 @@ void AOEvidenceButton::enterEvent(QEvent * e)
   QPushButton::enterEvent(e);
 }
 
-void AOEvidenceButton::leaveEvent(QEvent * e)
+void AOEvidenceButton::leaveEvent(QEvent *e)
 {
   ui_selector->hide();
 

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -39,7 +39,7 @@ void AOEvidenceButton::reset()
 
 void AOEvidenceButton::set_image(QString p_image)
 {
-  QString image_path = ao_app->get_evidence_path() + p_image;
+  QString image_path = ao_app->get_evidence_path(p_image);
 
   if (file_exists(image_path))
   {

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -68,7 +68,10 @@ void AOEvidenceButton::set_selected(bool p_selected)
     ui_selected->hide();
 }
 
-void AOEvidenceButton::on_clicked() { evidence_clicked(m_id); }
+void AOEvidenceButton::on_clicked()
+{
+  evidence_clicked(m_id);
+}
 
 void AOEvidenceButton::mouseDoubleClickEvent(QMouseEvent *e)
 {

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -68,10 +68,7 @@ void AOEvidenceButton::set_selected(bool p_selected)
     ui_selected->hide();
 }
 
-void AOEvidenceButton::on_clicked()
-{
-  evidence_clicked(m_id);
-}
+void AOEvidenceButton::on_clicked() { evidence_clicked(m_id); }
 
 void AOEvidenceButton::mouseDoubleClickEvent(QMouseEvent *e)
 {

--- a/aoevidencebutton.h
+++ b/aoevidencebutton.h
@@ -18,7 +18,10 @@ public:
   void reset();
   void set_image(QString p_image);
   void set_theme_image(QString p_image);
-  void set_id(int p_id) { m_id = p_id; }
+  void set_id(int p_id)
+  {
+    m_id = p_id;
+  }
 
   void set_selected(bool p_selected);
 

--- a/aoevidencebutton.h
+++ b/aoevidencebutton.h
@@ -12,12 +12,16 @@ class AOEvidenceButton : public QPushButton
   Q_OBJECT
 
 public:
-  AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y);
+  AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x,
+                   int p_y);
 
   void reset();
   void set_image(QString p_image);
   void set_theme_image(QString p_image);
-  void set_id(int p_id) {m_id = p_id;}
+  void set_id(int p_id)
+  {
+    m_id = p_id;
+  }
 
   void set_selected(bool p_selected);
 

--- a/aoevidencebutton.h
+++ b/aoevidencebutton.h
@@ -18,10 +18,7 @@ public:
   void reset();
   void set_image(QString p_image);
   void set_theme_image(QString p_image);
-  void set_id(int p_id)
-  {
-    m_id = p_id;
-  }
+  void set_id(int p_id) { m_id = p_id; }
 
   void set_selected(bool p_selected);
 

--- a/aoevidencedescription.cpp
+++ b/aoevidencedescription.cpp
@@ -1,10 +1,11 @@
 #include "aoevidencedescription.h"
 
-AOEvidenceDescription::AOEvidenceDescription(QWidget *parent) : QPlainTextEdit(parent)
+AOEvidenceDescription::AOEvidenceDescription(QWidget *parent)
+    : QPlainTextEdit(parent)
 {
   this->setReadOnly(true);
 
-  //connect(this, SIGNAL(returnPressed()), this, SLOT(on_enter_pressed()));
+  // connect(this, SIGNAL(returnPressed()), this, SLOT(on_enter_pressed()));
 }
 
 void AOEvidenceDescription::mouseDoubleClickEvent(QMouseEvent *e)
@@ -18,4 +19,3 @@ void AOEvidenceDescription::on_enter_pressed()
 {
   this->setReadOnly(true);
 }
-

--- a/aoevidencedescription.cpp
+++ b/aoevidencedescription.cpp
@@ -15,4 +15,7 @@ void AOEvidenceDescription::mouseDoubleClickEvent(QMouseEvent *e)
   this->setReadOnly(false);
 }
 
-void AOEvidenceDescription::on_enter_pressed() { this->setReadOnly(true); }
+void AOEvidenceDescription::on_enter_pressed()
+{
+  this->setReadOnly(true);
+}

--- a/aoevidencedescription.cpp
+++ b/aoevidencedescription.cpp
@@ -15,7 +15,4 @@ void AOEvidenceDescription::mouseDoubleClickEvent(QMouseEvent *e)
   this->setReadOnly(false);
 }
 
-void AOEvidenceDescription::on_enter_pressed()
-{
-  this->setReadOnly(true);
-}
+void AOEvidenceDescription::on_enter_pressed() { this->setReadOnly(true); }

--- a/aoevidencedescription.h
+++ b/aoevidencedescription.h
@@ -17,7 +17,6 @@ signals:
 
 private slots:
   void on_enter_pressed();
-
 };
 
 #endif // AOEVIDENCEDESCRIPTION_H

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -83,4 +83,7 @@ void AOEvidenceDisplay::reset()
   this->clear();
 }
 
-QLabel *AOEvidenceDisplay::get_evidence_icon() { return evidence_icon; }
+QLabel *AOEvidenceDisplay::get_evidence_icon()
+{
+  return evidence_icon;
+}

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -2,11 +2,12 @@
 
 #include "aoevidencedisplay.h"
 
-#include "file_functions.h"
 #include "datatypes.h"
+#include "file_functions.h"
 #include "misc_functions.h"
 
-AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
+    : QLabel(p_parent)
 {
   ao_app = p_ao_app;
 
@@ -14,10 +15,12 @@ AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
   evidence_icon = new QLabel(this);
   sfx_player = new AOSfxPlayer(this, ao_app);
 
-  connect(evidence_movie, SIGNAL(frameChanged(int)), this, SLOT(frame_change(int)));
+  connect(evidence_movie, SIGNAL(frameChanged(int)), this,
+          SLOT(frame_change(int)));
 }
 
-void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_side)
+void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
+                                      bool is_left_side)
 {
   this->reset();
 
@@ -40,7 +43,8 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
     gif_name = "evidence_appear_right.gif";
   }
 
-  pos_size_type icon_dimensions = ao_app->get_element_dimensions(icon_identifier, "courtroom_design.ini");
+  pos_size_type icon_dimensions =
+      ao_app->get_element_dimensions(icon_identifier, "courtroom_design.ini");
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
@@ -48,7 +52,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
 
   QString f_path = ao_app->get_image_path(gif_name);
   evidence_movie->setFileName(f_path);
-  if(evidence_movie->frameCount() < 1)
+  if (evidence_movie->frameCount() < 1)
     return;
 
   this->setMovie(evidence_movie);
@@ -61,7 +65,7 @@ void AOEvidenceDisplay::frame_change(int p_frame)
 {
   if (p_frame == (evidence_movie->frameCount() - 1))
   {
-    //we need this or else the last frame wont show
+    // we need this or else the last frame wont show
     delay(evidence_movie->nextFrameDelay());
 
     evidence_movie->stop();
@@ -79,9 +83,7 @@ void AOEvidenceDisplay::reset()
   this->clear();
 }
 
-QLabel* AOEvidenceDisplay::get_evidence_icon()
+QLabel *AOEvidenceDisplay::get_evidence_icon()
 {
   return evidence_icon;
 }
-
-

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -7,8 +7,7 @@
 #include "misc_functions.h"
 
 AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
-    : QLabel(p_parent)
-{
+    : QLabel(p_parent) {
   ao_app = p_ao_app;
 
   evidence_movie = new QMovie(this);
@@ -20,11 +19,10 @@ AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
 }
 
 void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
-                                      bool is_left_side)
-{
+                                      bool is_left_side) {
   this->reset();
 
-  QString f_evidence_path = ao_app->get_evidence_path() + p_evidence_image;
+  QString f_evidence_path = ao_app->get_evidence_path(p_evidence_image);
 
   AOPixmap f_pixmap(f_evidence_path);
 
@@ -32,13 +30,10 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
   QString gif_name;
   QString icon_identifier;
 
-  if (is_left_side)
-  {
+  if (is_left_side) {
     icon_identifier = "left_evidence_icon";
     gif_name = "evidence_appear_left.gif";
-  }
-  else
-  {
+  } else {
     icon_identifier = "right_evidence_icon";
     gif_name = "evidence_appear_right.gif";
   }
@@ -61,10 +56,8 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
   sfx_player->play(ao_app->get_sfx("evidence_present"));
 }
 
-void AOEvidenceDisplay::frame_change(int p_frame)
-{
-  if (p_frame == (evidence_movie->frameCount() - 1))
-  {
+void AOEvidenceDisplay::frame_change(int p_frame) {
+  if (p_frame == (evidence_movie->frameCount() - 1)) {
     // we need this or else the last frame wont show
     delay(evidence_movie->nextFrameDelay());
 
@@ -75,15 +68,11 @@ void AOEvidenceDisplay::frame_change(int p_frame)
   }
 }
 
-void AOEvidenceDisplay::reset()
-{
+void AOEvidenceDisplay::reset() {
   sfx_player->stop();
   evidence_movie->stop();
   evidence_icon->hide();
   this->clear();
 }
 
-QLabel *AOEvidenceDisplay::get_evidence_icon()
-{
-  return evidence_icon;
-}
+QLabel *AOEvidenceDisplay::get_evidence_icon() { return evidence_icon; }

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -7,7 +7,8 @@
 #include "misc_functions.h"
 
 AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
-    : QLabel(p_parent) {
+    : QLabel(p_parent)
+{
   ao_app = p_ao_app;
 
   evidence_movie = new QMovie(this);
@@ -19,7 +20,8 @@ AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
 }
 
 void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
-                                      bool is_left_side) {
+                                      bool is_left_side)
+{
   this->reset();
 
   QString f_evidence_path = ao_app->get_evidence_path(p_evidence_image);
@@ -30,10 +32,13 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
   QString gif_name;
   QString icon_identifier;
 
-  if (is_left_side) {
+  if (is_left_side)
+  {
     icon_identifier = "left_evidence_icon";
     gif_name = "evidence_appear_left.gif";
-  } else {
+  }
+  else
+  {
     icon_identifier = "right_evidence_icon";
     gif_name = "evidence_appear_right.gif";
   }
@@ -56,8 +61,10 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
   sfx_player->play(ao_app->get_sfx("evidence_present"));
 }
 
-void AOEvidenceDisplay::frame_change(int p_frame) {
-  if (p_frame == (evidence_movie->frameCount() - 1)) {
+void AOEvidenceDisplay::frame_change(int p_frame)
+{
+  if (p_frame == (evidence_movie->frameCount() - 1))
+  {
     // we need this or else the last frame wont show
     delay(evidence_movie->nextFrameDelay());
 
@@ -68,7 +75,8 @@ void AOEvidenceDisplay::frame_change(int p_frame) {
   }
 }
 
-void AOEvidenceDisplay::reset() {
+void AOEvidenceDisplay::reset()
+{
   sfx_player->stop();
   evidence_movie->stop();
   evidence_icon->hide();

--- a/aoevidencedisplay.h
+++ b/aoevidencedisplay.h
@@ -5,8 +5,8 @@
 #include <QMovie>
 
 #include "aoapplication.h"
-#include "aosfxplayer.h"
 #include "aopixmap.h"
+#include "aosfxplayer.h"
 
 class AOEvidenceDisplay : public QLabel
 {
@@ -16,7 +16,7 @@ public:
   AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app);
 
   void show_evidence(QString p_evidence_image, bool is_left_side);
-  QLabel* get_evidence_icon();
+  QLabel *get_evidence_icon();
   void reset();
 
 private:

--- a/aoexception.cpp
+++ b/aoexception.cpp
@@ -1,6 +1,8 @@
 #include "aoexception.h"
 
-AOException::AOException(QString p_msg) : m_msg(p_msg) {}
+AOException::AOException(QString p_msg) : m_msg(p_msg)
+{
+}
 
 const char *AOException::what() const noexcept
 {

--- a/aoexception.cpp
+++ b/aoexception.cpp
@@ -1,10 +1,10 @@
 #include "aoexception.h"
 
-AOException::AOException(QString p_msg)
-    : m_msg(p_msg)
-{}
+AOException::AOException(QString p_msg) : m_msg(p_msg)
+{
+}
 
 const char *AOException::what() const noexcept
 {
-    return m_msg.toStdString().c_str();
+  return m_msg.toStdString().c_str();
 }

--- a/aoexception.cpp
+++ b/aoexception.cpp
@@ -1,8 +1,6 @@
 #include "aoexception.h"
 
-AOException::AOException(QString p_msg) : m_msg(p_msg)
-{
-}
+AOException::AOException(QString p_msg) : m_msg(p_msg) {}
 
 const char *AOException::what() const noexcept
 {

--- a/aoexception.h
+++ b/aoexception.h
@@ -8,14 +8,14 @@
 class AOException : public std::exception
 {
 public:
-    AOException() = default;
-    AOException(QString p_msg);
-    virtual ~AOException() noexcept = default;
+  AOException() = default;
+  AOException(QString p_msg);
+  virtual ~AOException() noexcept = default;
 
-    virtual const char *what() const noexcept;
+  virtual const char *what() const noexcept;
 
 private:
-    QString m_msg;
+  QString m_msg;
 };
 
 #endif // AOEXCEPTION_HPP

--- a/aoguiloader.cpp
+++ b/aoguiloader.cpp
@@ -5,26 +5,26 @@
 
 AOGuiLoader::AOGuiLoader(QObject *p_parent) : QUiLoader(p_parent)
 {
-    // padding
+  // padding
 }
 
 QWidget *AOGuiLoader::load_from_file(QString p_file_path, QWidget *p_parent)
 {
-    QWidget *r_widget = nullptr;
+  QWidget *r_widget = nullptr;
 
-    QFile f_file(p_file_path);
-    if (f_file.open(QIODevice::ReadOnly))
+  QFile f_file(p_file_path);
+  if (f_file.open(QIODevice::ReadOnly))
+  {
+    r_widget = load(&f_file, p_parent);
+
+    // lazily replace the parent's layout with our own
+    if (p_parent != nullptr)
     {
-        r_widget = load(&f_file, p_parent);
-
-        // lazily replace the parent's layout with our own
-        if (p_parent != nullptr)
-        {
-            QVBoxLayout *f_parent_layout = new QVBoxLayout(p_parent);
-            f_parent_layout->addWidget(r_widget);
-            p_parent->setLayout(f_parent_layout);
-        }
+      QVBoxLayout *f_parent_layout = new QVBoxLayout(p_parent);
+      f_parent_layout->addWidget(r_widget);
+      p_parent->setLayout(f_parent_layout);
     }
+  }
 
-    return r_widget;
+  return r_widget;
 }

--- a/aoguiloader.h
+++ b/aoguiloader.h
@@ -5,17 +5,16 @@
 #include <QWidget>
 
 // we could make a smarter system but let's keep it simple ;)
-#define AO_GUI_WIDGET(p_type, p_name) \
-    findChild<p_type *>(p_name)
+#define AO_GUI_WIDGET(p_type, p_name) findChild<p_type *>(p_name)
 
 class AOGuiLoader : public QUiLoader
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOGuiLoader(QObject *p_parent = nullptr);
+  AOGuiLoader(QObject *p_parent = nullptr);
 
-    QWidget *load_from_file(QString p_file_path, QWidget *p_parent = nullptr);
+  QWidget *load_from_file(QString p_file_path, QWidget *p_parent = nullptr);
 };
 
 #endif

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -4,13 +4,11 @@
 
 #include <QDebug>
 
-AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
-{
+AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent) {
   ao_app = p_ao_app;
 }
 
-void AOImage::set_image(QString p_image)
-{
+void AOImage::set_image(QString p_image) {
   QString f_path = ao_app->get_image_path(p_image);
   AOPixmap f_pixmap(f_path);
   this->setPixmap(f_pixmap.scale_to_size(size()));
@@ -22,9 +20,8 @@ void AOImage::set_image(QString p_image)
     image_path = "";
 }
 
-void AOImage::set_image_from_path(QString p_path)
-{
-  QString default_path = ao_app->get_default_theme_path() + "chatmed.png";
+void AOImage::set_image_from_path(QString p_path) {
+  QString default_path = ao_app->get_default_theme_path("chatmed.png");
 
   QString final_path;
 

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -4,11 +4,13 @@
 
 #include <QDebug>
 
-AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent) {
+AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
+{
   ao_app = p_ao_app;
 }
 
-void AOImage::set_image(QString p_image) {
+void AOImage::set_image(QString p_image)
+{
   QString f_path = ao_app->get_image_path(p_image);
   AOPixmap f_pixmap(f_path);
   this->setPixmap(f_pixmap.scale_to_size(size()));
@@ -20,7 +22,8 @@ void AOImage::set_image(QString p_image) {
     image_path = "";
 }
 
-void AOImage::set_image_from_path(QString p_path) {
+void AOImage::set_image_from_path(QString p_path)
+{
   QString default_path = ao_app->get_default_theme_path("chatmed.png");
 
   QString final_path;

--- a/aoimage.h
+++ b/aoimage.h
@@ -1,4 +1,4 @@
-//This class represents a static theme-dependent image
+// This class represents a static theme-dependent image
 
 #ifndef AOIMAGE_H
 #define AOIMAGE_H

--- a/aolabel.h
+++ b/aolabel.h
@@ -5,7 +5,6 @@
 
 #include <QLabel>
 
-
 class AOLabel : public QLabel
 {
 public:

--- a/aolineedit.cpp
+++ b/aolineedit.cpp
@@ -15,7 +15,4 @@ void AOLineEdit::mouseDoubleClickEvent(QMouseEvent *e)
   this->setReadOnly(false);
 }
 
-void AOLineEdit::on_enter_pressed()
-{
-  this->setReadOnly(true);
-}
+void AOLineEdit::on_enter_pressed() { this->setReadOnly(true); }

--- a/aolineedit.cpp
+++ b/aolineedit.cpp
@@ -15,4 +15,7 @@ void AOLineEdit::mouseDoubleClickEvent(QMouseEvent *e)
   this->setReadOnly(false);
 }
 
-void AOLineEdit::on_enter_pressed() { this->setReadOnly(true); }
+void AOLineEdit::on_enter_pressed()
+{
+  this->setReadOnly(true);
+}

--- a/aolineedit.h
+++ b/aolineedit.h
@@ -19,8 +19,6 @@ signals:
 
 private slots:
   void on_enter_pressed();
-
-
 };
 
 #endif // AOLINEEDIT_H

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -1,7 +1,7 @@
 #include "aomovie.h"
 
-#include "file_functions.h"
 #include "courtroom.h"
+#include "file_functions.h"
 #include "misc_functions.h"
 
 AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
@@ -32,8 +32,8 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
   QString file_path = "";
 
   // Remove ! at the beginning of p_file if needed
-  // This is an indicator that the file is not selectable in the current theme (variant) but
-  // is still usable by other people
+  // This is an indicator that the file is not selectable in the current theme
+  // (variant) but is still usable by other people
   if (p_file.length() > 0 && p_file.at(0) == "!")
     p_file = p_file.remove(0, 1);
 
@@ -43,19 +43,18 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
   else
     custom_path = ao_app->get_character_path(p_char) + p_file + "_bubble";
 
-  QStringList f_paths{
-    custom_path,
-    ao_app->get_character_path(p_char) + "overlay/" + p_file,
-    ao_app->get_base_path() + "themes/" + p_custom_theme + "/" + p_file,
-    ao_app->get_theme_variant_path() + p_file,
-    ao_app->get_theme_path() + p_file,
-    ao_app->get_default_theme_path() + p_file,
-    ao_app->get_theme_variant_path() + "placeholder",
-    ao_app->get_theme_path() + "placeholder",
-    ao_app->get_default_theme_path() + "placeholder"
-  };
+  QStringList f_paths{custom_path,
+                      ao_app->get_character_path(p_char) + "overlay/" + p_file,
+                      ao_app->get_base_path() + "themes/" + p_custom_theme +
+                          "/" + p_file,
+                      ao_app->get_theme_variant_path() + p_file,
+                      ao_app->get_theme_path() + p_file,
+                      ao_app->get_default_theme_path() + p_file,
+                      ao_app->get_theme_variant_path() + "placeholder",
+                      ao_app->get_theme_path() + "placeholder",
+                      ao_app->get_default_theme_path() + "placeholder"};
 
-  for(auto &f_file : f_paths)
+  for (auto &f_file : f_paths)
   {
     bool found = false;
     for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"})
@@ -91,12 +90,12 @@ void AOMovie::frame_change(int n_frame)
 {
   if (n_frame == (m_movie->frameCount() - 1) && play_once)
   {
-    //we need this or else the last frame wont show
+    // we need this or else the last frame wont show
     delay(m_movie->nextFrameDelay());
 
     this->stop();
 
-    //signal connected to courtroom object, let it figure out what to do
+    // signal connected to courtroom object, let it figure out what to do
     emit done();
   }
 }

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -15,9 +15,15 @@ AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
   connect(m_movie, SIGNAL(frameChanged(int)), this, SLOT(frame_change(int)));
 }
 
-AOMovie::~AOMovie() { delete m_movie; }
+AOMovie::~AOMovie()
+{
+  delete m_movie;
+}
 
-void AOMovie::set_play_once(bool p_play_once) { play_once = p_play_once; }
+void AOMovie::set_play_once(bool p_play_once)
+{
+  play_once = p_play_once;
+}
 
 void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
 {

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -4,8 +4,8 @@
 #include "file_functions.h"
 #include "misc_functions.h"
 
-AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
-{
+AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app)
+    : QLabel(p_parent) {
   ao_app = p_ao_app;
 
   m_movie = new QMovie();
@@ -15,18 +15,11 @@ AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
   connect(m_movie, SIGNAL(frameChanged(int)), this, SLOT(frame_change(int)));
 }
 
-AOMovie::~AOMovie()
-{
-  delete m_movie;
-}
+AOMovie::~AOMovie() { delete m_movie; }
 
-void AOMovie::set_play_once(bool p_play_once)
-{
-  play_once = p_play_once;
-}
+void AOMovie::set_play_once(bool p_play_once) { play_once = p_play_once; }
 
-void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
-{
+void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme) {
   m_movie->stop();
   QVector<QString> f_vec;
   QString file_path = "";
@@ -39,30 +32,28 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
 
   QString custom_path;
   if (p_file == "custom")
-    custom_path = ao_app->get_character_path(p_char) + p_file;
+    custom_path = ao_app->get_character_path(p_char, p_file);
   else
-    custom_path = ao_app->get_character_path(p_char) + p_file + "_bubble";
+    custom_path = ao_app->get_character_path(p_char, p_file + "_bubble");
 
-  QStringList f_paths{custom_path,
-                      ao_app->get_character_path(p_char) + "overlay/" + p_file,
-                      ao_app->get_base_path() + "themes/" + p_custom_theme +
-                          "/" + p_file,
-                      ao_app->get_theme_variant_path() + p_file,
-                      ao_app->get_theme_path() + p_file,
-                      ao_app->get_default_theme_path() + p_file,
-                      ao_app->get_theme_variant_path() + "placeholder",
-                      ao_app->get_theme_path() + "placeholder",
-                      ao_app->get_default_theme_path() + "placeholder"};
+  QStringList f_paths{
+      custom_path,
+      ao_app->get_character_path(p_char, "overlay/" + p_file),
+      ao_app->get_case_sensitive_path(ao_app->get_base_path() + "themes/" +
+                                      p_custom_theme + "/" + p_file),
+      ao_app->get_theme_variant_path(p_file),
+      ao_app->get_theme_path(p_file),
+      ao_app->get_default_theme_path(p_file),
+      ao_app->get_theme_variant_path("placeholder"),
+      ao_app->get_theme_path("placeholder"),
+      ao_app->get_default_theme_path("placeholder")};
 
-  for (auto &f_file : f_paths)
-  {
+  for (auto &f_file : f_paths) {
     bool found = false;
-    for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"})
-    {
+    for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"}) {
       QString fullPath = f_file + ext;
       found = file_exists(fullPath);
-      if (found)
-      {
+      if (found) {
         file_path = fullPath;
         break;
       }
@@ -80,16 +71,13 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
   m_movie->start();
 }
 
-void AOMovie::stop()
-{
+void AOMovie::stop() {
   m_movie->stop();
   this->hide();
 }
 
-void AOMovie::frame_change(int n_frame)
-{
-  if (n_frame == (m_movie->frameCount() - 1) && play_once)
-  {
+void AOMovie::frame_change(int n_frame) {
+  if (n_frame == (m_movie->frameCount() - 1) && play_once) {
     // we need this or else the last frame wont show
     delay(m_movie->nextFrameDelay());
 
@@ -100,8 +88,7 @@ void AOMovie::frame_change(int n_frame)
   }
 }
 
-void AOMovie::combo_resize(int w, int h)
-{
+void AOMovie::combo_resize(int w, int h) {
   QSize f_size(w, h);
   this->resize(f_size);
   m_movie->setScaledSize(f_size);

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -4,8 +4,8 @@
 #include "file_functions.h"
 #include "misc_functions.h"
 
-AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app)
-    : QLabel(p_parent) {
+AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+{
   ao_app = p_ao_app;
 
   m_movie = new QMovie();
@@ -19,7 +19,8 @@ AOMovie::~AOMovie() { delete m_movie; }
 
 void AOMovie::set_play_once(bool p_play_once) { play_once = p_play_once; }
 
-void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme) {
+void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
+{
   m_movie->stop();
   QVector<QString> f_vec;
   QString file_path = "";
@@ -48,12 +49,15 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme) {
       ao_app->get_theme_path("placeholder"),
       ao_app->get_default_theme_path("placeholder")};
 
-  for (auto &f_file : f_paths) {
+  for (auto &f_file : f_paths)
+  {
     bool found = false;
-    for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"}) {
+    for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"})
+    {
       QString fullPath = f_file + ext;
       found = file_exists(fullPath);
-      if (found) {
+      if (found)
+      {
         file_path = fullPath;
         break;
       }
@@ -71,13 +75,16 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme) {
   m_movie->start();
 }
 
-void AOMovie::stop() {
+void AOMovie::stop()
+{
   m_movie->stop();
   this->hide();
 }
 
-void AOMovie::frame_change(int n_frame) {
-  if (n_frame == (m_movie->frameCount() - 1) && play_once) {
+void AOMovie::frame_change(int n_frame)
+{
+  if (n_frame == (m_movie->frameCount() - 1) && play_once)
+  {
     // we need this or else the last frame wont show
     delay(m_movie->nextFrameDelay());
 
@@ -88,7 +95,8 @@ void AOMovie::frame_change(int n_frame) {
   }
 }
 
-void AOMovie::combo_resize(int w, int h) {
+void AOMovie::combo_resize(int w, int h)
+{
   QSize f_size(w, h);
   this->resize(f_size);
   m_movie->setScaledSize(f_size);

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -38,4 +38,7 @@ void AOMusicPlayer::play(QString p_file)
   }
 }
 
-void AOMusicPlayer::stop() { emit stopping(); }
+void AOMusicPlayer::stop()
+{
+  emit stopping();
+}

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -6,34 +6,39 @@
 
 AOMusicPlayer::AOMusicPlayer(QObject *p_parent, AOApplication *p_ao_app)
     : AOAbstractPlayer(p_parent, p_ao_app)
-{}
+{
+}
 
 void AOMusicPlayer::play(QString p_file)
 {
-    QString f_file = ao_app->get_music_path(p_file);
+  QString f_file = ao_app->get_music_path(p_file);
 
-    stop();
+  stop();
 
-    m_file = f_file;
+  m_file = f_file;
 
-    try { // create new song
-        AOBassHandle *handle = new AOBassHandle(m_file, false, this);
-        connect(this, &AOMusicPlayer::new_volume, handle, &AOBassHandle::set_volume);
-        connect(this, &AOMusicPlayer::stopping, handle, &AOBassHandle::stop);
+  try
+  { // create new song
+    AOBassHandle *handle = new AOBassHandle(m_file, false, this);
+    connect(this, &AOMusicPlayer::new_volume, handle,
+            &AOBassHandle::set_volume);
+    connect(this, &AOMusicPlayer::stopping, handle, &AOBassHandle::stop);
 
-        // delete previous
-        if (m_handle)
-            delete m_handle;
+    // delete previous
+    if (m_handle)
+      delete m_handle;
 
-        m_handle = handle;
-        m_handle->set_volume(get_volume());
-        m_handle->play();
-    } catch(const std::exception &e_exception) {
-        qDebug() << e_exception.what();
-    }
+    m_handle = handle;
+    m_handle->set_volume(get_volume());
+    m_handle->play();
+  }
+  catch (const std::exception &e_exception)
+  {
+    qDebug() << e_exception.what();
+  }
 }
 
 void AOMusicPlayer::stop()
 {
-    emit stopping();
+  emit stopping();
 }

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -38,7 +38,4 @@ void AOMusicPlayer::play(QString p_file)
   }
 }
 
-void AOMusicPlayer::stop()
-{
-  emit stopping();
-}
+void AOMusicPlayer::stop() { emit stopping(); }

--- a/aomusicplayer.h
+++ b/aomusicplayer.h
@@ -5,17 +5,17 @@
 
 class AOMusicPlayer : public AOAbstractPlayer
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOMusicPlayer(QObject *p_parent, AOApplication *p_ao_app);
+  AOMusicPlayer(QObject *p_parent, AOApplication *p_ao_app);
 
-    void play(QString p_file);
-    void stop();
+  void play(QString p_file);
+  void stop();
 
 private:
-    AOBassHandle* m_handle = nullptr;
-    QString       m_file;
+  AOBassHandle *m_handle = nullptr;
+  QString m_file;
 };
 
 #endif // AOMUSICPLAYER_H

--- a/aonotearea.cpp
+++ b/aonotearea.cpp
@@ -1,18 +1,19 @@
-#include "aonotepicker.h"
 #include "aonotearea.h"
+#include "aonotepicker.h"
 
 #include "courtroom.h"
 
 #include <QDebug>
 
-AONoteArea::AONoteArea(QWidget *p_parent, AOApplication *p_ao_app) : AOImage(p_parent, p_ao_app)
+AONoteArea::AONoteArea(QWidget *p_parent, AOApplication *p_ao_app)
+    : AOImage(p_parent, p_ao_app)
 {
   ao_app = p_ao_app;
 }
 
 void Courtroom::on_add_button_clicked()
 {
-  if(ui_note_area->m_layout->count() > 6)
+  if (ui_note_area->m_layout->count() > 6)
     return;
 
   AONotePicker *f_notepicker = new AONotePicker(ui_note_area, ao_app);
@@ -27,7 +28,7 @@ void Courtroom::on_add_button_clicked()
   f_notepicker->m_layout = f_layout;
   f_notepicker->m_delete_button = f_delete;
   f_notepicker->m_hover = f_hover;
-  f_notepicker->setProperty("index", ui_note_area->m_layout->count()-1);
+  f_notepicker->setProperty("index", ui_note_area->m_layout->count() - 1);
 
   f_button->set_image("note_edit.png");
   f_delete->set_image("note_delete.png");
@@ -44,17 +45,19 @@ void Courtroom::on_add_button_clicked()
   f_notepicker->setLayout(f_layout);
   ui_note_area->m_layout->addWidget(f_notepicker);
 
-  if(contains_add_button)
-    {
-      ui_note_area->m_layout->removeWidget(ui_note_area->add_button);
-      ui_note_area->m_layout->addWidget(ui_note_area->add_button);
-      set_note_files();
-    }
+  if (contains_add_button)
+  {
+    ui_note_area->m_layout->removeWidget(ui_note_area->add_button);
+    ui_note_area->m_layout->addWidget(ui_note_area->add_button);
+    set_note_files();
+  }
 
   set_dropdown(f_line, "[LINE EDIT]");
 
-  connect(f_button, SIGNAL(clicked(bool)), this, SLOT(on_set_file_button_clicked()));
-  connect(f_delete, SIGNAL(clicked(bool)), this, SLOT(on_delete_button_clicked()));
+  connect(f_button, SIGNAL(clicked(bool)), this,
+          SLOT(on_set_file_button_clicked()));
+  connect(f_delete, SIGNAL(clicked(bool)), this,
+          SLOT(on_delete_button_clicked()));
   connect(f_hover, SIGNAL(clicked(bool)), this, SLOT(on_file_selected()));
 }
 
@@ -63,33 +66,34 @@ void Courtroom::set_note_files()
   QString filename = ao_app->get_base_path() + "configs/filesabstract.ini";
   QFile config_file(filename);
 
-  if(!config_file.open(QIODevice::ReadOnly | QIODevice::Text))
+  if (!config_file.open(QIODevice::ReadOnly | QIODevice::Text))
   {
-      qDebug() << "Couldn't open" << filename;
-      return;
+    qDebug() << "Couldn't open" << filename;
+    return;
   }
 
   QTextStream in(&config_file);
 
   QByteArray t = "";
 
-  for(int i = 0; i < ui_note_area->m_layout->count()-1; ++i)
-    {
-      AONotePicker *f_notepicker = static_cast<AONotePicker*>(ui_note_area->m_layout->itemAt(i)->widget());
-      QString f_filestring = f_notepicker->real_file;
-      QString f_filename = f_notepicker->m_line->text();
+  for (int i = 0; i < ui_note_area->m_layout->count() - 1; ++i)
+  {
+    AONotePicker *f_notepicker = static_cast<AONotePicker *>(
+        ui_note_area->m_layout->itemAt(i)->widget());
+    QString f_filestring = f_notepicker->real_file;
+    QString f_filename = f_notepicker->m_line->text();
 
-      t += QString::number(i) + " = " + f_filestring + " = " + f_filename + "\n\n";
-    }
-
+    t +=
+        QString::number(i) + " = " + f_filestring + " = " + f_filename + "\n\n";
+  }
 
   config_file.close();
 
   QFile ex(filename);
-  if(!ex.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+  if (!ex.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
   {
-      qDebug() << "Couldn't open" << filename;
-      return;
+    qDebug() << "Couldn't open" << filename;
+    return;
   }
 
   ex.write(t);

--- a/aonotearea.h
+++ b/aonotearea.h
@@ -2,13 +2,13 @@
 #define AONOTEAREA_HPP
 
 #include <QLabel>
-#include <QScrollArea>
 #include <QListWidget>
-#include <QVector>
+#include <QScrollArea>
 #include <QVBoxLayout>
+#include <QVector>
 #include <aobutton.h>
-#include <aonotepicker.h>
 #include <aoimage.h>
+#include <aonotepicker.h>
 
 #include "aoapplication.h"
 
@@ -25,7 +25,6 @@ public:
 private:
   AOApplication *ao_app;
   void set_layout();
-
 };
 
 #endif // AONOTEAREA_HPP

--- a/aonotepad.cpp
+++ b/aonotepad.cpp
@@ -1,5 +1,6 @@
 #include "aonotepad.h"
 
-AONotepad::AONotepad(QWidget* p_parent, AOApplication *p_ao_app)
-  : QTextEdit(p_parent), ao_app(p_ao_app)
-{}
+AONotepad::AONotepad(QWidget *p_parent, AOApplication *p_ao_app)
+    : QTextEdit(p_parent), ao_app(p_ao_app)
+{
+}

--- a/aonotepad.h
+++ b/aonotepad.h
@@ -10,7 +10,7 @@ class AONotepad : public QTextEdit
   Q_OBJECT
 
 public:
-  AONotepad(QWidget* p_parent, AOApplication *p_ao_app);
+  AONotepad(QWidget *p_parent, AOApplication *p_ao_app);
 
 private:
   AOApplication *ao_app = nullptr;

--- a/aonotepicker.cpp
+++ b/aonotepicker.cpp
@@ -2,48 +2,49 @@
 
 #include "courtroom.h"
 
-#include <QFileDialog>
 #include <QDebug>
+#include <QFileDialog>
 
-AONotePicker::AONotePicker(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AONotePicker::AONotePicker(QWidget *p_parent, AOApplication *p_ao_app)
+    : QLabel(p_parent)
 {
   ao_app = p_ao_app;
 }
 
 void Courtroom::on_file_selected()
 {
-  for(int i=0; i < ui_note_area->m_layout->count() -1; ++i)
-    {
-      AONotePicker *f_notepicker = static_cast<AONotePicker*>(ui_note_area->m_layout->itemAt(i)->widget());
-      f_notepicker->m_hover->set_image("note_select.png");
-    }
+  for (int i = 0; i < ui_note_area->m_layout->count() - 1; ++i)
+  {
+    AONotePicker *f_notepicker = static_cast<AONotePicker *>(
+        ui_note_area->m_layout->itemAt(i)->widget());
+    f_notepicker->m_hover->set_image("note_select.png");
+  }
 
-  AOButton *f_button = static_cast<AOButton*>(sender());
-  AONotePicker *f_notepicker = static_cast<AONotePicker*>(f_button->parent());
+  AOButton *f_button = static_cast<AOButton *>(sender());
+  AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
   current_file = f_notepicker->real_file;
   load_note();
   f_button->set_image("note_select_selected.png");
 }
 
-
 void Courtroom::on_set_file_button_clicked()
 {
-  AOButton *f_button = static_cast<AOButton*>(sender());
-  AONotePicker *f_notepicker = static_cast<AONotePicker*>(f_button->parent());
+  AOButton *f_button = static_cast<AOButton *>(sender());
+  AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
   QString f_filename = QFileDialog::getOpenFileName(this, "Open File");
-  if(f_filename != "")
-    {
-      f_notepicker->m_line->setText(f_filename);
-      f_notepicker->real_file = f_filename;
+  if (f_filename != "")
+  {
+    f_notepicker->m_line->setText(f_filename);
+    f_notepicker->real_file = f_filename;
 
-      set_note_files();
-    }
+    set_note_files();
+  }
 }
 
 void Courtroom::on_delete_button_clicked()
 {
-  AOButton *f_button = static_cast<AOButton*>(sender());
-  AONotePicker *f_notepicker = static_cast<AONotePicker*>(f_button->parent());
+  AOButton *f_button = static_cast<AOButton *>(sender());
+  AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
   ui_note_area->m_layout->removeWidget(f_notepicker);
   delete f_notepicker;
   set_note_files();

--- a/aonotepicker.h
+++ b/aonotepicker.h
@@ -1,10 +1,10 @@
 #ifndef AONOTEPICKER_HPP
 #define AONOTEPICKER_HPP
 
+#include "aobutton.h"
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
-#include <QHBoxLayout>
-#include "aobutton.h"
 
 class AONotePicker : public QLabel
 {

--- a/aopacket.cpp
+++ b/aopacket.cpp
@@ -10,7 +10,7 @@ AOPacket::AOPacket(QString p_packet_string)
 
   m_header = packet_contents.at(0);
 
-  for(int n_string = 1 ; n_string < packet_contents.size() - 1 ; ++n_string)
+  for (int n_string = 1; n_string < packet_contents.size() - 1; ++n_string)
   {
     m_contents.append(packet_contents.at(n_string));
   }
@@ -32,7 +32,6 @@ QString AOPacket::to_string()
   }
 
   f_string += "#%";
-
 
   if (encrypted)
     return "#" + f_string;
@@ -56,10 +55,13 @@ void AOPacket::decrypt_header(unsigned int p_key)
 
 void AOPacket::net_encode()
 {
-  for (int n_element = 0 ; n_element < m_contents.size() ; ++n_element)
+  for (int n_element = 0; n_element < m_contents.size(); ++n_element)
   {
     QString f_element = m_contents.at(n_element);
-    f_element.replace("#", "<num>").replace("%", "<percent>").replace("$", "<dollar>").replace("&", "<and>");
+    f_element.replace("#", "<num>")
+        .replace("%", "<percent>")
+        .replace("$", "<dollar>")
+        .replace("&", "<and>");
 
     m_contents.removeAt(n_element);
     m_contents.insert(n_element, f_element);
@@ -68,13 +70,15 @@ void AOPacket::net_encode()
 
 void AOPacket::net_decode()
 {
-  for (int n_element = 0 ; n_element < m_contents.size() ; ++n_element)
+  for (int n_element = 0; n_element < m_contents.size(); ++n_element)
   {
     QString f_element = m_contents.at(n_element);
-    f_element.replace("<num>", "#").replace("<percent>", "%").replace("<dollar>", "$").replace("<and>", "&");
+    f_element.replace("<num>", "#")
+        .replace("<percent>", "%")
+        .replace("<dollar>", "$")
+        .replace("<and>", "&");
 
     m_contents.removeAt(n_element);
     m_contents.insert(n_element, f_element);
   }
 }
-

--- a/aopacket.h
+++ b/aopacket.h
@@ -10,8 +10,14 @@ public:
   AOPacket(QString p_packet_string);
   AOPacket(QString header, QStringList &p_contents);
 
-  QString get_header() { return m_header; }
-  QStringList &get_contents() { return m_contents; }
+  QString get_header()
+  {
+    return m_header;
+  }
+  QStringList &get_contents()
+  {
+    return m_contents;
+  }
   QString to_string();
 
   void encrypt_header(unsigned int p_key);

--- a/aopacket.h
+++ b/aopacket.h
@@ -10,8 +10,14 @@ public:
   AOPacket(QString p_packet_string);
   AOPacket(QString header, QStringList &p_contents);
 
-  QString get_header() {return m_header;}
-  QStringList &get_contents() {return m_contents;}
+  QString get_header()
+  {
+    return m_header;
+  }
+  QStringList &get_contents()
+  {
+    return m_contents;
+  }
   QString to_string();
 
   void encrypt_header(unsigned int p_key);

--- a/aopacket.h
+++ b/aopacket.h
@@ -10,14 +10,8 @@ public:
   AOPacket(QString p_packet_string);
   AOPacket(QString header, QStringList &p_contents);
 
-  QString get_header()
-  {
-    return m_header;
-  }
-  QStringList &get_contents()
-  {
-    return m_contents;
-  }
+  QString get_header() { return m_header; }
+  QStringList &get_contents() { return m_contents; }
   QString to_string();
 
   void encrypt_header(unsigned int p_key);

--- a/aopixmap.cpp
+++ b/aopixmap.cpp
@@ -2,25 +2,27 @@
 
 AOPixmap::AOPixmap(QPixmap p_pixmap) : m_pixmap(p_pixmap)
 {
-    if (m_pixmap.isNull())
-    {
-        clear();
-    }
+  if (m_pixmap.isNull())
+  {
+    clear();
+  }
 }
 
 AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path))
 {
-
 }
 
 void AOPixmap::clear()
 {
-    m_pixmap = QPixmap(1, 1);
-    m_pixmap.fill(Qt::transparent);
+  m_pixmap = QPixmap(1, 1);
+  m_pixmap.fill(Qt::transparent);
 }
 
 QPixmap AOPixmap::scale_to_size(QSize p_size)
 {
-    bool f_is_pixmap_larger = m_pixmap.width() > p_size.width() || m_pixmap.height() > p_size.height();
-    return m_pixmap.scaled(p_size, Qt::IgnoreAspectRatio, f_is_pixmap_larger ? Qt::SmoothTransformation : Qt::FastTransformation);
+  bool f_is_pixmap_larger =
+      m_pixmap.width() > p_size.width() || m_pixmap.height() > p_size.height();
+  return m_pixmap.scaled(p_size, Qt::IgnoreAspectRatio,
+                         f_is_pixmap_larger ? Qt::SmoothTransformation
+                                            : Qt::FastTransformation);
 }

--- a/aopixmap.cpp
+++ b/aopixmap.cpp
@@ -8,7 +8,9 @@ AOPixmap::AOPixmap(QPixmap p_pixmap) : m_pixmap(p_pixmap)
   }
 }
 
-AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path)) {}
+AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path))
+{
+}
 
 void AOPixmap::clear()
 {

--- a/aopixmap.cpp
+++ b/aopixmap.cpp
@@ -8,9 +8,7 @@ AOPixmap::AOPixmap(QPixmap p_pixmap) : m_pixmap(p_pixmap)
   }
 }
 
-AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path))
-{
-}
+AOPixmap::AOPixmap(QString p_file_path) : AOPixmap(QPixmap(p_file_path)) {}
 
 void AOPixmap::clear()
 {

--- a/aopixmap.h
+++ b/aopixmap.h
@@ -6,15 +6,15 @@
 class AOPixmap
 {
 public:
-    AOPixmap(QPixmap p_pixmap = QPixmap());
-    AOPixmap(QString p_file_path);
+  AOPixmap(QPixmap p_pixmap = QPixmap());
+  AOPixmap(QString p_file_path);
 
-    void clear();
+  void clear();
 
-    QPixmap scale_to_size(QSize p_size);
+  QPixmap scale_to_size(QSize p_size);
 
 private:
-    QPixmap m_pixmap;
+  QPixmap m_pixmap;
 };
 
 #endif

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -6,48 +6,49 @@
 #include <QDebug>
 #include <QMovie>
 
-AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent), ao_app(p_ao_app)
+AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app)
+    : QLabel(parent), ao_app(p_ao_app)
 {
-    m_reader = new QMovie(this);
-    setMovie(m_reader);
+  m_reader = new QMovie(this);
+  setMovie(m_reader);
 }
 
 void AOScene::set_image(QString p_image)
 {
-    QString target_path = ao_app->get_default_background_path() + p_image;
+  QString target_path = ao_app->get_default_background_path() + p_image;
 
-    // background specific path
-    QString background_path = ao_app->get_background_path() + p_image;
+  // background specific path
+  QString background_path = ao_app->get_background_path() + p_image;
 
-    for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
+  for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
+  {
+    QString full_background_path = background_path + ext;
+
+    if (file_exists(full_background_path))
     {
-        QString full_background_path = background_path + ext;
-
-        if (file_exists(full_background_path))
-        {
-            target_path = full_background_path;
-            break;
-        }
+      target_path = full_background_path;
+      break;
     }
+  }
 
-    // do not update the movie if we're using the same file
-    if (m_reader->fileName() == target_path)
-        return;
+  // do not update the movie if we're using the same file
+  if (m_reader->fileName() == target_path)
+    return;
 
-    m_reader->stop();
-    delete m_reader;
+  m_reader->stop();
+  delete m_reader;
 
-    m_reader = new QMovie(this);
-    m_reader->setScaledSize(size());
-    m_reader->setFileName(target_path);
-    setMovie(m_reader);
-    m_reader->start();
+  m_reader = new QMovie(this);
+  m_reader->setScaledSize(size());
+  m_reader->setFileName(target_path);
+  setMovie(m_reader);
+  m_reader->start();
 }
 
 void AOScene::combo_resize(QSize p_size)
 {
-    resize(p_size);
-    m_reader->stop();
-    m_reader->setScaledSize(p_size);
-    m_reader->start();
+  resize(p_size);
+  m_reader->stop();
+  m_reader->setScaledSize(p_size);
+  m_reader->start();
 }

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -6,48 +6,49 @@
 #include <QDebug>
 #include <QMovie>
 
-AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent), ao_app(p_ao_app)
+AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app)
+    : QLabel(parent), ao_app(p_ao_app)
 {
-    m_reader = new QMovie(this);
-    setMovie(m_reader);
+  m_reader = new QMovie(this);
+  setMovie(m_reader);
 }
 
 void AOScene::set_image(QString p_image)
 {
-    QString target_path = ao_app->get_default_background_path(p_image);
+  QString target_path = ao_app->get_default_background_path(p_image);
 
-    // background specific path
-    QString background_path = ao_app->get_background_path(p_image);
+  // background specific path
+  QString background_path = ao_app->get_background_path(p_image);
 
-    for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
+  for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
+  {
+    QString full_background_path = background_path + ext;
+
+    if (file_exists(full_background_path))
     {
-        QString full_background_path = background_path + ext;
-
-        if (file_exists(full_background_path))
-        {
-            target_path = full_background_path;
-            break;
-        }
+      target_path = full_background_path;
+      break;
     }
+  }
 
-    // do not update the movie if we're using the same file
-    if (m_reader->fileName() == target_path)
-        return;
+  // do not update the movie if we're using the same file
+  if (m_reader->fileName() == target_path)
+    return;
 
-    m_reader->stop();
-    delete m_reader;
+  m_reader->stop();
+  delete m_reader;
 
-    m_reader = new QMovie(this);
-    m_reader->setScaledSize(size());
-    m_reader->setFileName(target_path);
-    setMovie(m_reader);
-    m_reader->start();
+  m_reader = new QMovie(this);
+  m_reader->setScaledSize(size());
+  m_reader->setFileName(target_path);
+  setMovie(m_reader);
+  m_reader->start();
 }
 
 void AOScene::combo_resize(QSize p_size)
 {
-    resize(p_size);
-    m_reader->stop();
-    m_reader->setScaledSize(p_size);
-    m_reader->start();
+  resize(p_size);
+  m_reader->stop();
+  m_reader->setScaledSize(p_size);
+  m_reader->start();
 }

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -6,49 +6,48 @@
 #include <QDebug>
 #include <QMovie>
 
-AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app)
-    : QLabel(parent), ao_app(p_ao_app)
+AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent), ao_app(p_ao_app)
 {
-  m_reader = new QMovie(this);
-  setMovie(m_reader);
+    m_reader = new QMovie(this);
+    setMovie(m_reader);
 }
 
 void AOScene::set_image(QString p_image)
 {
-  QString target_path = ao_app->get_default_background_path() + p_image;
+    QString target_path = ao_app->get_default_background_path(p_image);
 
-  // background specific path
-  QString background_path = ao_app->get_background_path() + p_image;
+    // background specific path
+    QString background_path = ao_app->get_background_path(p_image);
 
-  for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
-  {
-    QString full_background_path = background_path + ext;
-
-    if (file_exists(full_background_path))
+    for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
     {
-      target_path = full_background_path;
-      break;
+        QString full_background_path = background_path + ext;
+
+        if (file_exists(full_background_path))
+        {
+            target_path = full_background_path;
+            break;
+        }
     }
-  }
 
-  // do not update the movie if we're using the same file
-  if (m_reader->fileName() == target_path)
-    return;
+    // do not update the movie if we're using the same file
+    if (m_reader->fileName() == target_path)
+        return;
 
-  m_reader->stop();
-  delete m_reader;
+    m_reader->stop();
+    delete m_reader;
 
-  m_reader = new QMovie(this);
-  m_reader->setScaledSize(size());
-  m_reader->setFileName(target_path);
-  setMovie(m_reader);
-  m_reader->start();
+    m_reader = new QMovie(this);
+    m_reader->setScaledSize(size());
+    m_reader->setFileName(target_path);
+    setMovie(m_reader);
+    m_reader->start();
 }
 
 void AOScene::combo_resize(QSize p_size)
 {
-  resize(p_size);
-  m_reader->stop();
-  m_reader->setScaledSize(p_size);
-  m_reader->start();
+    resize(p_size);
+    m_reader->stop();
+    m_reader->setScaledSize(p_size);
+    m_reader->start();
 }

--- a/aoscene.h
+++ b/aoscene.h
@@ -8,17 +8,17 @@ class AOApplication;
 
 class AOScene : public QLabel
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOScene(QWidget *parent, AOApplication *p_ao_app);
+  AOScene(QWidget *parent, AOApplication *p_ao_app);
 
-    void set_image(QString p_image);
-    void combo_resize(QSize p_size);
+  void set_image(QString p_image);
+  void combo_resize(QSize p_size);
 
 private:
-    AOApplication *ao_app = nullptr;
-    QMovie *m_reader      = nullptr;
+  AOApplication *ao_app = nullptr;
+  QMovie *m_reader = nullptr;
 };
 
 #endif // AOSCENE_H

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -6,24 +6,28 @@
 
 AOSfxPlayer::AOSfxPlayer(QObject *p_parent, AOApplication *p_ao_app)
     : AOAbstractPlayer(p_parent, p_ao_app)
-{}
+{
+}
 
 void AOSfxPlayer::play(QString p_name)
 {
-    QString f_file = ao_app->get_sounds_path() + p_name.toLower();
+  QString f_file = ao_app->get_sounds_path() + p_name.toLower();
 
-    try {
-        AOBassHandle *handle = new AOBassHandle(f_file, true, this);
-        connect(this, &AOSfxPlayer::new_volume, handle, &AOBassHandle::set_volume);
-        connect(this, &AOSfxPlayer::stopping, handle, &AOBassHandle::stop);
-        handle->set_volume(get_volume());
-        handle->play();
-    } catch(const std::exception &e_exception) {
-        qDebug() << e_exception.what();
-    }
+  try
+  {
+    AOBassHandle *handle = new AOBassHandle(f_file, true, this);
+    connect(this, &AOSfxPlayer::new_volume, handle, &AOBassHandle::set_volume);
+    connect(this, &AOSfxPlayer::stopping, handle, &AOBassHandle::stop);
+    handle->set_volume(get_volume());
+    handle->play();
+  }
+  catch (const std::exception &e_exception)
+  {
+    qDebug() << e_exception.what();
+  }
 }
 
 void AOSfxPlayer::stop()
 {
-    emit stopping();
+  emit stopping();
 }

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -27,4 +27,7 @@ void AOSfxPlayer::play(QString p_name)
   }
 }
 
-void AOSfxPlayer::stop() { emit stopping(); }
+void AOSfxPlayer::stop()
+{
+  emit stopping();
+}

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -5,29 +5,20 @@
 #include <QDebug>
 
 AOSfxPlayer::AOSfxPlayer(QObject *p_parent, AOApplication *p_ao_app)
-    : AOAbstractPlayer(p_parent, p_ao_app)
-{
-}
+    : AOAbstractPlayer(p_parent, p_ao_app) {}
 
-void AOSfxPlayer::play(QString p_name)
-{
-  QString f_file = ao_app->get_sounds_path() + p_name.toLower();
+void AOSfxPlayer::play(QString p_name) {
+  QString f_file = ao_app->get_sounds_path(p_name);
 
-  try
-  {
+  try {
     AOBassHandle *handle = new AOBassHandle(f_file, true, this);
     connect(this, &AOSfxPlayer::new_volume, handle, &AOBassHandle::set_volume);
     connect(this, &AOSfxPlayer::stopping, handle, &AOBassHandle::stop);
     handle->set_volume(get_volume());
     handle->play();
-  }
-  catch (const std::exception &e_exception)
-  {
+  } catch (const std::exception &e_exception) {
     qDebug() << e_exception.what();
   }
 }
 
-void AOSfxPlayer::stop()
-{
-  emit stopping();
-}
+void AOSfxPlayer::stop() { emit stopping(); }

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -5,18 +5,24 @@
 #include <QDebug>
 
 AOSfxPlayer::AOSfxPlayer(QObject *p_parent, AOApplication *p_ao_app)
-    : AOAbstractPlayer(p_parent, p_ao_app) {}
+    : AOAbstractPlayer(p_parent, p_ao_app)
+{
+}
 
-void AOSfxPlayer::play(QString p_name) {
+void AOSfxPlayer::play(QString p_name)
+{
   QString f_file = ao_app->get_sounds_path(p_name);
 
-  try {
+  try
+  {
     AOBassHandle *handle = new AOBassHandle(f_file, true, this);
     connect(this, &AOSfxPlayer::new_volume, handle, &AOBassHandle::set_volume);
     connect(this, &AOSfxPlayer::stopping, handle, &AOBassHandle::stop);
     handle->set_volume(get_volume());
     handle->play();
-  } catch (const std::exception &e_exception) {
+  }
+  catch (const std::exception &e_exception)
+  {
     qDebug() << e_exception.what();
   }
 }

--- a/aosfxplayer.h
+++ b/aosfxplayer.h
@@ -5,13 +5,13 @@
 
 class AOSfxPlayer : public AOAbstractPlayer
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOSfxPlayer(QObject *p_parent, AOApplication *p_ao_app);
+  AOSfxPlayer(QObject *p_parent, AOApplication *p_ao_app);
 
-    void play(QString p_file);
-    void stop();
+  void play(QString p_file);
+  void stop();
 };
 
 #endif // AOSFXPLAYER_H

--- a/aoshoutplayer.cpp
+++ b/aoshoutplayer.cpp
@@ -40,4 +40,7 @@ void AOShoutPlayer::play(QString p_name, QString p_char)
   }
 }
 
-void AOShoutPlayer::stop() { emit stopping(); }
+void AOShoutPlayer::stop()
+{
+  emit stopping();
+}

--- a/aoshoutplayer.cpp
+++ b/aoshoutplayer.cpp
@@ -5,37 +5,42 @@
 
 AOShoutPlayer::AOShoutPlayer(QObject *p_parent, AOApplication *p_ao_app)
     : AOAbstractPlayer(p_parent, p_ao_app)
-{}
+{
+}
 
 void AOShoutPlayer::play(QString p_name, QString p_char)
 {
-    QString f_file;
+  QString f_file;
 
-    QString char_path = ao_app->get_character_path(p_char) + p_name.toLower();
-    QString theme_path = ao_app->get_image_path(p_name.toLower());
+  QString char_path = ao_app->get_character_path(p_char) + p_name.toLower();
+  QString theme_path = ao_app->get_image_path(p_name.toLower());
 
-    qDebug() << char_path;
-    qDebug() << theme_path;
+  qDebug() << char_path;
+  qDebug() << theme_path;
 
-    if(file_exists(char_path))
-      f_file = char_path;
-    else if (file_exists(theme_path))
-      f_file = theme_path;
-    else
-      f_file = "";
+  if (file_exists(char_path))
+    f_file = char_path;
+  else if (file_exists(theme_path))
+    f_file = theme_path;
+  else
+    f_file = "";
 
-    try {
-        AOBassHandle *handle = new AOBassHandle(f_file, true, this);
-        connect(this, &AOShoutPlayer::new_volume, handle, &AOBassHandle::set_volume);
-        connect(this, &AOShoutPlayer::stopping, handle, &AOBassHandle::stop);
-        handle->set_volume(get_volume());
-        handle->play();
-    } catch(const std::exception &e_exception) {
-        qDebug() << e_exception.what();
-    }
+  try
+  {
+    AOBassHandle *handle = new AOBassHandle(f_file, true, this);
+    connect(this, &AOShoutPlayer::new_volume, handle,
+            &AOBassHandle::set_volume);
+    connect(this, &AOShoutPlayer::stopping, handle, &AOBassHandle::stop);
+    handle->set_volume(get_volume());
+    handle->play();
+  }
+  catch (const std::exception &e_exception)
+  {
+    qDebug() << e_exception.what();
+  }
 }
 
 void AOShoutPlayer::stop()
 {
-    emit stopping();
+  emit stopping();
 }

--- a/aoshoutplayer.cpp
+++ b/aoshoutplayer.cpp
@@ -4,16 +4,13 @@
 #include <QDebug>
 
 AOShoutPlayer::AOShoutPlayer(QObject *p_parent, AOApplication *p_ao_app)
-    : AOAbstractPlayer(p_parent, p_ao_app)
-{
-}
+    : AOAbstractPlayer(p_parent, p_ao_app) {}
 
-void AOShoutPlayer::play(QString p_name, QString p_char)
-{
+void AOShoutPlayer::play(QString p_name, QString p_char) {
   QString f_file;
 
-  QString char_path = ao_app->get_character_path(p_char) + p_name.toLower();
-  QString theme_path = ao_app->get_image_path(p_name.toLower());
+  QString char_path = ao_app->get_character_path(p_char, p_name);
+  QString theme_path = ao_app->get_image_path(p_name);
 
   qDebug() << char_path;
   qDebug() << theme_path;
@@ -25,22 +22,16 @@ void AOShoutPlayer::play(QString p_name, QString p_char)
   else
     f_file = "";
 
-  try
-  {
+  try {
     AOBassHandle *handle = new AOBassHandle(f_file, true, this);
     connect(this, &AOShoutPlayer::new_volume, handle,
             &AOBassHandle::set_volume);
     connect(this, &AOShoutPlayer::stopping, handle, &AOBassHandle::stop);
     handle->set_volume(get_volume());
     handle->play();
-  }
-  catch (const std::exception &e_exception)
-  {
+  } catch (const std::exception &e_exception) {
     qDebug() << e_exception.what();
   }
 }
 
-void AOShoutPlayer::stop()
-{
-  emit stopping();
-}
+void AOShoutPlayer::stop() { emit stopping(); }

--- a/aoshoutplayer.cpp
+++ b/aoshoutplayer.cpp
@@ -4,9 +4,12 @@
 #include <QDebug>
 
 AOShoutPlayer::AOShoutPlayer(QObject *p_parent, AOApplication *p_ao_app)
-    : AOAbstractPlayer(p_parent, p_ao_app) {}
+    : AOAbstractPlayer(p_parent, p_ao_app)
+{
+}
 
-void AOShoutPlayer::play(QString p_name, QString p_char) {
+void AOShoutPlayer::play(QString p_name, QString p_char)
+{
   QString f_file;
 
   QString char_path = ao_app->get_character_path(p_char, p_name);
@@ -22,14 +25,17 @@ void AOShoutPlayer::play(QString p_name, QString p_char) {
   else
     f_file = "";
 
-  try {
+  try
+  {
     AOBassHandle *handle = new AOBassHandle(f_file, true, this);
     connect(this, &AOShoutPlayer::new_volume, handle,
             &AOBassHandle::set_volume);
     connect(this, &AOShoutPlayer::stopping, handle, &AOBassHandle::stop);
     handle->set_volume(get_volume());
     handle->play();
-  } catch (const std::exception &e_exception) {
+  }
+  catch (const std::exception &e_exception)
+  {
     qDebug() << e_exception.what();
   }
 }

--- a/aoshoutplayer.h
+++ b/aoshoutplayer.h
@@ -5,13 +5,13 @@
 
 class AOShoutPlayer : public AOAbstractPlayer
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    AOShoutPlayer(QObject *p_parent, AOApplication *p_ao_app);
+  AOShoutPlayer(QObject *p_parent, AOApplication *p_ao_app);
 
-    void play(QString p_name, QString p_char);
-    void stop();
+  void play(QString p_name, QString p_char);
+  void stop();
 };
 
 #endif // AOSHOUTPLAYER_HPP

--- a/aotextarea.cpp
+++ b/aotextarea.cpp
@@ -5,7 +5,9 @@
 #include <QScrollBar>
 #include <QTextCursor>
 
-AOTextArea::AOTextArea(QWidget *p_parent) : QTextBrowser(p_parent) {}
+AOTextArea::AOTextArea(QWidget *p_parent) : QTextBrowser(p_parent)
+{
+}
 
 void AOTextArea::append_chatmessage(QString p_name, QString p_message)
 {

--- a/aotextarea.cpp
+++ b/aotextarea.cpp
@@ -1,30 +1,30 @@
 #include "aotextarea.h"
 
+#include <QDebug>
+#include <QRegExp>
 #include <QScrollBar>
 #include <QTextCursor>
-#include <QRegExp>
-#include <QDebug>
 
 AOTextArea::AOTextArea(QWidget *p_parent) : QTextBrowser(p_parent)
 {
-
 }
 
 void AOTextArea::append_chatmessage(QString p_name, QString p_message)
 {
   const QTextCursor old_cursor = this->textCursor();
   const int old_scrollbar_value = this->verticalScrollBar()->value();
-  const bool is_scrolled_down = old_scrollbar_value == this->verticalScrollBar()->maximum();
+  const bool is_scrolled_down =
+      old_scrollbar_value == this->verticalScrollBar()->maximum();
 
   this->moveCursor(QTextCursor::End);
 
   this->append("");
   this->insertHtml("<b>" + p_name.toHtmlEscaped() + "</b>:&nbsp;");
 
-  //cheap workarounds ahoy
+  // cheap workarounds ahoy
   p_message += " ";
   QString result = p_message.toHtmlEscaped().replace("\n", "<br>");
-  result = result.replace(omnis_dank_url_regex, "<a href='\\1'>\\1</a>" );
+  result = result.replace(omnis_dank_url_regex, "<a href='\\1'>\\1</a>");
 
   this->insertHtml(result);
 
@@ -35,7 +35,8 @@ void AOTextArea::append_error(QString p_message)
 {
   const QTextCursor old_cursor = this->textCursor();
   const int old_scrollbar_value = this->verticalScrollBar()->value();
-  const bool is_scrolled_down = old_scrollbar_value == this->verticalScrollBar()->maximum();
+  const bool is_scrolled_down =
+      old_scrollbar_value == this->verticalScrollBar()->maximum();
 
   this->moveCursor(QTextCursor::End);
 
@@ -43,25 +44,28 @@ void AOTextArea::append_error(QString p_message)
 
   p_message += " ";
   QString result = p_message.replace("\n", "<br>");
-  result = result.replace(omnis_dank_url_regex, "<a href='\\1'>\\1</a>" );
+  result = result.replace(omnis_dank_url_regex, "<a href='\\1'>\\1</a>");
 
   this->insertHtml("<font color='red'>" + result + "</font>");
 
   this->auto_scroll(old_cursor, old_scrollbar_value, is_scrolled_down);
 }
 
-void AOTextArea::auto_scroll(QTextCursor old_cursor, int old_scrollbar_value, bool is_scrolled_down)
+void AOTextArea::auto_scroll(QTextCursor old_cursor, int old_scrollbar_value,
+                             bool is_scrolled_down)
 {
   if (old_cursor.hasSelection() || !is_scrolled_down)
   {
-      // The user has selected text or scrolled away from the bottom: maintain position.
-      this->setTextCursor(old_cursor);
-      this->verticalScrollBar()->setValue(old_scrollbar_value);
+    // The user has selected text or scrolled away from the bottom: maintain
+    // position.
+    this->setTextCursor(old_cursor);
+    this->verticalScrollBar()->setValue(old_scrollbar_value);
   }
   else
   {
-      // The user hasn't selected any text and the scrollbar is at the bottom: scroll to the bottom.
-      this->moveCursor(QTextCursor::End);
-      this->verticalScrollBar()->setValue(this->verticalScrollBar()->maximum());
+    // The user hasn't selected any text and the scrollbar is at the bottom:
+    // scroll to the bottom.
+    this->moveCursor(QTextCursor::End);
+    this->verticalScrollBar()->setValue(this->verticalScrollBar()->maximum());
   }
 }

--- a/aotextarea.cpp
+++ b/aotextarea.cpp
@@ -5,9 +5,7 @@
 #include <QScrollBar>
 #include <QTextCursor>
 
-AOTextArea::AOTextArea(QWidget *p_parent) : QTextBrowser(p_parent)
-{
-}
+AOTextArea::AOTextArea(QWidget *p_parent) : QTextBrowser(p_parent) {}
 
 void AOTextArea::append_chatmessage(QString p_name, QString p_message)
 {

--- a/aotextarea.h
+++ b/aotextarea.h
@@ -14,7 +14,8 @@ public:
 private:
   const QRegExp omnis_dank_url_regex = QRegExp("\\b(https?://\\S+\\.\\S+)\\b");
 
-  void auto_scroll(QTextCursor old_cursor, int scrollbar_value, bool is_scrolled_down);
+  void auto_scroll(QTextCursor old_cursor, int scrollbar_value,
+                   bool is_scrolled_down);
 };
 
 #endif // AOTEXTAREA_H

--- a/aotimer.cpp
+++ b/aotimer.cpp
@@ -60,11 +60,20 @@ void AOTimer::update_time()
   firing_timer.start(firing_timer_length);
 }
 
-void AOTimer::set() { set_time(start_time); }
+void AOTimer::set()
+{
+  set_time(start_time);
+}
 
-void AOTimer::resume() { firing_timer.start(firing_timer_length); }
+void AOTimer::resume()
+{
+  firing_timer.start(firing_timer_length);
+}
 
-void AOTimer::pause() { firing_timer.stop(); }
+void AOTimer::pause()
+{
+  firing_timer.stop();
+}
 
 void AOTimer::redraw()
 {

--- a/aotimer.cpp
+++ b/aotimer.cpp
@@ -1,9 +1,10 @@
 #include "aotimer.h"
 #include <QDebug>
 
-AOTimer::AOTimer(QWidget* p_parent) : QTextEdit(p_parent)
+AOTimer::AOTimer(QWidget *p_parent) : QTextEdit(p_parent)
 {
-  // Adapted from: https://stackoverflow.com/questions/36679708/how-to-make-a-chronometer-in-qt-c
+  // Adapted from:
+  // https://stackoverflow.com/questions/36679708/how-to-make-a-chronometer-in-qt-c
   setStyleSheet("QLabel { color : white; }");
   setFrameStyle(QFrame::NoFrame);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -25,33 +26,35 @@ void AOTimer::update_time()
 
   // Check for underflow/overflow
 
-  // This one checks overflows, as the updated manual timer would appear to have a past time
-  // compared to the manual timer a step ago (represented by old_manual_timer)
+  // This one checks overflows, as the updated manual timer would appear to have
+  // a past time compared to the manual timer a step ago (represented by
+  // old_manual_timer)
   if (manual_timer.get_timestep_length() > 0)
   {
-      if (manual_timer.get_time().operator<(old_manual_timer.get_time()))
-      {
-        set_time(QTime(0, 0));
-        firing_timer.stop();
-        redraw();
-        return;
-      }
+    if (manual_timer.get_time().operator<(old_manual_timer.get_time()))
+    {
+      set_time(QTime(0, 0));
+      firing_timer.stop();
+      redraw();
+      return;
+    }
   }
-  // This one checks underflows, as the updated manual timer would appear to have a future time
-  // compared to the manual timer a step ago (represented by old_manual_timer)
+  // This one checks underflows, as the updated manual timer would appear to
+  // have a future time compared to the manual timer a step ago (represented by
+  // old_manual_timer)
   else if (manual_timer.get_timestep_length() < 0)
   {
-      if (manual_timer.get_time().operator>(old_manual_timer.get_time()))
-      {
-        set_time(QTime(0, 0));
-        firing_timer.stop();
-        redraw();
-        return;
-      }
+    if (manual_timer.get_time().operator>(old_manual_timer.get_time()))
+    {
+      set_time(QTime(0, 0));
+      firing_timer.stop();
+      redraw();
+      return;
+    }
   }
 
-  // If no overflow/underflow, now update the old manual timer so it matches the current timer
-  // Redraw and return
+  // If no overflow/underflow, now update the old manual timer so it matches the
+  // current timer Redraw and return
   old_manual_timer.perform_timestep();
   redraw();
   firing_timer.start(firing_timer_length);
@@ -93,22 +96,26 @@ void AOTimer::set_timestep_length(int new_timestep_length)
 void AOTimer::set_firing_interval(int new_firing_interval)
 {
   /*
-   * Update the firing interval of the steptimer for all future timesteps. If a timestep
-   * has started when this function is scheduled to run, the current timestep will be
-   * readapted to finish in this new firing interval as follows:
+   * Update the firing interval of the steptimer for all future timesteps. If a
+   * timestep has started when this function is scheduled to run, the current
+   * timestep will be readapted to finish in this new firing interval as
+   * follows:
    * - Assume length x of the 'current' timestep with orig has elapsed.
-   * - Then, the current timestep will be adapted to have length max(0, new_interval-x)
+   * - Then, the current timestep will be adapted to have length max(0,
+   * new_interval-x)
    */
 
   // Update time spent so far and new future firing interval
-  time_spent_in_timestep += (firing_timer_length - firing_timer.remainingTime());
+  time_spent_in_timestep +=
+      (firing_timer_length - firing_timer.remainingTime());
   firing_timer_length = new_firing_interval;
-  // For this timestep however, the firing interval will be shorter than firing_timer_length
-  // to account for the fact the timer may have already been running a bit in this timestep
+  // For this timestep however, the firing interval will be shorter than
+  // firing_timer_length to account for the fact the timer may have already been
+  // running a bit in this timestep
   if (new_firing_interval < time_spent_in_timestep)
     firing_timer.start(0);
   else
-    firing_timer.start(new_firing_interval-time_spent_in_timestep);
+    firing_timer.start(new_firing_interval - time_spent_in_timestep);
 }
 
 void AOTimer::set_concentrate_mode()

--- a/aotimer.cpp
+++ b/aotimer.cpp
@@ -60,20 +60,11 @@ void AOTimer::update_time()
   firing_timer.start(firing_timer_length);
 }
 
-void AOTimer::set()
-{
-  set_time(start_time);
-}
+void AOTimer::set() { set_time(start_time); }
 
-void AOTimer::resume()
-{
-  firing_timer.start(firing_timer_length);
-}
+void AOTimer::resume() { firing_timer.start(firing_timer_length); }
 
-void AOTimer::pause()
-{
-  firing_timer.stop();
-}
+void AOTimer::pause() { firing_timer.stop(); }
 
 void AOTimer::redraw()
 {

--- a/aotimer.h
+++ b/aotimer.h
@@ -15,10 +15,19 @@ class ManualTimer
   int timestep_length;
 
 public:
-  QTime get_time() { return current_time; }
-  int get_timestep_length() { return timestep_length; }
+  QTime get_time()
+  {
+    return current_time;
+  }
+  int get_timestep_length()
+  {
+    return timestep_length;
+  }
 
-  void set_time(QTime new_time) { current_time = new_time; }
+  void set_time(QTime new_time)
+  {
+    current_time = new_time;
+  }
   void set_timestep_length(int new_timestep_length)
   {
     timestep_length = new_timestep_length;

--- a/aotimer.h
+++ b/aotimer.h
@@ -1,25 +1,41 @@
 #ifndef AOTIMER_H
 #define AOTIMER_H
 
+#include <QElapsedTimer>
 #include <QTextEdit>
-#include <QWidget>
 #include <QTime>
 #include <QTimer>
-#include <QElapsedTimer>
-#include <aolabel.h>
+#include <QWidget>
 #include <aobutton.h>
+#include <aolabel.h>
 
-class ManualTimer {
+class ManualTimer
+{
   QTime current_time;
   int timestep_length;
 
-  public:
-    QTime get_time() { return current_time; }
-    int get_timestep_length() { return timestep_length; }
+public:
+  QTime get_time()
+  {
+    return current_time;
+  }
+  int get_timestep_length()
+  {
+    return timestep_length;
+  }
 
-    void set_time(QTime new_time) { current_time = new_time; }
-    void set_timestep_length(int new_timestep_length) { timestep_length = new_timestep_length ;}
-    void perform_timestep() {current_time = current_time.addMSecs(timestep_length);}
+  void set_time(QTime new_time)
+  {
+    current_time = new_time;
+  }
+  void set_timestep_length(int new_timestep_length)
+  {
+    timestep_length = new_timestep_length;
+  }
+  void perform_timestep()
+  {
+    current_time = current_time.addMSecs(timestep_length);
+  }
 };
 
 class AOTimer : public QTextEdit

--- a/aotimer.h
+++ b/aotimer.h
@@ -15,19 +15,10 @@ class ManualTimer
   int timestep_length;
 
 public:
-  QTime get_time()
-  {
-    return current_time;
-  }
-  int get_timestep_length()
-  {
-    return timestep_length;
-  }
+  QTime get_time() { return current_time; }
+  int get_timestep_length() { return timestep_length; }
 
-  void set_time(QTime new_time)
-  {
-    current_time = new_time;
-  }
+  void set_time(QTime new_time) { current_time = new_time; }
   void set_timestep_length(int new_timestep_length)
   {
     timestep_length = new_timestep_length;

--- a/audio_functions.cpp
+++ b/audio_functions.cpp
@@ -1,6 +1,9 @@
 #include "courtroom.h"
 
-bool Courtroom::is_audio_muted() { return m_audio_mute; }
+bool Courtroom::is_audio_muted()
+{
+  return m_audio_mute;
+}
 
 void Courtroom::set_audio_mute_enabled(bool p_enabled)
 {

--- a/audio_functions.cpp
+++ b/audio_functions.cpp
@@ -2,58 +2,58 @@
 
 bool Courtroom::is_audio_muted()
 {
-    return m_audio_mute;
+  return m_audio_mute;
 }
 
 void Courtroom::set_audio_mute_enabled(bool p_enabled)
 {
-    if (m_audio_mute == p_enabled)
-        return;
-    m_audio_mute = p_enabled;
+  if (m_audio_mute == p_enabled)
+    return;
+  m_audio_mute = p_enabled;
 
-    // restore volume
-    set_effects_volume(ao_config->effects_volume());
-    set_music_volume(ao_config->music_volume());
-    set_blips_volume(ao_config->blips_volume());
+  // restore volume
+  set_effects_volume(ao_config->effects_volume());
+  set_music_volume(ao_config->music_volume());
+  set_blips_volume(ao_config->blips_volume());
 }
 
 void Courtroom::set_effects_volume(int p_volume)
 {
-    m_effects_player->set_volume(is_audio_muted() ? 0 : p_volume);
-    m_shouts_player->set_volume(is_audio_muted() ? 0 : p_volume);
+  m_effects_player->set_volume(is_audio_muted() ? 0 : p_volume);
+  m_shouts_player->set_volume(is_audio_muted() ? 0 : p_volume);
 }
 
 void Courtroom::set_system_volume(int p_volume)
 {
-    m_system_player->set_volume(p_volume);
+  m_system_player->set_volume(p_volume);
 }
 
 void Courtroom::set_music_volume(int p_volume)
 {
-    m_music_player->set_volume(is_audio_muted() ? 0 : p_volume);
+  m_music_player->set_volume(is_audio_muted() ? 0 : p_volume);
 }
 
 void Courtroom::set_blips_volume(int p_volume)
 {
-    m_blips_player->set_volume(is_audio_muted() ? 0 : p_volume);
+  m_blips_player->set_volume(is_audio_muted() ? 0 : p_volume);
 }
 
 void Courtroom::on_config_effects_volume_changed(int p_volume)
 {
-    set_effects_volume(p_volume);
+  set_effects_volume(p_volume);
 }
 
 void Courtroom::on_config_system_volume_changed(int p_volume)
 {
-    set_system_volume(p_volume);
+  set_system_volume(p_volume);
 }
 
 void Courtroom::on_config_music_volume_changed(int p_volume)
 {
-    set_music_volume(p_volume);
+  set_music_volume(p_volume);
 }
 
 void Courtroom::on_config_blips_volume_changed(int p_volume)
 {
-    set_blips_volume(p_volume);
+  set_blips_volume(p_volume);
 }

--- a/audio_functions.cpp
+++ b/audio_functions.cpp
@@ -1,9 +1,6 @@
 #include "courtroom.h"
 
-bool Courtroom::is_audio_muted()
-{
-  return m_audio_mute;
-}
+bool Courtroom::is_audio_muted() { return m_audio_mute; }
 
 void Courtroom::set_audio_mute_enabled(bool p_enabled)
 {

--- a/bass.h
+++ b/bass.h
@@ -1,8 +1,8 @@
 /*
-	BASS 2.4 C/C++ header file
-	Copyright (c) 1999-2016 Un4seen Developments Ltd.
+        BASS 2.4 C/C++ header file
+        Copyright (c) 1999-2016 Un4seen Developments Ltd.
 
-	See the BASS.CHM file for more detailed documentation
+        See the BASS.CHM file for more detailed documentation
 */
 
 #ifndef BASS_H
@@ -27,19 +27,20 @@ typedef int BOOL;
 #define FALSE 0
 #endif
 #define LOBYTE(a) (BYTE)(a)
-#define HIBYTE(a) (BYTE)((a)>>8)
+#define HIBYTE(a) (BYTE)((a) >> 8)
 #define LOWORD(a) (WORD)(a)
-#define HIWORD(a) (WORD)((a)>>16)
-#define MAKEWORD(a,b) (WORD)(((a)&0xff)|((b)<<8))
-#define MAKELONG(a,b) (DWORD)(((a)&0xffff)|((b)<<16))
+#define HIWORD(a) (WORD)((a) >> 16)
+#define MAKEWORD(a, b) (WORD)(((a)&0xff) | ((b) << 8))
+#define MAKELONG(a, b) (DWORD)(((a)&0xffff) | ((b) << 16))
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-#define BASSVERSION			0x204	// API version
-#define BASSVERSIONTEXT		"2.4"
+#define BASSVERSION 0x204 // API version
+#define BASSVERSIONTEXT "2.4"
 
 #ifndef BASSDEF
 #define BASSDEF(f) WINAPI f
@@ -47,379 +48,407 @@ extern "C" {
 #define NOBASSOVERLOADS
 #endif
 
-typedef DWORD HMUSIC;		// MOD music handle
-typedef DWORD HSAMPLE;		// sample handle
-typedef DWORD HCHANNEL;		// playing sample's channel handle
-typedef DWORD HSTREAM;		// sample stream handle
-typedef DWORD HRECORD;		// recording handle
-typedef DWORD HSYNC;		// synchronizer handle
-typedef DWORD HDSP;			// DSP handle
-typedef DWORD HFX;			// DX8 effect handle
-typedef DWORD HPLUGIN;		// Plugin handle
+  typedef DWORD HMUSIC;   // MOD music handle
+  typedef DWORD HSAMPLE;  // sample handle
+  typedef DWORD HCHANNEL; // playing sample's channel handle
+  typedef DWORD HSTREAM;  // sample stream handle
+  typedef DWORD HRECORD;  // recording handle
+  typedef DWORD HSYNC;    // synchronizer handle
+  typedef DWORD HDSP;     // DSP handle
+  typedef DWORD HFX;      // DX8 effect handle
+  typedef DWORD HPLUGIN;  // Plugin handle
 
 // Error codes returned by BASS_ErrorGetCode
-#define BASS_OK				0	// all is OK
-#define BASS_ERROR_MEM		1	// memory error
-#define BASS_ERROR_FILEOPEN	2	// can't open the file
-#define BASS_ERROR_DRIVER	3	// can't find a free/valid driver
-#define BASS_ERROR_BUFLOST	4	// the sample buffer was lost
-#define BASS_ERROR_HANDLE	5	// invalid handle
-#define BASS_ERROR_FORMAT	6	// unsupported sample format
-#define BASS_ERROR_POSITION	7	// invalid position
-#define BASS_ERROR_INIT		8	// BASS_Init has not been successfully called
-#define BASS_ERROR_START	9	// BASS_Start has not been successfully called
-#define BASS_ERROR_SSL		10	// SSL/HTTPS support isn't available
-#define BASS_ERROR_ALREADY	14	// already initialized/paused/whatever
-#define BASS_ERROR_NOCHAN	18	// can't get a free channel
-#define BASS_ERROR_ILLTYPE	19	// an illegal type was specified
-#define BASS_ERROR_ILLPARAM	20	// an illegal parameter was specified
-#define BASS_ERROR_NO3D		21	// no 3D support
-#define BASS_ERROR_NOEAX	22	// no EAX support
-#define BASS_ERROR_DEVICE	23	// illegal device number
-#define BASS_ERROR_NOPLAY	24	// not playing
-#define BASS_ERROR_FREQ		25	// illegal sample rate
-#define BASS_ERROR_NOTFILE	27	// the stream is not a file stream
-#define BASS_ERROR_NOHW		29	// no hardware voices available
-#define BASS_ERROR_EMPTY	31	// the MOD music has no sequence data
-#define BASS_ERROR_NONET	32	// no internet connection could be opened
-#define BASS_ERROR_CREATE	33	// couldn't create the file
-#define BASS_ERROR_NOFX		34	// effects are not available
-#define BASS_ERROR_NOTAVAIL	37	// requested data is not available
-#define BASS_ERROR_DECODE	38	// the channel is/isn't a "decoding channel"
-#define BASS_ERROR_DX		39	// a sufficient DirectX version is not installed
-#define BASS_ERROR_TIMEOUT	40	// connection timedout
-#define BASS_ERROR_FILEFORM	41	// unsupported file format
-#define BASS_ERROR_SPEAKER	42	// unavailable speaker
-#define BASS_ERROR_VERSION	43	// invalid BASS version (used by add-ons)
-#define BASS_ERROR_CODEC	44	// codec is not available/supported
-#define BASS_ERROR_ENDED	45	// the channel/file has ended
-#define BASS_ERROR_BUSY		46	// the device is busy
-#define BASS_ERROR_UNKNOWN	-1	// some other mystery problem
+#define BASS_OK 0              // all is OK
+#define BASS_ERROR_MEM 1       // memory error
+#define BASS_ERROR_FILEOPEN 2  // can't open the file
+#define BASS_ERROR_DRIVER 3    // can't find a free/valid driver
+#define BASS_ERROR_BUFLOST 4   // the sample buffer was lost
+#define BASS_ERROR_HANDLE 5    // invalid handle
+#define BASS_ERROR_FORMAT 6    // unsupported sample format
+#define BASS_ERROR_POSITION 7  // invalid position
+#define BASS_ERROR_INIT 8      // BASS_Init has not been successfully called
+#define BASS_ERROR_START 9     // BASS_Start has not been successfully called
+#define BASS_ERROR_SSL 10      // SSL/HTTPS support isn't available
+#define BASS_ERROR_ALREADY 14  // already initialized/paused/whatever
+#define BASS_ERROR_NOCHAN 18   // can't get a free channel
+#define BASS_ERROR_ILLTYPE 19  // an illegal type was specified
+#define BASS_ERROR_ILLPARAM 20 // an illegal parameter was specified
+#define BASS_ERROR_NO3D 21     // no 3D support
+#define BASS_ERROR_NOEAX 22    // no EAX support
+#define BASS_ERROR_DEVICE 23   // illegal device number
+#define BASS_ERROR_NOPLAY 24   // not playing
+#define BASS_ERROR_FREQ 25     // illegal sample rate
+#define BASS_ERROR_NOTFILE 27  // the stream is not a file stream
+#define BASS_ERROR_NOHW 29     // no hardware voices available
+#define BASS_ERROR_EMPTY 31    // the MOD music has no sequence data
+#define BASS_ERROR_NONET 32    // no internet connection could be opened
+#define BASS_ERROR_CREATE 33   // couldn't create the file
+#define BASS_ERROR_NOFX 34     // effects are not available
+#define BASS_ERROR_NOTAVAIL 37 // requested data is not available
+#define BASS_ERROR_DECODE 38   // the channel is/isn't a "decoding channel"
+#define BASS_ERROR_DX 39       // a sufficient DirectX version is not installed
+#define BASS_ERROR_TIMEOUT 40  // connection timedout
+#define BASS_ERROR_FILEFORM 41 // unsupported file format
+#define BASS_ERROR_SPEAKER 42  // unavailable speaker
+#define BASS_ERROR_VERSION 43  // invalid BASS version (used by add-ons)
+#define BASS_ERROR_CODEC 44    // codec is not available/supported
+#define BASS_ERROR_ENDED 45    // the channel/file has ended
+#define BASS_ERROR_BUSY 46     // the device is busy
+#define BASS_ERROR_UNKNOWN -1  // some other mystery problem
 
 // BASS_SetConfig options
-#define BASS_CONFIG_BUFFER			0
-#define BASS_CONFIG_UPDATEPERIOD	1
-#define BASS_CONFIG_GVOL_SAMPLE		4
-#define BASS_CONFIG_GVOL_STREAM		5
-#define BASS_CONFIG_GVOL_MUSIC		6
-#define BASS_CONFIG_CURVE_VOL		7
-#define BASS_CONFIG_CURVE_PAN		8
-#define BASS_CONFIG_FLOATDSP		9
-#define BASS_CONFIG_3DALGORITHM		10
-#define BASS_CONFIG_NET_TIMEOUT		11
-#define BASS_CONFIG_NET_BUFFER		12
-#define BASS_CONFIG_PAUSE_NOPLAY	13
-#define BASS_CONFIG_NET_PREBUF		15
-#define BASS_CONFIG_NET_PASSIVE		18
-#define BASS_CONFIG_REC_BUFFER		19
-#define BASS_CONFIG_NET_PLAYLIST	21
-#define BASS_CONFIG_MUSIC_VIRTUAL	22
-#define BASS_CONFIG_VERIFY			23
-#define BASS_CONFIG_UPDATETHREADS	24
-#define BASS_CONFIG_DEV_BUFFER		27
-#define BASS_CONFIG_VISTA_TRUEPOS	30
-#define BASS_CONFIG_IOS_MIXAUDIO	34
-#define BASS_CONFIG_DEV_DEFAULT		36
-#define BASS_CONFIG_NET_READTIMEOUT	37
-#define BASS_CONFIG_VISTA_SPEAKERS	38
-#define BASS_CONFIG_IOS_SPEAKER		39
-#define BASS_CONFIG_MF_DISABLE		40
-#define BASS_CONFIG_HANDLES			41
-#define BASS_CONFIG_UNICODE			42
-#define BASS_CONFIG_SRC				43
-#define BASS_CONFIG_SRC_SAMPLE		44
+#define BASS_CONFIG_BUFFER 0
+#define BASS_CONFIG_UPDATEPERIOD 1
+#define BASS_CONFIG_GVOL_SAMPLE 4
+#define BASS_CONFIG_GVOL_STREAM 5
+#define BASS_CONFIG_GVOL_MUSIC 6
+#define BASS_CONFIG_CURVE_VOL 7
+#define BASS_CONFIG_CURVE_PAN 8
+#define BASS_CONFIG_FLOATDSP 9
+#define BASS_CONFIG_3DALGORITHM 10
+#define BASS_CONFIG_NET_TIMEOUT 11
+#define BASS_CONFIG_NET_BUFFER 12
+#define BASS_CONFIG_PAUSE_NOPLAY 13
+#define BASS_CONFIG_NET_PREBUF 15
+#define BASS_CONFIG_NET_PASSIVE 18
+#define BASS_CONFIG_REC_BUFFER 19
+#define BASS_CONFIG_NET_PLAYLIST 21
+#define BASS_CONFIG_MUSIC_VIRTUAL 22
+#define BASS_CONFIG_VERIFY 23
+#define BASS_CONFIG_UPDATETHREADS 24
+#define BASS_CONFIG_DEV_BUFFER 27
+#define BASS_CONFIG_VISTA_TRUEPOS 30
+#define BASS_CONFIG_IOS_MIXAUDIO 34
+#define BASS_CONFIG_DEV_DEFAULT 36
+#define BASS_CONFIG_NET_READTIMEOUT 37
+#define BASS_CONFIG_VISTA_SPEAKERS 38
+#define BASS_CONFIG_IOS_SPEAKER 39
+#define BASS_CONFIG_MF_DISABLE 40
+#define BASS_CONFIG_HANDLES 41
+#define BASS_CONFIG_UNICODE 42
+#define BASS_CONFIG_SRC 43
+#define BASS_CONFIG_SRC_SAMPLE 44
 #define BASS_CONFIG_ASYNCFILE_BUFFER 45
-#define BASS_CONFIG_OGG_PRESCAN		47
-#define BASS_CONFIG_MF_VIDEO		48
-#define BASS_CONFIG_AIRPLAY			49
-#define BASS_CONFIG_DEV_NONSTOP		50
-#define BASS_CONFIG_IOS_NOCATEGORY	51
-#define BASS_CONFIG_VERIFY_NET		52
-#define BASS_CONFIG_DEV_PERIOD		53
-#define BASS_CONFIG_FLOAT			54
-#define BASS_CONFIG_NET_SEEK		56
+#define BASS_CONFIG_OGG_PRESCAN 47
+#define BASS_CONFIG_MF_VIDEO 48
+#define BASS_CONFIG_AIRPLAY 49
+#define BASS_CONFIG_DEV_NONSTOP 50
+#define BASS_CONFIG_IOS_NOCATEGORY 51
+#define BASS_CONFIG_VERIFY_NET 52
+#define BASS_CONFIG_DEV_PERIOD 53
+#define BASS_CONFIG_FLOAT 54
+#define BASS_CONFIG_NET_SEEK 56
 
 // BASS_SetConfigPtr options
-#define BASS_CONFIG_NET_AGENT		16
-#define BASS_CONFIG_NET_PROXY		17
-#define BASS_CONFIG_IOS_NOTIFY		46
+#define BASS_CONFIG_NET_AGENT 16
+#define BASS_CONFIG_NET_PROXY 17
+#define BASS_CONFIG_IOS_NOTIFY 46
 
 // BASS_Init flags
-#define BASS_DEVICE_8BITS		1		// 8 bit
-#define BASS_DEVICE_MONO		2		// mono
-#define BASS_DEVICE_3D			4		// enable 3D functionality
-#define BASS_DEVICE_16BITS		8		// limit output to 16 bit
-#define BASS_DEVICE_LATENCY		0x100	// calculate device latency (BASS_INFO struct)
-#define BASS_DEVICE_CPSPEAKERS	0x400	// detect speakers via Windows control panel
-#define BASS_DEVICE_SPEAKERS	0x800	// force enabling of speaker assignment
-#define BASS_DEVICE_NOSPEAKER	0x1000	// ignore speaker arrangement
-#define BASS_DEVICE_DMIX		0x2000	// use ALSA "dmix" plugin
-#define BASS_DEVICE_FREQ		0x4000	// set device sample rate
-#define BASS_DEVICE_STEREO		0x8000	// limit output to stereo
+#define BASS_DEVICE_8BITS 1       // 8 bit
+#define BASS_DEVICE_MONO 2        // mono
+#define BASS_DEVICE_3D 4          // enable 3D functionality
+#define BASS_DEVICE_16BITS 8      // limit output to 16 bit
+#define BASS_DEVICE_LATENCY 0x100 // calculate device latency (BASS_INFO struct)
+#define BASS_DEVICE_CPSPEAKERS                                                 \
+  0x400                            // detect speakers via Windows control panel
+#define BASS_DEVICE_SPEAKERS 0x800 // force enabling of speaker assignment
+#define BASS_DEVICE_NOSPEAKER 0x1000 // ignore speaker arrangement
+#define BASS_DEVICE_DMIX 0x2000      // use ALSA "dmix" plugin
+#define BASS_DEVICE_FREQ 0x4000      // set device sample rate
+#define BASS_DEVICE_STEREO 0x8000    // limit output to stereo
 
 // DirectSound interfaces (for use with BASS_GetDSoundObject)
-#define BASS_OBJECT_DS		1	// IDirectSound
-#define BASS_OBJECT_DS3DL	2	// IDirectSound3DListener
+#define BASS_OBJECT_DS 1    // IDirectSound
+#define BASS_OBJECT_DS3DL 2 // IDirectSound3DListener
 
-// Device info structure
-typedef struct {
-#if defined(_WIN32_WCE) || (WINAPI_FAMILY && WINAPI_FAMILY!=WINAPI_FAMILY_DESKTOP_APP)
-	const wchar_t *name;	// description
-	const wchar_t *driver;	// driver
+  // Device info structure
+  typedef struct
+  {
+#if defined(_WIN32_WCE) ||                                                     \
+    (WINAPI_FAMILY && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+    const wchar_t *name;   // description
+    const wchar_t *driver; // driver
 #else
-	const char *name;	// description
-	const char *driver;	// driver
+  const char *name;     // description
+  const char *driver;   // driver
 #endif
-	DWORD flags;
-} BASS_DEVICEINFO;
+    DWORD flags;
+  } BASS_DEVICEINFO;
 
 // BASS_DEVICEINFO flags
-#define BASS_DEVICE_ENABLED		1
-#define BASS_DEVICE_DEFAULT		2
-#define BASS_DEVICE_INIT		4
+#define BASS_DEVICE_ENABLED 1
+#define BASS_DEVICE_DEFAULT 2
+#define BASS_DEVICE_INIT 4
 
-#define BASS_DEVICE_TYPE_MASK			0xff000000
-#define BASS_DEVICE_TYPE_NETWORK		0x01000000
-#define BASS_DEVICE_TYPE_SPEAKERS		0x02000000
-#define BASS_DEVICE_TYPE_LINE			0x03000000
-#define BASS_DEVICE_TYPE_HEADPHONES		0x04000000
-#define BASS_DEVICE_TYPE_MICROPHONE		0x05000000
-#define BASS_DEVICE_TYPE_HEADSET		0x06000000
-#define BASS_DEVICE_TYPE_HANDSET		0x07000000
-#define BASS_DEVICE_TYPE_DIGITAL		0x08000000
-#define BASS_DEVICE_TYPE_SPDIF			0x09000000
-#define BASS_DEVICE_TYPE_HDMI			0x0a000000
-#define BASS_DEVICE_TYPE_DISPLAYPORT	0x40000000
+#define BASS_DEVICE_TYPE_MASK 0xff000000
+#define BASS_DEVICE_TYPE_NETWORK 0x01000000
+#define BASS_DEVICE_TYPE_SPEAKERS 0x02000000
+#define BASS_DEVICE_TYPE_LINE 0x03000000
+#define BASS_DEVICE_TYPE_HEADPHONES 0x04000000
+#define BASS_DEVICE_TYPE_MICROPHONE 0x05000000
+#define BASS_DEVICE_TYPE_HEADSET 0x06000000
+#define BASS_DEVICE_TYPE_HANDSET 0x07000000
+#define BASS_DEVICE_TYPE_DIGITAL 0x08000000
+#define BASS_DEVICE_TYPE_SPDIF 0x09000000
+#define BASS_DEVICE_TYPE_HDMI 0x0a000000
+#define BASS_DEVICE_TYPE_DISPLAYPORT 0x40000000
 
 // BASS_GetDeviceInfo flags
-#define BASS_DEVICES_AIRPLAY	0x1000000
+#define BASS_DEVICES_AIRPLAY 0x1000000
 
-typedef struct {
-	DWORD flags;	// device capabilities (DSCAPS_xxx flags)
-	DWORD hwsize;	// size of total device hardware memory
-	DWORD hwfree;	// size of free device hardware memory
-	DWORD freesam;	// number of free sample slots in the hardware
-	DWORD free3d;	// number of free 3D sample slots in the hardware
-	DWORD minrate;	// min sample rate supported by the hardware
-	DWORD maxrate;	// max sample rate supported by the hardware
-	BOOL eax;		// device supports EAX? (always FALSE if BASS_DEVICE_3D was not used)
-	DWORD minbuf;	// recommended minimum buffer length in ms (requires BASS_DEVICE_LATENCY)
-	DWORD dsver;	// DirectSound version
-	DWORD latency;	// delay (in ms) before start of playback (requires BASS_DEVICE_LATENCY)
-	DWORD initflags; // BASS_Init "flags" parameter
-	DWORD speakers; // number of speakers available
-	DWORD freq;		// current output rate
-} BASS_INFO;
+  typedef struct
+  {
+    DWORD flags;   // device capabilities (DSCAPS_xxx flags)
+    DWORD hwsize;  // size of total device hardware memory
+    DWORD hwfree;  // size of free device hardware memory
+    DWORD freesam; // number of free sample slots in the hardware
+    DWORD free3d;  // number of free 3D sample slots in the hardware
+    DWORD minrate; // min sample rate supported by the hardware
+    DWORD maxrate; // max sample rate supported by the hardware
+    BOOL eax; // device supports EAX? (always FALSE if BASS_DEVICE_3D was not
+              // used)
+    DWORD minbuf;    // recommended minimum buffer length in ms (requires
+                     // BASS_DEVICE_LATENCY)
+    DWORD dsver;     // DirectSound version
+    DWORD latency;   // delay (in ms) before start of playback (requires
+                     // BASS_DEVICE_LATENCY)
+    DWORD initflags; // BASS_Init "flags" parameter
+    DWORD speakers;  // number of speakers available
+    DWORD freq;      // current output rate
+  } BASS_INFO;
 
 // BASS_INFO flags (from DSOUND.H)
-#define DSCAPS_CONTINUOUSRATE	0x00000010	// supports all sample rates between min/maxrate
-#define DSCAPS_EMULDRIVER		0x00000020	// device does NOT have hardware DirectSound support
-#define DSCAPS_CERTIFIED		0x00000040	// device driver has been certified by Microsoft
-#define DSCAPS_SECONDARYMONO	0x00000100	// mono
-#define DSCAPS_SECONDARYSTEREO	0x00000200	// stereo
-#define DSCAPS_SECONDARY8BIT	0x00000400	// 8 bit
-#define DSCAPS_SECONDARY16BIT	0x00000800	// 16 bit
+#define DSCAPS_CONTINUOUSRATE                                                  \
+  0x00000010 // supports all sample rates between min/maxrate
+#define DSCAPS_EMULDRIVER                                                      \
+  0x00000020 // device does NOT have hardware DirectSound support
+#define DSCAPS_CERTIFIED                                                       \
+  0x00000040 // device driver has been certified by Microsoft
+#define DSCAPS_SECONDARYMONO 0x00000100   // mono
+#define DSCAPS_SECONDARYSTEREO 0x00000200 // stereo
+#define DSCAPS_SECONDARY8BIT 0x00000400   // 8 bit
+#define DSCAPS_SECONDARY16BIT 0x00000800  // 16 bit
 
-// Recording device info structure
-typedef struct {
-	DWORD flags;	// device capabilities (DSCCAPS_xxx flags)
-	DWORD formats;	// supported standard formats (WAVE_FORMAT_xxx flags)
-	DWORD inputs;	// number of inputs
-	BOOL singlein;	// TRUE = only 1 input can be set at a time
-	DWORD freq;		// current input rate
-} BASS_RECORDINFO;
+  // Recording device info structure
+  typedef struct
+  {
+    DWORD flags;   // device capabilities (DSCCAPS_xxx flags)
+    DWORD formats; // supported standard formats (WAVE_FORMAT_xxx flags)
+    DWORD inputs;  // number of inputs
+    BOOL singlein; // TRUE = only 1 input can be set at a time
+    DWORD freq;    // current input rate
+  } BASS_RECORDINFO;
 
 // BASS_RECORDINFO flags (from DSOUND.H)
-#define DSCCAPS_EMULDRIVER		DSCAPS_EMULDRIVER	// device does NOT have hardware DirectSound recording support
-#define DSCCAPS_CERTIFIED		DSCAPS_CERTIFIED	// device driver has been certified by Microsoft
+#define DSCCAPS_EMULDRIVER                                                     \
+  DSCAPS_EMULDRIVER // device does NOT have hardware DirectSound recording
+                    // support
+#define DSCCAPS_CERTIFIED                                                      \
+  DSCAPS_CERTIFIED // device driver has been certified by Microsoft
 
 // defines for formats field of BASS_RECORDINFO (from MMSYSTEM.H)
 #ifndef WAVE_FORMAT_1M08
-#define WAVE_FORMAT_1M08       0x00000001       /* 11.025 kHz, Mono,   8-bit  */
-#define WAVE_FORMAT_1S08       0x00000002       /* 11.025 kHz, Stereo, 8-bit  */
-#define WAVE_FORMAT_1M16       0x00000004       /* 11.025 kHz, Mono,   16-bit */
-#define WAVE_FORMAT_1S16       0x00000008       /* 11.025 kHz, Stereo, 16-bit */
-#define WAVE_FORMAT_2M08       0x00000010       /* 22.05  kHz, Mono,   8-bit  */
-#define WAVE_FORMAT_2S08       0x00000020       /* 22.05  kHz, Stereo, 8-bit  */
-#define WAVE_FORMAT_2M16       0x00000040       /* 22.05  kHz, Mono,   16-bit */
-#define WAVE_FORMAT_2S16       0x00000080       /* 22.05  kHz, Stereo, 16-bit */
-#define WAVE_FORMAT_4M08       0x00000100       /* 44.1   kHz, Mono,   8-bit  */
-#define WAVE_FORMAT_4S08       0x00000200       /* 44.1   kHz, Stereo, 8-bit  */
-#define WAVE_FORMAT_4M16       0x00000400       /* 44.1   kHz, Mono,   16-bit */
-#define WAVE_FORMAT_4S16       0x00000800       /* 44.1   kHz, Stereo, 16-bit */
+#define WAVE_FORMAT_1M08 0x00000001 /* 11.025 kHz, Mono,   8-bit  */
+#define WAVE_FORMAT_1S08 0x00000002 /* 11.025 kHz, Stereo, 8-bit  */
+#define WAVE_FORMAT_1M16 0x00000004 /* 11.025 kHz, Mono,   16-bit */
+#define WAVE_FORMAT_1S16 0x00000008 /* 11.025 kHz, Stereo, 16-bit */
+#define WAVE_FORMAT_2M08 0x00000010 /* 22.05  kHz, Mono,   8-bit  */
+#define WAVE_FORMAT_2S08 0x00000020 /* 22.05  kHz, Stereo, 8-bit  */
+#define WAVE_FORMAT_2M16 0x00000040 /* 22.05  kHz, Mono,   16-bit */
+#define WAVE_FORMAT_2S16 0x00000080 /* 22.05  kHz, Stereo, 16-bit */
+#define WAVE_FORMAT_4M08 0x00000100 /* 44.1   kHz, Mono,   8-bit  */
+#define WAVE_FORMAT_4S08 0x00000200 /* 44.1   kHz, Stereo, 8-bit  */
+#define WAVE_FORMAT_4M16 0x00000400 /* 44.1   kHz, Mono,   16-bit */
+#define WAVE_FORMAT_4S16 0x00000800 /* 44.1   kHz, Stereo, 16-bit */
 #endif
 
-// Sample info structure
-typedef struct {
-	DWORD freq;		// default playback rate
-	float volume;	// default volume (0-1)
-	float pan;		// default pan (-1=left, 0=middle, 1=right)
-	DWORD flags;	// BASS_SAMPLE_xxx flags
-	DWORD length;	// length (in bytes)
-	DWORD max;		// maximum simultaneous playbacks
-	DWORD origres;	// original resolution bits
-	DWORD chans;	// number of channels
-	DWORD mingap;	// minimum gap (ms) between creating channels
-	DWORD mode3d;	// BASS_3DMODE_xxx mode
-	float mindist;	// minimum distance
-	float maxdist;	// maximum distance
-	DWORD iangle;	// angle of inside projection cone
-	DWORD oangle;	// angle of outside projection cone
-	float outvol;	// delta-volume outside the projection cone
-	DWORD vam;		// voice allocation/management flags (BASS_VAM_xxx)
-	DWORD priority;	// priority (0=lowest, 0xffffffff=highest)
-} BASS_SAMPLE;
+  // Sample info structure
+  typedef struct
+  {
+    DWORD freq;     // default playback rate
+    float volume;   // default volume (0-1)
+    float pan;      // default pan (-1=left, 0=middle, 1=right)
+    DWORD flags;    // BASS_SAMPLE_xxx flags
+    DWORD length;   // length (in bytes)
+    DWORD max;      // maximum simultaneous playbacks
+    DWORD origres;  // original resolution bits
+    DWORD chans;    // number of channels
+    DWORD mingap;   // minimum gap (ms) between creating channels
+    DWORD mode3d;   // BASS_3DMODE_xxx mode
+    float mindist;  // minimum distance
+    float maxdist;  // maximum distance
+    DWORD iangle;   // angle of inside projection cone
+    DWORD oangle;   // angle of outside projection cone
+    float outvol;   // delta-volume outside the projection cone
+    DWORD vam;      // voice allocation/management flags (BASS_VAM_xxx)
+    DWORD priority; // priority (0=lowest, 0xffffffff=highest)
+  } BASS_SAMPLE;
 
-#define BASS_SAMPLE_8BITS		1	// 8 bit
-#define BASS_SAMPLE_FLOAT		256	// 32 bit floating-point
-#define BASS_SAMPLE_MONO		2	// mono
-#define BASS_SAMPLE_LOOP		4	// looped
-#define BASS_SAMPLE_3D			8	// 3D functionality
-#define BASS_SAMPLE_SOFTWARE	16	// not using hardware mixing
-#define BASS_SAMPLE_MUTEMAX		32	// mute at max distance (3D only)
-#define BASS_SAMPLE_VAM			64	// DX7 voice allocation & management
-#define BASS_SAMPLE_FX			128	// old implementation of DX8 effects
-#define BASS_SAMPLE_OVER_VOL	0x10000	// override lowest volume
-#define BASS_SAMPLE_OVER_POS	0x20000	// override longest playing
-#define BASS_SAMPLE_OVER_DIST	0x30000 // override furthest from listener (3D only)
+#define BASS_SAMPLE_8BITS 1          // 8 bit
+#define BASS_SAMPLE_FLOAT 256        // 32 bit floating-point
+#define BASS_SAMPLE_MONO 2           // mono
+#define BASS_SAMPLE_LOOP 4           // looped
+#define BASS_SAMPLE_3D 8             // 3D functionality
+#define BASS_SAMPLE_SOFTWARE 16      // not using hardware mixing
+#define BASS_SAMPLE_MUTEMAX 32       // mute at max distance (3D only)
+#define BASS_SAMPLE_VAM 64           // DX7 voice allocation & management
+#define BASS_SAMPLE_FX 128           // old implementation of DX8 effects
+#define BASS_SAMPLE_OVER_VOL 0x10000 // override lowest volume
+#define BASS_SAMPLE_OVER_POS 0x20000 // override longest playing
+#define BASS_SAMPLE_OVER_DIST                                                  \
+  0x30000 // override furthest from listener (3D only)
 
-#define BASS_STREAM_PRESCAN		0x20000 // enable pin-point seeking/length (MP3/MP2/MP1)
-#define BASS_MP3_SETPOS			BASS_STREAM_PRESCAN
-#define BASS_STREAM_AUTOFREE	0x40000	// automatically free the stream when it stop/ends
-#define BASS_STREAM_RESTRATE	0x80000	// restrict the download rate of internet file streams
-#define BASS_STREAM_BLOCK		0x100000 // download/play internet file stream in small blocks
-#define BASS_STREAM_DECODE		0x200000 // don't play the stream, only decode (BASS_ChannelGetData)
-#define BASS_STREAM_STATUS		0x800000 // give server status info (HTTP/ICY tags) in DOWNLOADPROC
+#define BASS_STREAM_PRESCAN                                                    \
+  0x20000 // enable pin-point seeking/length (MP3/MP2/MP1)
+#define BASS_MP3_SETPOS BASS_STREAM_PRESCAN
+#define BASS_STREAM_AUTOFREE                                                   \
+  0x40000 // automatically free the stream when it stop/ends
+#define BASS_STREAM_RESTRATE                                                   \
+  0x80000 // restrict the download rate of internet file streams
+#define BASS_STREAM_BLOCK                                                      \
+  0x100000 // download/play internet file stream in small blocks
+#define BASS_STREAM_DECODE                                                     \
+  0x200000 // don't play the stream, only decode (BASS_ChannelGetData)
+#define BASS_STREAM_STATUS                                                     \
+  0x800000 // give server status info (HTTP/ICY tags) in DOWNLOADPROC
 
-#define BASS_MUSIC_FLOAT		BASS_SAMPLE_FLOAT
-#define BASS_MUSIC_MONO			BASS_SAMPLE_MONO
-#define BASS_MUSIC_LOOP			BASS_SAMPLE_LOOP
-#define BASS_MUSIC_3D			BASS_SAMPLE_3D
-#define BASS_MUSIC_FX			BASS_SAMPLE_FX
-#define BASS_MUSIC_AUTOFREE		BASS_STREAM_AUTOFREE
-#define BASS_MUSIC_DECODE		BASS_STREAM_DECODE
-#define BASS_MUSIC_PRESCAN		BASS_STREAM_PRESCAN	// calculate playback length
-#define BASS_MUSIC_CALCLEN		BASS_MUSIC_PRESCAN
-#define BASS_MUSIC_RAMP			0x200	// normal ramping
-#define BASS_MUSIC_RAMPS		0x400	// sensitive ramping
-#define BASS_MUSIC_SURROUND		0x800	// surround sound
-#define BASS_MUSIC_SURROUND2	0x1000	// surround sound (mode 2)
-#define BASS_MUSIC_FT2PAN		0x2000	// apply FastTracker 2 panning to XM files
-#define BASS_MUSIC_FT2MOD		0x2000	// play .MOD as FastTracker 2 does
-#define BASS_MUSIC_PT1MOD		0x4000	// play .MOD as ProTracker 1 does
-#define BASS_MUSIC_NONINTER		0x10000	// non-interpolated sample mixing
-#define BASS_MUSIC_SINCINTER	0x800000 // sinc interpolated sample mixing
-#define BASS_MUSIC_POSRESET		0x8000	// stop all notes when moving position
-#define BASS_MUSIC_POSRESETEX	0x400000 // stop all notes and reset bmp/etc when moving position
-#define BASS_MUSIC_STOPBACK		0x80000	// stop the music on a backwards jump effect
-#define BASS_MUSIC_NOSAMPLE		0x100000 // don't load the samples
+#define BASS_MUSIC_FLOAT BASS_SAMPLE_FLOAT
+#define BASS_MUSIC_MONO BASS_SAMPLE_MONO
+#define BASS_MUSIC_LOOP BASS_SAMPLE_LOOP
+#define BASS_MUSIC_3D BASS_SAMPLE_3D
+#define BASS_MUSIC_FX BASS_SAMPLE_FX
+#define BASS_MUSIC_AUTOFREE BASS_STREAM_AUTOFREE
+#define BASS_MUSIC_DECODE BASS_STREAM_DECODE
+#define BASS_MUSIC_PRESCAN BASS_STREAM_PRESCAN // calculate playback length
+#define BASS_MUSIC_CALCLEN BASS_MUSIC_PRESCAN
+#define BASS_MUSIC_RAMP 0x200         // normal ramping
+#define BASS_MUSIC_RAMPS 0x400        // sensitive ramping
+#define BASS_MUSIC_SURROUND 0x800     // surround sound
+#define BASS_MUSIC_SURROUND2 0x1000   // surround sound (mode 2)
+#define BASS_MUSIC_FT2PAN 0x2000      // apply FastTracker 2 panning to XM files
+#define BASS_MUSIC_FT2MOD 0x2000      // play .MOD as FastTracker 2 does
+#define BASS_MUSIC_PT1MOD 0x4000      // play .MOD as ProTracker 1 does
+#define BASS_MUSIC_NONINTER 0x10000   // non-interpolated sample mixing
+#define BASS_MUSIC_SINCINTER 0x800000 // sinc interpolated sample mixing
+#define BASS_MUSIC_POSRESET 0x8000    // stop all notes when moving position
+#define BASS_MUSIC_POSRESETEX                                                  \
+  0x400000 // stop all notes and reset bmp/etc when moving position
+#define BASS_MUSIC_STOPBACK 0x80000 // stop the music on a backwards jump effect
+#define BASS_MUSIC_NOSAMPLE 0x100000 // don't load the samples
 
 // Speaker assignment flags
-#define BASS_SPEAKER_FRONT	0x1000000	// front speakers
-#define BASS_SPEAKER_REAR	0x2000000	// rear/side speakers
-#define BASS_SPEAKER_CENLFE	0x3000000	// center & LFE speakers (5.1)
-#define BASS_SPEAKER_REAR2	0x4000000	// rear center speakers (7.1)
-#define BASS_SPEAKER_N(n)	((n)<<24)	// n'th pair of speakers (max 15)
-#define BASS_SPEAKER_LEFT	0x10000000	// modifier: left
-#define BASS_SPEAKER_RIGHT	0x20000000	// modifier: right
-#define BASS_SPEAKER_FRONTLEFT	BASS_SPEAKER_FRONT|BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_FRONTRIGHT	BASS_SPEAKER_FRONT|BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_REARLEFT	BASS_SPEAKER_REAR|BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_REARRIGHT	BASS_SPEAKER_REAR|BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_CENTER		BASS_SPEAKER_CENLFE|BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_LFE		BASS_SPEAKER_CENLFE|BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_REAR2LEFT	BASS_SPEAKER_REAR2|BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_REAR2RIGHT	BASS_SPEAKER_REAR2|BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_FRONT 0x1000000  // front speakers
+#define BASS_SPEAKER_REAR 0x2000000   // rear/side speakers
+#define BASS_SPEAKER_CENLFE 0x3000000 // center & LFE speakers (5.1)
+#define BASS_SPEAKER_REAR2 0x4000000  // rear center speakers (7.1)
+#define BASS_SPEAKER_N(n) ((n) << 24) // n'th pair of speakers (max 15)
+#define BASS_SPEAKER_LEFT 0x10000000  // modifier: left
+#define BASS_SPEAKER_RIGHT 0x20000000 // modifier: right
+#define BASS_SPEAKER_FRONTLEFT BASS_SPEAKER_FRONT | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_FRONTRIGHT BASS_SPEAKER_FRONT | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_REARLEFT BASS_SPEAKER_REAR | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_REARRIGHT BASS_SPEAKER_REAR | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_CENTER BASS_SPEAKER_CENLFE | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_LFE BASS_SPEAKER_CENLFE | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_REAR2LEFT BASS_SPEAKER_REAR2 | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_REAR2RIGHT BASS_SPEAKER_REAR2 | BASS_SPEAKER_RIGHT
 
-#define BASS_ASYNCFILE			0x40000000
-#define BASS_UNICODE			0x80000000
+#define BASS_ASYNCFILE 0x40000000
+#define BASS_UNICODE 0x80000000
 
-#define BASS_RECORD_PAUSE		0x8000	// start recording paused
-#define BASS_RECORD_ECHOCANCEL	0x2000
-#define BASS_RECORD_AGC			0x4000
+#define BASS_RECORD_PAUSE 0x8000 // start recording paused
+#define BASS_RECORD_ECHOCANCEL 0x2000
+#define BASS_RECORD_AGC 0x4000
 
 // DX7 voice allocation & management flags
-#define BASS_VAM_HARDWARE		1
-#define BASS_VAM_SOFTWARE		2
-#define BASS_VAM_TERM_TIME		4
-#define BASS_VAM_TERM_DIST		8
-#define BASS_VAM_TERM_PRIO		16
+#define BASS_VAM_HARDWARE 1
+#define BASS_VAM_SOFTWARE 2
+#define BASS_VAM_TERM_TIME 4
+#define BASS_VAM_TERM_DIST 8
+#define BASS_VAM_TERM_PRIO 16
 
-// Channel info structure
-typedef struct {
-	DWORD freq;		// default playback rate
-	DWORD chans;	// channels
-	DWORD flags;	// BASS_SAMPLE/STREAM/MUSIC/SPEAKER flags
-	DWORD ctype;	// type of channel
-	DWORD origres;	// original resolution
-	HPLUGIN plugin;	// plugin
-	HSAMPLE sample; // sample
-	const char *filename; // filename
-} BASS_CHANNELINFO;
+  // Channel info structure
+  typedef struct
+  {
+    DWORD freq;           // default playback rate
+    DWORD chans;          // channels
+    DWORD flags;          // BASS_SAMPLE/STREAM/MUSIC/SPEAKER flags
+    DWORD ctype;          // type of channel
+    DWORD origres;        // original resolution
+    HPLUGIN plugin;       // plugin
+    HSAMPLE sample;       // sample
+    const char *filename; // filename
+  } BASS_CHANNELINFO;
 
 // BASS_CHANNELINFO types
-#define BASS_CTYPE_SAMPLE		1
-#define BASS_CTYPE_RECORD		2
-#define BASS_CTYPE_STREAM		0x10000
-#define BASS_CTYPE_STREAM_OGG	0x10002
-#define BASS_CTYPE_STREAM_MP1	0x10003
-#define BASS_CTYPE_STREAM_MP2	0x10004
-#define BASS_CTYPE_STREAM_MP3	0x10005
-#define BASS_CTYPE_STREAM_AIFF	0x10006
-#define BASS_CTYPE_STREAM_CA	0x10007
-#define BASS_CTYPE_STREAM_MF	0x10008
-#define BASS_CTYPE_STREAM_WAV	0x40000 // WAVE flag, LOWORD=codec
-#define BASS_CTYPE_STREAM_WAV_PCM	0x50001
-#define BASS_CTYPE_STREAM_WAV_FLOAT	0x50003
-#define BASS_CTYPE_MUSIC_MOD	0x20000
-#define BASS_CTYPE_MUSIC_MTM	0x20001
-#define BASS_CTYPE_MUSIC_S3M	0x20002
-#define BASS_CTYPE_MUSIC_XM		0x20003
-#define BASS_CTYPE_MUSIC_IT		0x20004
-#define BASS_CTYPE_MUSIC_MO3	0x00100 // MO3 flag
+#define BASS_CTYPE_SAMPLE 1
+#define BASS_CTYPE_RECORD 2
+#define BASS_CTYPE_STREAM 0x10000
+#define BASS_CTYPE_STREAM_OGG 0x10002
+#define BASS_CTYPE_STREAM_MP1 0x10003
+#define BASS_CTYPE_STREAM_MP2 0x10004
+#define BASS_CTYPE_STREAM_MP3 0x10005
+#define BASS_CTYPE_STREAM_AIFF 0x10006
+#define BASS_CTYPE_STREAM_CA 0x10007
+#define BASS_CTYPE_STREAM_MF 0x10008
+#define BASS_CTYPE_STREAM_WAV 0x40000 // WAVE flag, LOWORD=codec
+#define BASS_CTYPE_STREAM_WAV_PCM 0x50001
+#define BASS_CTYPE_STREAM_WAV_FLOAT 0x50003
+#define BASS_CTYPE_MUSIC_MOD 0x20000
+#define BASS_CTYPE_MUSIC_MTM 0x20001
+#define BASS_CTYPE_MUSIC_S3M 0x20002
+#define BASS_CTYPE_MUSIC_XM 0x20003
+#define BASS_CTYPE_MUSIC_IT 0x20004
+#define BASS_CTYPE_MUSIC_MO3 0x00100 // MO3 flag
 
-typedef struct {
-	DWORD ctype;		// channel type
-#if defined(_WIN32_WCE) || (WINAPI_FAMILY && WINAPI_FAMILY!=WINAPI_FAMILY_DESKTOP_APP)
-	const wchar_t *name;	// format description
-	const wchar_t *exts;	// file extension filter (*.ext1;*.ext2;etc...)
+  typedef struct
+  {
+    DWORD ctype; // channel type
+#if defined(_WIN32_WCE) ||                                                     \
+    (WINAPI_FAMILY && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+    const wchar_t *name; // format description
+    const wchar_t *exts; // file extension filter (*.ext1;*.ext2;etc...)
 #else
-	const char *name;	// format description
-	const char *exts;	// file extension filter (*.ext1;*.ext2;etc...)
+  const char *name;     // format description
+  const char *exts;     // file extension filter (*.ext1;*.ext2;etc...)
 #endif
-} BASS_PLUGINFORM;
+  } BASS_PLUGINFORM;
 
-typedef struct {
-	DWORD version;					// version (same form as BASS_GetVersion)
-	DWORD formatc;					// number of formats
-	const BASS_PLUGINFORM *formats;	// the array of formats
-} BASS_PLUGININFO;
+  typedef struct
+  {
+    DWORD version;                  // version (same form as BASS_GetVersion)
+    DWORD formatc;                  // number of formats
+    const BASS_PLUGINFORM *formats; // the array of formats
+  } BASS_PLUGININFO;
 
-// 3D vector (for 3D positions/velocities/orientations)
-typedef struct BASS_3DVECTOR {
+  // 3D vector (for 3D positions/velocities/orientations)
+  typedef struct BASS_3DVECTOR
+  {
 #ifdef __cplusplus
-	BASS_3DVECTOR() {};
-	BASS_3DVECTOR(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {};
+    BASS_3DVECTOR(){};
+    BASS_3DVECTOR(float _x, float _y, float _z) : x(_x), y(_y), z(_z){};
 #endif
-	float x;	// +=right, -=left
-	float y;	// +=up, -=down
-	float z;	// +=front, -=behind
-} BASS_3DVECTOR;
+    float x; // +=right, -=left
+    float y; // +=up, -=down
+    float z; // +=front, -=behind
+  } BASS_3DVECTOR;
 
 // 3D channel modes
-#define BASS_3DMODE_NORMAL		0	// normal 3D processing
-#define BASS_3DMODE_RELATIVE	1	// position is relative to the listener
-#define BASS_3DMODE_OFF			2	// no 3D processing
+#define BASS_3DMODE_NORMAL 0   // normal 3D processing
+#define BASS_3DMODE_RELATIVE 1 // position is relative to the listener
+#define BASS_3DMODE_OFF 2      // no 3D processing
 
 // software 3D mixing algorithms (used with BASS_CONFIG_3DALGORITHM)
-#define BASS_3DALG_DEFAULT	0
-#define BASS_3DALG_OFF		1
-#define BASS_3DALG_FULL		2
-#define BASS_3DALG_LIGHT	3
+#define BASS_3DALG_DEFAULT 0
+#define BASS_3DALG_OFF 1
+#define BASS_3DALG_FULL 2
+#define BASS_3DALG_LIGHT 3
 
-// EAX environments, use with BASS_SetEAXParameters
-enum
-{
+  // EAX environments, use with BASS_SetEAXParameters
+  enum
+  {
     EAX_ENVIRONMENT_GENERIC,
     EAX_ENVIRONMENT_PADDEDCELL,
     EAX_ENVIRONMENT_ROOM,
@@ -447,129 +476,135 @@ enum
     EAX_ENVIRONMENT_DIZZY,
     EAX_ENVIRONMENT_PSYCHOTIC,
 
-    EAX_ENVIRONMENT_COUNT			// total number of environments
-};
+    EAX_ENVIRONMENT_COUNT // total number of environments
+  };
 
 // EAX presets, usage: BASS_SetEAXParameters(EAX_PRESET_xxx)
-#define EAX_PRESET_GENERIC         EAX_ENVIRONMENT_GENERIC,0.5F,1.493F,0.5F
-#define EAX_PRESET_PADDEDCELL      EAX_ENVIRONMENT_PADDEDCELL,0.25F,0.1F,0.0F
-#define EAX_PRESET_ROOM            EAX_ENVIRONMENT_ROOM,0.417F,0.4F,0.666F
-#define EAX_PRESET_BATHROOM        EAX_ENVIRONMENT_BATHROOM,0.653F,1.499F,0.166F
-#define EAX_PRESET_LIVINGROOM      EAX_ENVIRONMENT_LIVINGROOM,0.208F,0.478F,0.0F
-#define EAX_PRESET_STONEROOM       EAX_ENVIRONMENT_STONEROOM,0.5F,2.309F,0.888F
-#define EAX_PRESET_AUDITORIUM      EAX_ENVIRONMENT_AUDITORIUM,0.403F,4.279F,0.5F
-#define EAX_PRESET_CONCERTHALL     EAX_ENVIRONMENT_CONCERTHALL,0.5F,3.961F,0.5F
-#define EAX_PRESET_CAVE            EAX_ENVIRONMENT_CAVE,0.5F,2.886F,1.304F
-#define EAX_PRESET_ARENA           EAX_ENVIRONMENT_ARENA,0.361F,7.284F,0.332F
-#define EAX_PRESET_HANGAR          EAX_ENVIRONMENT_HANGAR,0.5F,10.0F,0.3F
-#define EAX_PRESET_CARPETEDHALLWAY EAX_ENVIRONMENT_CARPETEDHALLWAY,0.153F,0.259F,2.0F
-#define EAX_PRESET_HALLWAY         EAX_ENVIRONMENT_HALLWAY,0.361F,1.493F,0.0F
-#define EAX_PRESET_STONECORRIDOR   EAX_ENVIRONMENT_STONECORRIDOR,0.444F,2.697F,0.638F
-#define EAX_PRESET_ALLEY           EAX_ENVIRONMENT_ALLEY,0.25F,1.752F,0.776F
-#define EAX_PRESET_FOREST          EAX_ENVIRONMENT_FOREST,0.111F,3.145F,0.472F
-#define EAX_PRESET_CITY            EAX_ENVIRONMENT_CITY,0.111F,2.767F,0.224F
-#define EAX_PRESET_MOUNTAINS       EAX_ENVIRONMENT_MOUNTAINS,0.194F,7.841F,0.472F
-#define EAX_PRESET_QUARRY          EAX_ENVIRONMENT_QUARRY,1.0F,1.499F,0.5F
-#define EAX_PRESET_PLAIN           EAX_ENVIRONMENT_PLAIN,0.097F,2.767F,0.224F
-#define EAX_PRESET_PARKINGLOT      EAX_ENVIRONMENT_PARKINGLOT,0.208F,1.652F,1.5F
-#define EAX_PRESET_SEWERPIPE       EAX_ENVIRONMENT_SEWERPIPE,0.652F,2.886F,0.25F
-#define EAX_PRESET_UNDERWATER      EAX_ENVIRONMENT_UNDERWATER,1.0F,1.499F,0.0F
-#define EAX_PRESET_DRUGGED         EAX_ENVIRONMENT_DRUGGED,0.875F,8.392F,1.388F
-#define EAX_PRESET_DIZZY           EAX_ENVIRONMENT_DIZZY,0.139F,17.234F,0.666F
-#define EAX_PRESET_PSYCHOTIC       EAX_ENVIRONMENT_PSYCHOTIC,0.486F,7.563F,0.806F
+#define EAX_PRESET_GENERIC EAX_ENVIRONMENT_GENERIC, 0.5F, 1.493F, 0.5F
+#define EAX_PRESET_PADDEDCELL EAX_ENVIRONMENT_PADDEDCELL, 0.25F, 0.1F, 0.0F
+#define EAX_PRESET_ROOM EAX_ENVIRONMENT_ROOM, 0.417F, 0.4F, 0.666F
+#define EAX_PRESET_BATHROOM EAX_ENVIRONMENT_BATHROOM, 0.653F, 1.499F, 0.166F
+#define EAX_PRESET_LIVINGROOM EAX_ENVIRONMENT_LIVINGROOM, 0.208F, 0.478F, 0.0F
+#define EAX_PRESET_STONEROOM EAX_ENVIRONMENT_STONEROOM, 0.5F, 2.309F, 0.888F
+#define EAX_PRESET_AUDITORIUM EAX_ENVIRONMENT_AUDITORIUM, 0.403F, 4.279F, 0.5F
+#define EAX_PRESET_CONCERTHALL EAX_ENVIRONMENT_CONCERTHALL, 0.5F, 3.961F, 0.5F
+#define EAX_PRESET_CAVE EAX_ENVIRONMENT_CAVE, 0.5F, 2.886F, 1.304F
+#define EAX_PRESET_ARENA EAX_ENVIRONMENT_ARENA, 0.361F, 7.284F, 0.332F
+#define EAX_PRESET_HANGAR EAX_ENVIRONMENT_HANGAR, 0.5F, 10.0F, 0.3F
+#define EAX_PRESET_CARPETEDHALLWAY                                             \
+  EAX_ENVIRONMENT_CARPETEDHALLWAY, 0.153F, 0.259F, 2.0F
+#define EAX_PRESET_HALLWAY EAX_ENVIRONMENT_HALLWAY, 0.361F, 1.493F, 0.0F
+#define EAX_PRESET_STONECORRIDOR                                               \
+  EAX_ENVIRONMENT_STONECORRIDOR, 0.444F, 2.697F, 0.638F
+#define EAX_PRESET_ALLEY EAX_ENVIRONMENT_ALLEY, 0.25F, 1.752F, 0.776F
+#define EAX_PRESET_FOREST EAX_ENVIRONMENT_FOREST, 0.111F, 3.145F, 0.472F
+#define EAX_PRESET_CITY EAX_ENVIRONMENT_CITY, 0.111F, 2.767F, 0.224F
+#define EAX_PRESET_MOUNTAINS EAX_ENVIRONMENT_MOUNTAINS, 0.194F, 7.841F, 0.472F
+#define EAX_PRESET_QUARRY EAX_ENVIRONMENT_QUARRY, 1.0F, 1.499F, 0.5F
+#define EAX_PRESET_PLAIN EAX_ENVIRONMENT_PLAIN, 0.097F, 2.767F, 0.224F
+#define EAX_PRESET_PARKINGLOT EAX_ENVIRONMENT_PARKINGLOT, 0.208F, 1.652F, 1.5F
+#define EAX_PRESET_SEWERPIPE EAX_ENVIRONMENT_SEWERPIPE, 0.652F, 2.886F, 0.25F
+#define EAX_PRESET_UNDERWATER EAX_ENVIRONMENT_UNDERWATER, 1.0F, 1.499F, 0.0F
+#define EAX_PRESET_DRUGGED EAX_ENVIRONMENT_DRUGGED, 0.875F, 8.392F, 1.388F
+#define EAX_PRESET_DIZZY EAX_ENVIRONMENT_DIZZY, 0.139F, 17.234F, 0.666F
+#define EAX_PRESET_PSYCHOTIC EAX_ENVIRONMENT_PSYCHOTIC, 0.486F, 7.563F, 0.806F
 
-typedef DWORD (CALLBACK STREAMPROC)(HSTREAM handle, void *buffer, DWORD length, void *user);
-/* User stream callback function. NOTE: A stream function should obviously be as quick
-as possible, other streams (and MOD musics) can't be mixed until it's finished.
-handle : The stream that needs writing
-buffer : Buffer to write the samples in
-length : Number of bytes to write
-user   : The 'user' parameter value given when calling BASS_StreamCreate
-RETURN : Number of bytes written. Set the BASS_STREAMPROC_END flag to end
-         the stream. */
+  typedef DWORD(CALLBACK STREAMPROC)(HSTREAM handle, void *buffer, DWORD length,
+                                     void *user);
+  /* User stream callback function. NOTE: A stream function should obviously be
+  as quick as possible, other streams (and MOD musics) can't be mixed until it's
+  finished. handle : The stream that needs writing buffer : Buffer to write the
+  samples in length : Number of bytes to write user   : The 'user' parameter
+  value given when calling BASS_StreamCreate RETURN : Number of bytes written.
+  Set the BASS_STREAMPROC_END flag to end the stream. */
 
-#define BASS_STREAMPROC_END		0x80000000	// end of user stream flag
+#define BASS_STREAMPROC_END 0x80000000 // end of user stream flag
 
 // special STREAMPROCs
-#define STREAMPROC_DUMMY		(STREAMPROC*)0		// "dummy" stream
-#define STREAMPROC_PUSH			(STREAMPROC*)-1		// push stream
+#define STREAMPROC_DUMMY (STREAMPROC *)0 // "dummy" stream
+#define STREAMPROC_PUSH (STREAMPROC *)-1 // push stream
 
 // BASS_StreamCreateFileUser file systems
-#define STREAMFILE_NOBUFFER		0
-#define STREAMFILE_BUFFER		1
-#define STREAMFILE_BUFFERPUSH	2
+#define STREAMFILE_NOBUFFER 0
+#define STREAMFILE_BUFFER 1
+#define STREAMFILE_BUFFERPUSH 2
 
-// User file stream callback functions
-typedef void (CALLBACK FILECLOSEPROC)(void *user);
-typedef QWORD (CALLBACK FILELENPROC)(void *user);
-typedef DWORD (CALLBACK FILEREADPROC)(void *buffer, DWORD length, void *user);
-typedef BOOL (CALLBACK FILESEEKPROC)(QWORD offset, void *user);
+  // User file stream callback functions
+  typedef void(CALLBACK FILECLOSEPROC)(void *user);
+  typedef QWORD(CALLBACK FILELENPROC)(void *user);
+  typedef DWORD(CALLBACK FILEREADPROC)(void *buffer, DWORD length, void *user);
+  typedef BOOL(CALLBACK FILESEEKPROC)(QWORD offset, void *user);
 
-typedef struct {
-	FILECLOSEPROC *close;
-	FILELENPROC *length;
-	FILEREADPROC *read;
-	FILESEEKPROC *seek;
-} BASS_FILEPROCS;
+  typedef struct
+  {
+    FILECLOSEPROC *close;
+    FILELENPROC *length;
+    FILEREADPROC *read;
+    FILESEEKPROC *seek;
+  } BASS_FILEPROCS;
 
 // BASS_StreamPutFileData options
-#define BASS_FILEDATA_END		0	// end & close the file
+#define BASS_FILEDATA_END 0 // end & close the file
 
 // BASS_StreamGetFilePosition modes
-#define BASS_FILEPOS_CURRENT	0
-#define BASS_FILEPOS_DECODE		BASS_FILEPOS_CURRENT
-#define BASS_FILEPOS_DOWNLOAD	1
-#define BASS_FILEPOS_END		2
-#define BASS_FILEPOS_START		3
-#define BASS_FILEPOS_CONNECTED	4
-#define BASS_FILEPOS_BUFFER		5
-#define BASS_FILEPOS_SOCKET		6
-#define BASS_FILEPOS_ASYNCBUF	7
-#define BASS_FILEPOS_SIZE		8
+#define BASS_FILEPOS_CURRENT 0
+#define BASS_FILEPOS_DECODE BASS_FILEPOS_CURRENT
+#define BASS_FILEPOS_DOWNLOAD 1
+#define BASS_FILEPOS_END 2
+#define BASS_FILEPOS_START 3
+#define BASS_FILEPOS_CONNECTED 4
+#define BASS_FILEPOS_BUFFER 5
+#define BASS_FILEPOS_SOCKET 6
+#define BASS_FILEPOS_ASYNCBUF 7
+#define BASS_FILEPOS_SIZE 8
 
-typedef void (CALLBACK DOWNLOADPROC)(const void *buffer, DWORD length, void *user);
+  typedef void(CALLBACK DOWNLOADPROC)(const void *buffer, DWORD length,
+                                      void *user);
 /* Internet stream download callback function.
 buffer : Buffer containing the downloaded data... NULL=end of download
 length : Number of bytes in the buffer
 user   : The 'user' parameter value given when calling BASS_StreamCreateURL */
 
 // BASS_ChannelSetSync types
-#define BASS_SYNC_POS			0
-#define BASS_SYNC_END			2
-#define BASS_SYNC_META			4
-#define BASS_SYNC_SLIDE			5
-#define BASS_SYNC_STALL			6
-#define BASS_SYNC_DOWNLOAD		7
-#define BASS_SYNC_FREE			8
-#define BASS_SYNC_SETPOS		11
-#define BASS_SYNC_MUSICPOS		10
-#define BASS_SYNC_MUSICINST		1
-#define BASS_SYNC_MUSICFX		3
-#define BASS_SYNC_OGG_CHANGE	12
-#define BASS_SYNC_MIXTIME		0x40000000	// flag: sync at mixtime, else at playtime
-#define BASS_SYNC_ONETIME		0x80000000	// flag: sync only once, else continuously
+#define BASS_SYNC_POS 0
+#define BASS_SYNC_END 2
+#define BASS_SYNC_META 4
+#define BASS_SYNC_SLIDE 5
+#define BASS_SYNC_STALL 6
+#define BASS_SYNC_DOWNLOAD 7
+#define BASS_SYNC_FREE 8
+#define BASS_SYNC_SETPOS 11
+#define BASS_SYNC_MUSICPOS 10
+#define BASS_SYNC_MUSICINST 1
+#define BASS_SYNC_MUSICFX 3
+#define BASS_SYNC_OGG_CHANGE 12
+#define BASS_SYNC_MIXTIME 0x40000000 // flag: sync at mixtime, else at playtime
+#define BASS_SYNC_ONETIME 0x80000000 // flag: sync only once, else continuously
 
-typedef void (CALLBACK SYNCPROC)(HSYNC handle, DWORD channel, DWORD data, void *user);
-/* Sync callback function. NOTE: a sync callback function should be very
-quick as other syncs can't be processed until it has finished. If the sync
-is a "mixtime" sync, then other streams and MOD musics can't be mixed until
-it's finished either.
-handle : The sync that has occured
-channel: Channel that the sync occured in
-data   : Additional data associated with the sync's occurance
-user   : The 'user' parameter given when calling BASS_ChannelSetSync */
+  typedef void(CALLBACK SYNCPROC)(HSYNC handle, DWORD channel, DWORD data,
+                                  void *user);
+  /* Sync callback function. NOTE: a sync callback function should be very
+  quick as other syncs can't be processed until it has finished. If the sync
+  is a "mixtime" sync, then other streams and MOD musics can't be mixed until
+  it's finished either.
+  handle : The sync that has occured
+  channel: Channel that the sync occured in
+  data   : Additional data associated with the sync's occurance
+  user   : The 'user' parameter given when calling BASS_ChannelSetSync */
 
-typedef void (CALLBACK DSPPROC)(HDSP handle, DWORD channel, void *buffer, DWORD length, void *user);
-/* DSP callback function. NOTE: A DSP function should obviously be as quick as
-possible... other DSP functions, streams and MOD musics can not be processed
-until it's finished.
-handle : The DSP handle
-channel: Channel that the DSP is being applied to
-buffer : Buffer to apply the DSP to
-length : Number of bytes in the buffer
-user   : The 'user' parameter given when calling BASS_ChannelSetDSP */
+  typedef void(CALLBACK DSPPROC)(HDSP handle, DWORD channel, void *buffer,
+                                 DWORD length, void *user);
+  /* DSP callback function. NOTE: A DSP function should obviously be as quick as
+  possible... other DSP functions, streams and MOD musics can not be processed
+  until it's finished.
+  handle : The DSP handle
+  channel: Channel that the DSP is being applied to
+  buffer : Buffer to apply the DSP to
+  length : Number of bytes in the buffer
+  user   : The 'user' parameter given when calling BASS_ChannelSetDSP */
 
-typedef BOOL (CALLBACK RECORDPROC)(HRECORD handle, const void *buffer, DWORD length, void *user);
+  typedef BOOL(CALLBACK RECORDPROC)(HRECORD handle, const void *buffer,
+                                    DWORD length, void *user);
 /* Recording callback function.
 handle : The recording handle
 buffer : Buffer containing the recorded sample data
@@ -578,439 +613,504 @@ user   : The 'user' parameter value given when calling BASS_RecordStart
 RETURN : TRUE = continue recording, FALSE = stop */
 
 // BASS_ChannelIsActive return values
-#define BASS_ACTIVE_STOPPED	0
-#define BASS_ACTIVE_PLAYING	1
-#define BASS_ACTIVE_STALLED	2
-#define BASS_ACTIVE_PAUSED	3
+#define BASS_ACTIVE_STOPPED 0
+#define BASS_ACTIVE_PLAYING 1
+#define BASS_ACTIVE_STALLED 2
+#define BASS_ACTIVE_PAUSED 3
 
 // Channel attributes
-#define BASS_ATTRIB_FREQ			1
-#define BASS_ATTRIB_VOL				2
-#define BASS_ATTRIB_PAN				3
-#define BASS_ATTRIB_EAXMIX			4
-#define BASS_ATTRIB_NOBUFFER		5
-#define BASS_ATTRIB_VBR				6
-#define BASS_ATTRIB_CPU				7
-#define BASS_ATTRIB_SRC				8
-#define BASS_ATTRIB_NET_RESUME		9
-#define BASS_ATTRIB_SCANINFO		10
-#define BASS_ATTRIB_NORAMP			11
-#define BASS_ATTRIB_BITRATE			12
-#define BASS_ATTRIB_MUSIC_AMPLIFY	0x100
-#define BASS_ATTRIB_MUSIC_PANSEP	0x101
-#define BASS_ATTRIB_MUSIC_PSCALER	0x102
-#define BASS_ATTRIB_MUSIC_BPM		0x103
-#define BASS_ATTRIB_MUSIC_SPEED		0x104
+#define BASS_ATTRIB_FREQ 1
+#define BASS_ATTRIB_VOL 2
+#define BASS_ATTRIB_PAN 3
+#define BASS_ATTRIB_EAXMIX 4
+#define BASS_ATTRIB_NOBUFFER 5
+#define BASS_ATTRIB_VBR 6
+#define BASS_ATTRIB_CPU 7
+#define BASS_ATTRIB_SRC 8
+#define BASS_ATTRIB_NET_RESUME 9
+#define BASS_ATTRIB_SCANINFO 10
+#define BASS_ATTRIB_NORAMP 11
+#define BASS_ATTRIB_BITRATE 12
+#define BASS_ATTRIB_MUSIC_AMPLIFY 0x100
+#define BASS_ATTRIB_MUSIC_PANSEP 0x101
+#define BASS_ATTRIB_MUSIC_PSCALER 0x102
+#define BASS_ATTRIB_MUSIC_BPM 0x103
+#define BASS_ATTRIB_MUSIC_SPEED 0x104
 #define BASS_ATTRIB_MUSIC_VOL_GLOBAL 0x105
-#define BASS_ATTRIB_MUSIC_ACTIVE	0x106
-#define BASS_ATTRIB_MUSIC_VOL_CHAN	0x200 // + channel #
-#define BASS_ATTRIB_MUSIC_VOL_INST	0x300 // + instrument #
+#define BASS_ATTRIB_MUSIC_ACTIVE 0x106
+#define BASS_ATTRIB_MUSIC_VOL_CHAN 0x200 // + channel #
+#define BASS_ATTRIB_MUSIC_VOL_INST 0x300 // + instrument #
 
 // BASS_ChannelGetData flags
-#define BASS_DATA_AVAILABLE	0			// query how much data is buffered
-#define BASS_DATA_FIXED		0x20000000	// flag: return 8.24 fixed-point data
-#define BASS_DATA_FLOAT		0x40000000	// flag: return floating-point sample data
-#define BASS_DATA_FFT256	0x80000000	// 256 sample FFT
-#define BASS_DATA_FFT512	0x80000001	// 512 FFT
-#define BASS_DATA_FFT1024	0x80000002	// 1024 FFT
-#define BASS_DATA_FFT2048	0x80000003	// 2048 FFT
-#define BASS_DATA_FFT4096	0x80000004	// 4096 FFT
-#define BASS_DATA_FFT8192	0x80000005	// 8192 FFT
-#define BASS_DATA_FFT16384	0x80000006	// 16384 FFT
-#define BASS_DATA_FFT32768	0x80000007	// 32768 FFT
-#define BASS_DATA_FFT_INDIVIDUAL 0x10	// FFT flag: FFT for each channel, else all combined
-#define BASS_DATA_FFT_NOWINDOW	0x20	// FFT flag: no Hanning window
-#define BASS_DATA_FFT_REMOVEDC	0x40	// FFT flag: pre-remove DC bias
-#define BASS_DATA_FFT_COMPLEX	0x80	// FFT flag: return complex data
+#define BASS_DATA_AVAILABLE 0         // query how much data is buffered
+#define BASS_DATA_FIXED 0x20000000    // flag: return 8.24 fixed-point data
+#define BASS_DATA_FLOAT 0x40000000    // flag: return floating-point sample data
+#define BASS_DATA_FFT256 0x80000000   // 256 sample FFT
+#define BASS_DATA_FFT512 0x80000001   // 512 FFT
+#define BASS_DATA_FFT1024 0x80000002  // 1024 FFT
+#define BASS_DATA_FFT2048 0x80000003  // 2048 FFT
+#define BASS_DATA_FFT4096 0x80000004  // 4096 FFT
+#define BASS_DATA_FFT8192 0x80000005  // 8192 FFT
+#define BASS_DATA_FFT16384 0x80000006 // 16384 FFT
+#define BASS_DATA_FFT32768 0x80000007 // 32768 FFT
+#define BASS_DATA_FFT_INDIVIDUAL                                               \
+  0x10 // FFT flag: FFT for each channel, else all combined
+#define BASS_DATA_FFT_NOWINDOW 0x20 // FFT flag: no Hanning window
+#define BASS_DATA_FFT_REMOVEDC 0x40 // FFT flag: pre-remove DC bias
+#define BASS_DATA_FFT_COMPLEX 0x80  // FFT flag: return complex data
 
 // BASS_ChannelGetLevelEx flags
-#define BASS_LEVEL_MONO		1
-#define BASS_LEVEL_STEREO	2
-#define BASS_LEVEL_RMS		4
+#define BASS_LEVEL_MONO 1
+#define BASS_LEVEL_STEREO 2
+#define BASS_LEVEL_RMS 4
 
 // BASS_ChannelGetTags types : what's returned
-#define BASS_TAG_ID3		0	// ID3v1 tags : TAG_ID3 structure
-#define BASS_TAG_ID3V2		1	// ID3v2 tags : variable length block
-#define BASS_TAG_OGG		2	// OGG comments : series of null-terminated UTF-8 strings
-#define BASS_TAG_HTTP		3	// HTTP headers : series of null-terminated ANSI strings
-#define BASS_TAG_ICY		4	// ICY headers : series of null-terminated ANSI strings
-#define BASS_TAG_META		5	// ICY metadata : ANSI string
-#define BASS_TAG_APE		6	// APE tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_MP4 		7	// MP4/iTunes metadata : series of null-terminated UTF-8 strings
-#define BASS_TAG_WMA		8	// WMA tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_VENDOR		9	// OGG encoder : UTF-8 string
-#define BASS_TAG_LYRICS3	10	// Lyric3v2 tag : ASCII string
-#define BASS_TAG_CA_CODEC	11	// CoreAudio codec info : TAG_CA_CODEC structure
-#define BASS_TAG_MF			13	// Media Foundation tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_WAVEFORMAT	14	// WAVE format : WAVEFORMATEEX structure
-#define BASS_TAG_RIFF_INFO	0x100 // RIFF "INFO" tags : series of null-terminated ANSI strings
-#define BASS_TAG_RIFF_BEXT	0x101 // RIFF/BWF "bext" tags : TAG_BEXT structure
-#define BASS_TAG_RIFF_CART	0x102 // RIFF/BWF "cart" tags : TAG_CART structure
-#define BASS_TAG_RIFF_DISP	0x103 // RIFF "DISP" text tag : ANSI string
-#define BASS_TAG_APE_BINARY	0x1000	// + index #, binary APE tag : TAG_APE_BINARY structure
-#define BASS_TAG_MUSIC_NAME		0x10000	// MOD music name : ANSI string
-#define BASS_TAG_MUSIC_MESSAGE	0x10001	// MOD message : ANSI string
-#define BASS_TAG_MUSIC_ORDERS	0x10002	// MOD order list : BYTE array of pattern numbers
-#define BASS_TAG_MUSIC_AUTH		0x10003	// MOD author : UTF-8 string
-#define BASS_TAG_MUSIC_INST		0x10100	// + instrument #, MOD instrument name : ANSI string
-#define BASS_TAG_MUSIC_SAMPLE	0x10300	// + sample #, MOD sample name : ANSI string
+#define BASS_TAG_ID3 0   // ID3v1 tags : TAG_ID3 structure
+#define BASS_TAG_ID3V2 1 // ID3v2 tags : variable length block
+#define BASS_TAG_OGG 2 // OGG comments : series of null-terminated UTF-8 strings
+#define BASS_TAG_HTTP 3 // HTTP headers : series of null-terminated ANSI strings
+#define BASS_TAG_ICY 4  // ICY headers : series of null-terminated ANSI strings
+#define BASS_TAG_META 5 // ICY metadata : ANSI string
+#define BASS_TAG_APE 6  // APE tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_MP4                                                           \
+  7 // MP4/iTunes metadata : series of null-terminated UTF-8 strings
+#define BASS_TAG_WMA 8    // WMA tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_VENDOR 9 // OGG encoder : UTF-8 string
+#define BASS_TAG_LYRICS3 10  // Lyric3v2 tag : ASCII string
+#define BASS_TAG_CA_CODEC 11 // CoreAudio codec info : TAG_CA_CODEC structure
+#define BASS_TAG_MF                                                            \
+  13 // Media Foundation tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_WAVEFORMAT 14 // WAVE format : WAVEFORMATEEX structure
+#define BASS_TAG_RIFF_INFO                                                     \
+  0x100 // RIFF "INFO" tags : series of null-terminated ANSI strings
+#define BASS_TAG_RIFF_BEXT 0x101 // RIFF/BWF "bext" tags : TAG_BEXT structure
+#define BASS_TAG_RIFF_CART 0x102 // RIFF/BWF "cart" tags : TAG_CART structure
+#define BASS_TAG_RIFF_DISP 0x103 // RIFF "DISP" text tag : ANSI string
+#define BASS_TAG_APE_BINARY                                                    \
+  0x1000 // + index #, binary APE tag : TAG_APE_BINARY structure
+#define BASS_TAG_MUSIC_NAME 0x10000    // MOD music name : ANSI string
+#define BASS_TAG_MUSIC_MESSAGE 0x10001 // MOD message : ANSI string
+#define BASS_TAG_MUSIC_ORDERS                                                  \
+  0x10002 // MOD order list : BYTE array of pattern numbers
+#define BASS_TAG_MUSIC_AUTH 0x10003 // MOD author : UTF-8 string
+#define BASS_TAG_MUSIC_INST                                                    \
+  0x10100 // + instrument #, MOD instrument name : ANSI string
+#define BASS_TAG_MUSIC_SAMPLE                                                  \
+  0x10300 // + sample #, MOD sample name : ANSI string
 
-// ID3v1 tag structure
-typedef struct {
-	char id[3];
-	char title[30];
-	char artist[30];
-	char album[30];
-	char year[4];
-	char comment[30];
-	BYTE genre;
-} TAG_ID3;
+  // ID3v1 tag structure
+  typedef struct
+  {
+    char id[3];
+    char title[30];
+    char artist[30];
+    char album[30];
+    char year[4];
+    char comment[30];
+    BYTE genre;
+  } TAG_ID3;
 
-// Binary APE tag structure
-typedef struct {
-	const char *key;
-	const void *data;
-	DWORD length;
-} TAG_APE_BINARY;
+  // Binary APE tag structure
+  typedef struct
+  {
+    const char *key;
+    const void *data;
+    DWORD length;
+  } TAG_APE_BINARY;
 
 // BWF "bext" tag structure
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4200)
+#pragma warning(disable : 4200)
 #endif
-#pragma pack(push,1)
-typedef struct {
-	char Description[256];			// description
-	char Originator[32];			// name of the originator
-	char OriginatorReference[32];	// reference of the originator
-	char OriginationDate[10];		// date of creation (yyyy-mm-dd)
-	char OriginationTime[8];		// time of creation (hh-mm-ss)
-	QWORD TimeReference;			// first sample count since midnight (little-endian)
-	WORD Version;					// BWF version (little-endian)
-	BYTE UMID[64];					// SMPTE UMID
-	BYTE Reserved[190];
-#if defined(__GNUC__) && __GNUC__<3
-	char CodingHistory[0];			// history
-#elif 1 // change to 0 if compiler fails the following line
-	char CodingHistory[];			// history
+#pragma pack(push, 1)
+  typedef struct
+  {
+    char Description[256];        // description
+    char Originator[32];          // name of the originator
+    char OriginatorReference[32]; // reference of the originator
+    char OriginationDate[10];     // date of creation (yyyy-mm-dd)
+    char OriginationTime[8];      // time of creation (hh-mm-ss)
+    QWORD TimeReference; // first sample count since midnight (little-endian)
+    WORD Version;        // BWF version (little-endian)
+    BYTE UMID[64];       // SMPTE UMID
+    BYTE Reserved[190];
+#if defined(__GNUC__) && __GNUC__ < 3
+    char CodingHistory[0]; // history
+#elif 1                    // change to 0 if compiler fails the following line
+  char CodingHistory[]; // history
 #else
-	char CodingHistory[1];			// history
+  char CodingHistory[1]; // history
 #endif
-} TAG_BEXT;
+  } TAG_BEXT;
 #pragma pack(pop)
 
-// BWF "cart" tag structures
-typedef struct
-{
-	DWORD dwUsage;					// FOURCC timer usage ID
-	DWORD dwValue;					// timer value in samples from head
-} TAG_CART_TIMER;
+  // BWF "cart" tag structures
+  typedef struct
+  {
+    DWORD dwUsage; // FOURCC timer usage ID
+    DWORD dwValue; // timer value in samples from head
+  } TAG_CART_TIMER;
 
-typedef struct
-{
-	char Version[4];				// version of the data structure
-	char Title[64];					// title of cart audio sequence
-	char Artist[64];				// artist or creator name
-	char CutID[64];					// cut number identification
-	char ClientID[64];				// client identification
-	char Category[64];				// category ID, PSA, NEWS, etc
-	char Classification[64];		// classification or auxiliary key
-	char OutCue[64];				// out cue text
-	char StartDate[10];				// yyyy-mm-dd
-	char StartTime[8];				// hh:mm:ss
-	char EndDate[10];				// yyyy-mm-dd
-	char EndTime[8];				// hh:mm:ss
-	char ProducerAppID[64];			// name of vendor or application
-	char ProducerAppVersion[64];	// version of producer application
-	char UserDef[64];				// user defined text
-	DWORD dwLevelReference;			// sample value for 0 dB reference
-	TAG_CART_TIMER PostTimer[8];	// 8 time markers after head
-	char Reserved[276];
-	char URL[1024];					// uniform resource locator
-#if defined(__GNUC__) && __GNUC__<3
-	char TagText[0];				// free form text for scripts or tags
-#elif 1 // change to 0 if compiler fails the following line
-	char TagText[];					// free form text for scripts or tags
+  typedef struct
+  {
+    char Version[4];             // version of the data structure
+    char Title[64];              // title of cart audio sequence
+    char Artist[64];             // artist or creator name
+    char CutID[64];              // cut number identification
+    char ClientID[64];           // client identification
+    char Category[64];           // category ID, PSA, NEWS, etc
+    char Classification[64];     // classification or auxiliary key
+    char OutCue[64];             // out cue text
+    char StartDate[10];          // yyyy-mm-dd
+    char StartTime[8];           // hh:mm:ss
+    char EndDate[10];            // yyyy-mm-dd
+    char EndTime[8];             // hh:mm:ss
+    char ProducerAppID[64];      // name of vendor or application
+    char ProducerAppVersion[64]; // version of producer application
+    char UserDef[64];            // user defined text
+    DWORD dwLevelReference;      // sample value for 0 dB reference
+    TAG_CART_TIMER PostTimer[8]; // 8 time markers after head
+    char Reserved[276];
+    char URL[1024]; // uniform resource locator
+#if defined(__GNUC__) && __GNUC__ < 3
+    char TagText[0]; // free form text for scripts or tags
+#elif 1              // change to 0 if compiler fails the following line
+  char TagText[];       // free form text for scripts or tags
 #else
-	char TagText[1];				// free form text for scripts or tags
+  char TagText[1];       // free form text for scripts or tags
 #endif
-} TAG_CART;
+  } TAG_CART;
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-// CoreAudio codec info structure
-typedef struct {
-	DWORD ftype;					// file format
-	DWORD atype;					// audio format
-	const char *name;				// description
-} TAG_CA_CODEC;
+  // CoreAudio codec info structure
+  typedef struct
+  {
+    DWORD ftype;      // file format
+    DWORD atype;      // audio format
+    const char *name; // description
+  } TAG_CA_CODEC;
 
 #ifndef _WAVEFORMATEX_
 #define _WAVEFORMATEX_
-#pragma pack(push,1)
-typedef struct tWAVEFORMATEX
-{
-	WORD wFormatTag;
-	WORD nChannels;
-	DWORD nSamplesPerSec;
-	DWORD nAvgBytesPerSec;
-	WORD nBlockAlign;
-	WORD wBitsPerSample;
-	WORD cbSize;
-} WAVEFORMATEX, *PWAVEFORMATEX, *LPWAVEFORMATEX;
-typedef const WAVEFORMATEX *LPCWAVEFORMATEX;
+#pragma pack(push, 1)
+  typedef struct tWAVEFORMATEX
+  {
+    WORD wFormatTag;
+    WORD nChannels;
+    DWORD nSamplesPerSec;
+    DWORD nAvgBytesPerSec;
+    WORD nBlockAlign;
+    WORD wBitsPerSample;
+    WORD cbSize;
+  } WAVEFORMATEX, *PWAVEFORMATEX, *LPWAVEFORMATEX;
+  typedef const WAVEFORMATEX *LPCWAVEFORMATEX;
 #pragma pack(pop)
 #endif
 
 // BASS_ChannelGetLength/GetPosition/SetPosition modes
-#define BASS_POS_BYTE			0		// byte position
-#define BASS_POS_MUSIC_ORDER	1		// order.row position, MAKELONG(order,row)
-#define BASS_POS_OGG			3		// OGG bitstream number
-#define BASS_POS_INEXACT		0x8000000 // flag: allow seeking to inexact position
-#define BASS_POS_DECODE			0x10000000 // flag: get the decoding (not playing) position
-#define BASS_POS_DECODETO		0x20000000 // flag: decode to the position instead of seeking
-#define BASS_POS_SCAN			0x40000000 // flag: scan to the position
+#define BASS_POS_BYTE 0            // byte position
+#define BASS_POS_MUSIC_ORDER 1     // order.row position, MAKELONG(order,row)
+#define BASS_POS_OGG 3             // OGG bitstream number
+#define BASS_POS_INEXACT 0x8000000 // flag: allow seeking to inexact position
+#define BASS_POS_DECODE                                                        \
+  0x10000000 // flag: get the decoding (not playing) position
+#define BASS_POS_DECODETO                                                      \
+  0x20000000 // flag: decode to the position instead of seeking
+#define BASS_POS_SCAN 0x40000000 // flag: scan to the position
 
 // BASS_RecordSetInput flags
-#define BASS_INPUT_OFF		0x10000
-#define BASS_INPUT_ON		0x20000
+#define BASS_INPUT_OFF 0x10000
+#define BASS_INPUT_ON 0x20000
 
-#define BASS_INPUT_TYPE_MASK		0xff000000
-#define BASS_INPUT_TYPE_UNDEF		0x00000000
-#define BASS_INPUT_TYPE_DIGITAL		0x01000000
-#define BASS_INPUT_TYPE_LINE		0x02000000
-#define BASS_INPUT_TYPE_MIC			0x03000000
-#define BASS_INPUT_TYPE_SYNTH		0x04000000
-#define BASS_INPUT_TYPE_CD			0x05000000
-#define BASS_INPUT_TYPE_PHONE		0x06000000
-#define BASS_INPUT_TYPE_SPEAKER		0x07000000
-#define BASS_INPUT_TYPE_WAVE		0x08000000
-#define BASS_INPUT_TYPE_AUX			0x09000000
-#define BASS_INPUT_TYPE_ANALOG		0x0a000000
+#define BASS_INPUT_TYPE_MASK 0xff000000
+#define BASS_INPUT_TYPE_UNDEF 0x00000000
+#define BASS_INPUT_TYPE_DIGITAL 0x01000000
+#define BASS_INPUT_TYPE_LINE 0x02000000
+#define BASS_INPUT_TYPE_MIC 0x03000000
+#define BASS_INPUT_TYPE_SYNTH 0x04000000
+#define BASS_INPUT_TYPE_CD 0x05000000
+#define BASS_INPUT_TYPE_PHONE 0x06000000
+#define BASS_INPUT_TYPE_SPEAKER 0x07000000
+#define BASS_INPUT_TYPE_WAVE 0x08000000
+#define BASS_INPUT_TYPE_AUX 0x09000000
+#define BASS_INPUT_TYPE_ANALOG 0x0a000000
 
-// DX8 effect types, use with BASS_ChannelSetFX
-enum
-{
-	BASS_FX_DX8_CHORUS,
-	BASS_FX_DX8_COMPRESSOR,
-	BASS_FX_DX8_DISTORTION,
-	BASS_FX_DX8_ECHO,
-	BASS_FX_DX8_FLANGER,
-	BASS_FX_DX8_GARGLE,
-	BASS_FX_DX8_I3DL2REVERB,
-	BASS_FX_DX8_PARAMEQ,
-	BASS_FX_DX8_REVERB
-};
+  // DX8 effect types, use with BASS_ChannelSetFX
+  enum
+  {
+    BASS_FX_DX8_CHORUS,
+    BASS_FX_DX8_COMPRESSOR,
+    BASS_FX_DX8_DISTORTION,
+    BASS_FX_DX8_ECHO,
+    BASS_FX_DX8_FLANGER,
+    BASS_FX_DX8_GARGLE,
+    BASS_FX_DX8_I3DL2REVERB,
+    BASS_FX_DX8_PARAMEQ,
+    BASS_FX_DX8_REVERB
+  };
 
-typedef struct {
-    float       fWetDryMix;
-    float       fDepth;
-    float       fFeedback;
-    float       fFrequency;
-    DWORD       lWaveform;	// 0=triangle, 1=sine
-    float       fDelay;
-    DWORD       lPhase;		// BASS_DX8_PHASE_xxx
-} BASS_DX8_CHORUS;
+  typedef struct
+  {
+    float fWetDryMix;
+    float fDepth;
+    float fFeedback;
+    float fFrequency;
+    DWORD lWaveform; // 0=triangle, 1=sine
+    float fDelay;
+    DWORD lPhase; // BASS_DX8_PHASE_xxx
+  } BASS_DX8_CHORUS;
 
-typedef struct {
-    float   fGain;
-    float   fAttack;
-    float   fRelease;
-    float   fThreshold;
-    float   fRatio;
-    float   fPredelay;
-} BASS_DX8_COMPRESSOR;
+  typedef struct
+  {
+    float fGain;
+    float fAttack;
+    float fRelease;
+    float fThreshold;
+    float fRatio;
+    float fPredelay;
+  } BASS_DX8_COMPRESSOR;
 
-typedef struct {
-    float   fGain;
-    float   fEdge;
-    float   fPostEQCenterFrequency;
-    float   fPostEQBandwidth;
-    float   fPreLowpassCutoff;
-} BASS_DX8_DISTORTION;
+  typedef struct
+  {
+    float fGain;
+    float fEdge;
+    float fPostEQCenterFrequency;
+    float fPostEQBandwidth;
+    float fPreLowpassCutoff;
+  } BASS_DX8_DISTORTION;
 
-typedef struct {
-    float   fWetDryMix;
-    float   fFeedback;
-    float   fLeftDelay;
-    float   fRightDelay;
-    BOOL    lPanDelay;
-} BASS_DX8_ECHO;
+  typedef struct
+  {
+    float fWetDryMix;
+    float fFeedback;
+    float fLeftDelay;
+    float fRightDelay;
+    BOOL lPanDelay;
+  } BASS_DX8_ECHO;
 
-typedef struct {
-    float       fWetDryMix;
-    float       fDepth;
-    float       fFeedback;
-    float       fFrequency;
-    DWORD       lWaveform;	// 0=triangle, 1=sine
-    float       fDelay;
-    DWORD       lPhase;		// BASS_DX8_PHASE_xxx
-} BASS_DX8_FLANGER;
+  typedef struct
+  {
+    float fWetDryMix;
+    float fDepth;
+    float fFeedback;
+    float fFrequency;
+    DWORD lWaveform; // 0=triangle, 1=sine
+    float fDelay;
+    DWORD lPhase; // BASS_DX8_PHASE_xxx
+  } BASS_DX8_FLANGER;
 
-typedef struct {
-    DWORD       dwRateHz;               // Rate of modulation in hz
-    DWORD       dwWaveShape;            // 0=triangle, 1=square
-} BASS_DX8_GARGLE;
+  typedef struct
+  {
+    DWORD dwRateHz;    // Rate of modulation in hz
+    DWORD dwWaveShape; // 0=triangle, 1=square
+  } BASS_DX8_GARGLE;
 
-typedef struct {
-    int     lRoom;                  // [-10000, 0]      default: -1000 mB
-    int     lRoomHF;                // [-10000, 0]      default: 0 mB
-    float   flRoomRolloffFactor;    // [0.0, 10.0]      default: 0.0
-    float   flDecayTime;            // [0.1, 20.0]      default: 1.49s
-    float   flDecayHFRatio;         // [0.1, 2.0]       default: 0.83
-    int     lReflections;           // [-10000, 1000]   default: -2602 mB
-    float   flReflectionsDelay;     // [0.0, 0.3]       default: 0.007 s
-    int     lReverb;                // [-10000, 2000]   default: 200 mB
-    float   flReverbDelay;          // [0.0, 0.1]       default: 0.011 s
-    float   flDiffusion;            // [0.0, 100.0]     default: 100.0 %
-    float   flDensity;              // [0.0, 100.0]     default: 100.0 %
-    float   flHFReference;          // [20.0, 20000.0]  default: 5000.0 Hz
-} BASS_DX8_I3DL2REVERB;
+  typedef struct
+  {
+    int lRoom;                 // [-10000, 0]      default: -1000 mB
+    int lRoomHF;               // [-10000, 0]      default: 0 mB
+    float flRoomRolloffFactor; // [0.0, 10.0]      default: 0.0
+    float flDecayTime;         // [0.1, 20.0]      default: 1.49s
+    float flDecayHFRatio;      // [0.1, 2.0]       default: 0.83
+    int lReflections;          // [-10000, 1000]   default: -2602 mB
+    float flReflectionsDelay;  // [0.0, 0.3]       default: 0.007 s
+    int lReverb;               // [-10000, 2000]   default: 200 mB
+    float flReverbDelay;       // [0.0, 0.1]       default: 0.011 s
+    float flDiffusion;         // [0.0, 100.0]     default: 100.0 %
+    float flDensity;           // [0.0, 100.0]     default: 100.0 %
+    float flHFReference;       // [20.0, 20000.0]  default: 5000.0 Hz
+  } BASS_DX8_I3DL2REVERB;
 
-typedef struct {
-    float   fCenter;
-    float   fBandwidth;
-    float   fGain;
-} BASS_DX8_PARAMEQ;
+  typedef struct
+  {
+    float fCenter;
+    float fBandwidth;
+    float fGain;
+  } BASS_DX8_PARAMEQ;
 
-typedef struct {
-    float   fInGain;                // [-96.0,0.0]            default: 0.0 dB
-    float   fReverbMix;             // [-96.0,0.0]            default: 0.0 db
-    float   fReverbTime;            // [0.001,3000.0]         default: 1000.0 ms
-    float   fHighFreqRTRatio;       // [0.001,0.999]          default: 0.001
-} BASS_DX8_REVERB;
+  typedef struct
+  {
+    float fInGain;          // [-96.0,0.0]            default: 0.0 dB
+    float fReverbMix;       // [-96.0,0.0]            default: 0.0 db
+    float fReverbTime;      // [0.001,3000.0]         default: 1000.0 ms
+    float fHighFreqRTRatio; // [0.001,0.999]          default: 0.001
+  } BASS_DX8_REVERB;
 
-#define BASS_DX8_PHASE_NEG_180        0
-#define BASS_DX8_PHASE_NEG_90         1
-#define BASS_DX8_PHASE_ZERO           2
-#define BASS_DX8_PHASE_90             3
-#define BASS_DX8_PHASE_180            4
+#define BASS_DX8_PHASE_NEG_180 0
+#define BASS_DX8_PHASE_NEG_90 1
+#define BASS_DX8_PHASE_ZERO 2
+#define BASS_DX8_PHASE_90 3
+#define BASS_DX8_PHASE_180 4
 
-typedef void (CALLBACK IOSNOTIFYPROC)(DWORD status);
-/* iOS notification callback function.
-status : The notification (BASS_IOSNOTIFY_xxx) */
+  typedef void(CALLBACK IOSNOTIFYPROC)(DWORD status);
+  /* iOS notification callback function.
+  status : The notification (BASS_IOSNOTIFY_xxx) */
 
-#define BASS_IOSNOTIFY_INTERRUPT		1	// interruption started
-#define BASS_IOSNOTIFY_INTERRUPT_END	2	// interruption ended
+#define BASS_IOSNOTIFY_INTERRUPT 1     // interruption started
+#define BASS_IOSNOTIFY_INTERRUPT_END 2 // interruption ended
 
-BOOL BASSDEF(BASS_SetConfig)(DWORD option, DWORD value);
-DWORD BASSDEF(BASS_GetConfig)(DWORD option);
-BOOL BASSDEF(BASS_SetConfigPtr)(DWORD option, const void *value);
-void *BASSDEF(BASS_GetConfigPtr)(DWORD option);
-DWORD BASSDEF(BASS_GetVersion)();
-int BASSDEF(BASS_ErrorGetCode)();
-BOOL BASSDEF(BASS_GetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !(WINAPI_FAMILY && WINAPI_FAMILY!=WINAPI_FAMILY_DESKTOP_APP)
-BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, HWND win, const GUID *dsguid);
+  BOOL BASSDEF(BASS_SetConfig)(DWORD option, DWORD value);
+  DWORD BASSDEF(BASS_GetConfig)(DWORD option);
+  BOOL BASSDEF(BASS_SetConfigPtr)(DWORD option, const void *value);
+  void *BASSDEF(BASS_GetConfigPtr)(DWORD option);
+  DWORD BASSDEF(BASS_GetVersion)();
+  int BASSDEF(BASS_ErrorGetCode)();
+  BOOL BASSDEF(BASS_GetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
+#if defined(_WIN32) && !defined(_WIN32_WCE) &&                                 \
+    !(WINAPI_FAMILY && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+  BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, HWND win,
+                          const GUID *dsguid);
 #else
-BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, void *win, void *dsguid);
+BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, void *win,
+                        void *dsguid);
 #endif
-BOOL BASSDEF(BASS_SetDevice)(DWORD device);
-DWORD BASSDEF(BASS_GetDevice)();
-BOOL BASSDEF(BASS_Free)();
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !(WINAPI_FAMILY && WINAPI_FAMILY!=WINAPI_FAMILY_DESKTOP_APP)
-void *BASSDEF(BASS_GetDSoundObject)(DWORD object);
+  BOOL BASSDEF(BASS_SetDevice)(DWORD device);
+  DWORD BASSDEF(BASS_GetDevice)();
+  BOOL BASSDEF(BASS_Free)();
+#if defined(_WIN32) && !defined(_WIN32_WCE) &&                                 \
+    !(WINAPI_FAMILY && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+  void *BASSDEF(BASS_GetDSoundObject)(DWORD object);
 #endif
-BOOL BASSDEF(BASS_GetInfo)(BASS_INFO *info);
-BOOL BASSDEF(BASS_Update)(DWORD length);
-float BASSDEF(BASS_GetCPU)();
-BOOL BASSDEF(BASS_Start)();
-BOOL BASSDEF(BASS_Stop)();
-BOOL BASSDEF(BASS_Pause)();
-BOOL BASSDEF(BASS_SetVolume)(float volume);
-float BASSDEF(BASS_GetVolume)();
+  BOOL BASSDEF(BASS_GetInfo)(BASS_INFO *info);
+  BOOL BASSDEF(BASS_Update)(DWORD length);
+  float BASSDEF(BASS_GetCPU)();
+  BOOL BASSDEF(BASS_Start)();
+  BOOL BASSDEF(BASS_Stop)();
+  BOOL BASSDEF(BASS_Pause)();
+  BOOL BASSDEF(BASS_SetVolume)(float volume);
+  float BASSDEF(BASS_GetVolume)();
 
-HPLUGIN BASSDEF(BASS_PluginLoad)(const char *file, DWORD flags);
-BOOL BASSDEF(BASS_PluginFree)(HPLUGIN handle);
-const BASS_PLUGININFO *BASSDEF(BASS_PluginGetInfo)(HPLUGIN handle);
+  HPLUGIN BASSDEF(BASS_PluginLoad)(const char *file, DWORD flags);
+  BOOL BASSDEF(BASS_PluginFree)(HPLUGIN handle);
+  const BASS_PLUGININFO *BASSDEF(BASS_PluginGetInfo)(HPLUGIN handle);
 
-BOOL BASSDEF(BASS_Set3DFactors)(float distf, float rollf, float doppf);
-BOOL BASSDEF(BASS_Get3DFactors)(float *distf, float *rollf, float *doppf);
-BOOL BASSDEF(BASS_Set3DPosition)(const BASS_3DVECTOR *pos, const BASS_3DVECTOR *vel, const BASS_3DVECTOR *front, const BASS_3DVECTOR *top);
-BOOL BASSDEF(BASS_Get3DPosition)(BASS_3DVECTOR *pos, BASS_3DVECTOR *vel, BASS_3DVECTOR *front, BASS_3DVECTOR *top);
-void BASSDEF(BASS_Apply3D)();
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !(WINAPI_FAMILY && WINAPI_FAMILY!=WINAPI_FAMILY_DESKTOP_APP)
-BOOL BASSDEF(BASS_SetEAXParameters)(int env, float vol, float decay, float damp);
-BOOL BASSDEF(BASS_GetEAXParameters)(DWORD *env, float *vol, float *decay, float *damp);
+  BOOL BASSDEF(BASS_Set3DFactors)(float distf, float rollf, float doppf);
+  BOOL BASSDEF(BASS_Get3DFactors)(float *distf, float *rollf, float *doppf);
+  BOOL BASSDEF(BASS_Set3DPosition)(const BASS_3DVECTOR *pos,
+                                   const BASS_3DVECTOR *vel,
+                                   const BASS_3DVECTOR *front,
+                                   const BASS_3DVECTOR *top);
+  BOOL BASSDEF(BASS_Get3DPosition)(BASS_3DVECTOR *pos, BASS_3DVECTOR *vel,
+                                   BASS_3DVECTOR *front, BASS_3DVECTOR *top);
+  void BASSDEF(BASS_Apply3D)();
+#if defined(_WIN32) && !defined(_WIN32_WCE) &&                                 \
+    !(WINAPI_FAMILY && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+  BOOL BASSDEF(BASS_SetEAXParameters)(int env, float vol, float decay,
+                                      float damp);
+  BOOL BASSDEF(BASS_GetEAXParameters)(DWORD *env, float *vol, float *decay,
+                                      float *damp);
 #endif
 
-HMUSIC BASSDEF(BASS_MusicLoad)(BOOL mem, const void *file, QWORD offset, DWORD length, DWORD flags, DWORD freq);
-BOOL BASSDEF(BASS_MusicFree)(HMUSIC handle);
+  HMUSIC BASSDEF(BASS_MusicLoad)(BOOL mem, const void *file, QWORD offset,
+                                 DWORD length, DWORD flags, DWORD freq);
+  BOOL BASSDEF(BASS_MusicFree)(HMUSIC handle);
 
-HSAMPLE BASSDEF(BASS_SampleLoad)(BOOL mem, const void *file, QWORD offset, DWORD length, DWORD max, DWORD flags);
-HSAMPLE BASSDEF(BASS_SampleCreate)(DWORD length, DWORD freq, DWORD chans, DWORD max, DWORD flags);
-BOOL BASSDEF(BASS_SampleFree)(HSAMPLE handle);
-BOOL BASSDEF(BASS_SampleSetData)(HSAMPLE handle, const void *buffer);
-BOOL BASSDEF(BASS_SampleGetData)(HSAMPLE handle, void *buffer);
-BOOL BASSDEF(BASS_SampleGetInfo)(HSAMPLE handle, BASS_SAMPLE *info);
-BOOL BASSDEF(BASS_SampleSetInfo)(HSAMPLE handle, const BASS_SAMPLE *info);
-HCHANNEL BASSDEF(BASS_SampleGetChannel)(HSAMPLE handle, BOOL onlynew);
-DWORD BASSDEF(BASS_SampleGetChannels)(HSAMPLE handle, HCHANNEL *channels);
-BOOL BASSDEF(BASS_SampleStop)(HSAMPLE handle);
+  HSAMPLE BASSDEF(BASS_SampleLoad)(BOOL mem, const void *file, QWORD offset,
+                                   DWORD length, DWORD max, DWORD flags);
+  HSAMPLE BASSDEF(BASS_SampleCreate)(DWORD length, DWORD freq, DWORD chans,
+                                     DWORD max, DWORD flags);
+  BOOL BASSDEF(BASS_SampleFree)(HSAMPLE handle);
+  BOOL BASSDEF(BASS_SampleSetData)(HSAMPLE handle, const void *buffer);
+  BOOL BASSDEF(BASS_SampleGetData)(HSAMPLE handle, void *buffer);
+  BOOL BASSDEF(BASS_SampleGetInfo)(HSAMPLE handle, BASS_SAMPLE *info);
+  BOOL BASSDEF(BASS_SampleSetInfo)(HSAMPLE handle, const BASS_SAMPLE *info);
+  HCHANNEL BASSDEF(BASS_SampleGetChannel)(HSAMPLE handle, BOOL onlynew);
+  DWORD BASSDEF(BASS_SampleGetChannels)(HSAMPLE handle, HCHANNEL *channels);
+  BOOL BASSDEF(BASS_SampleStop)(HSAMPLE handle);
 
-HSTREAM BASSDEF(BASS_StreamCreate)(DWORD freq, DWORD chans, DWORD flags, STREAMPROC *proc, void *user);
-HSTREAM BASSDEF(BASS_StreamCreateFile)(BOOL mem, const void *file, QWORD offset, QWORD length, DWORD flags);
-HSTREAM BASSDEF(BASS_StreamCreateURL)(const char *url, DWORD offset, DWORD flags, DOWNLOADPROC *proc, void *user);
-HSTREAM BASSDEF(BASS_StreamCreateFileUser)(DWORD system, DWORD flags, const BASS_FILEPROCS *proc, void *user);
-BOOL BASSDEF(BASS_StreamFree)(HSTREAM handle);
-QWORD BASSDEF(BASS_StreamGetFilePosition)(HSTREAM handle, DWORD mode);
-DWORD BASSDEF(BASS_StreamPutData)(HSTREAM handle, const void *buffer, DWORD length);
-DWORD BASSDEF(BASS_StreamPutFileData)(HSTREAM handle, const void *buffer, DWORD length);
+  HSTREAM BASSDEF(BASS_StreamCreate)(DWORD freq, DWORD chans, DWORD flags,
+                                     STREAMPROC *proc, void *user);
+  HSTREAM BASSDEF(BASS_StreamCreateFile)(BOOL mem, const void *file,
+                                         QWORD offset, QWORD length,
+                                         DWORD flags);
+  HSTREAM BASSDEF(BASS_StreamCreateURL)(const char *url, DWORD offset,
+                                        DWORD flags, DOWNLOADPROC *proc,
+                                        void *user);
+  HSTREAM BASSDEF(BASS_StreamCreateFileUser)(DWORD system, DWORD flags,
+                                             const BASS_FILEPROCS *proc,
+                                             void *user);
+  BOOL BASSDEF(BASS_StreamFree)(HSTREAM handle);
+  QWORD BASSDEF(BASS_StreamGetFilePosition)(HSTREAM handle, DWORD mode);
+  DWORD BASSDEF(BASS_StreamPutData)(HSTREAM handle, const void *buffer,
+                                    DWORD length);
+  DWORD BASSDEF(BASS_StreamPutFileData)(HSTREAM handle, const void *buffer,
+                                        DWORD length);
 
-BOOL BASSDEF(BASS_RecordGetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
-BOOL BASSDEF(BASS_RecordInit)(int device);
-BOOL BASSDEF(BASS_RecordSetDevice)(DWORD device);
-DWORD BASSDEF(BASS_RecordGetDevice)();
-BOOL BASSDEF(BASS_RecordFree)();
-BOOL BASSDEF(BASS_RecordGetInfo)(BASS_RECORDINFO *info);
-const char *BASSDEF(BASS_RecordGetInputName)(int input);
-BOOL BASSDEF(BASS_RecordSetInput)(int input, DWORD flags, float volume);
-DWORD BASSDEF(BASS_RecordGetInput)(int input, float *volume);
-HRECORD BASSDEF(BASS_RecordStart)(DWORD freq, DWORD chans, DWORD flags, RECORDPROC *proc, void *user);
+  BOOL BASSDEF(BASS_RecordGetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
+  BOOL BASSDEF(BASS_RecordInit)(int device);
+  BOOL BASSDEF(BASS_RecordSetDevice)(DWORD device);
+  DWORD BASSDEF(BASS_RecordGetDevice)();
+  BOOL BASSDEF(BASS_RecordFree)();
+  BOOL BASSDEF(BASS_RecordGetInfo)(BASS_RECORDINFO *info);
+  const char *BASSDEF(BASS_RecordGetInputName)(int input);
+  BOOL BASSDEF(BASS_RecordSetInput)(int input, DWORD flags, float volume);
+  DWORD BASSDEF(BASS_RecordGetInput)(int input, float *volume);
+  HRECORD BASSDEF(BASS_RecordStart)(DWORD freq, DWORD chans, DWORD flags,
+                                    RECORDPROC *proc, void *user);
 
-double BASSDEF(BASS_ChannelBytes2Seconds)(DWORD handle, QWORD pos);
-QWORD BASSDEF(BASS_ChannelSeconds2Bytes)(DWORD handle, double pos);
-DWORD BASSDEF(BASS_ChannelGetDevice)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelSetDevice)(DWORD handle, DWORD device);
-DWORD BASSDEF(BASS_ChannelIsActive)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelGetInfo)(DWORD handle, BASS_CHANNELINFO *info);
-const char *BASSDEF(BASS_ChannelGetTags)(DWORD handle, DWORD tags);
-DWORD BASSDEF(BASS_ChannelFlags)(DWORD handle, DWORD flags, DWORD mask);
-BOOL BASSDEF(BASS_ChannelUpdate)(DWORD handle, DWORD length);
-BOOL BASSDEF(BASS_ChannelLock)(DWORD handle, BOOL lock);
-BOOL BASSDEF(BASS_ChannelPlay)(DWORD handle, BOOL restart);
-BOOL BASSDEF(BASS_ChannelStop)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelPause)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelSetAttribute)(DWORD handle, DWORD attrib, float value);
-BOOL BASSDEF(BASS_ChannelGetAttribute)(DWORD handle, DWORD attrib, float *value);
-BOOL BASSDEF(BASS_ChannelSlideAttribute)(DWORD handle, DWORD attrib, float value, DWORD time);
-BOOL BASSDEF(BASS_ChannelIsSliding)(DWORD handle, DWORD attrib);
-BOOL BASSDEF(BASS_ChannelSetAttributeEx)(DWORD handle, DWORD attrib, void *value, DWORD size);
-DWORD BASSDEF(BASS_ChannelGetAttributeEx)(DWORD handle, DWORD attrib, void *value, DWORD size);
-BOOL BASSDEF(BASS_ChannelSet3DAttributes)(DWORD handle, int mode, float min, float max, int iangle, int oangle, float outvol);
-BOOL BASSDEF(BASS_ChannelGet3DAttributes)(DWORD handle, DWORD *mode, float *min, float *max, DWORD *iangle, DWORD *oangle, float *outvol);
-BOOL BASSDEF(BASS_ChannelSet3DPosition)(DWORD handle, const BASS_3DVECTOR *pos, const BASS_3DVECTOR *orient, const BASS_3DVECTOR *vel);
-BOOL BASSDEF(BASS_ChannelGet3DPosition)(DWORD handle, BASS_3DVECTOR *pos, BASS_3DVECTOR *orient, BASS_3DVECTOR *vel);
-QWORD BASSDEF(BASS_ChannelGetLength)(DWORD handle, DWORD mode);
-BOOL BASSDEF(BASS_ChannelSetPosition)(DWORD handle, QWORD pos, DWORD mode);
-QWORD BASSDEF(BASS_ChannelGetPosition)(DWORD handle, DWORD mode);
-DWORD BASSDEF(BASS_ChannelGetLevel)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelGetLevelEx)(DWORD handle, float *levels, float length, DWORD flags);
-DWORD BASSDEF(BASS_ChannelGetData)(DWORD handle, void *buffer, DWORD length);
-HSYNC BASSDEF(BASS_ChannelSetSync)(DWORD handle, DWORD type, QWORD param, SYNCPROC *proc, void *user);
-BOOL BASSDEF(BASS_ChannelRemoveSync)(DWORD handle, HSYNC sync);
-HDSP BASSDEF(BASS_ChannelSetDSP)(DWORD handle, DSPPROC *proc, void *user, int priority);
-BOOL BASSDEF(BASS_ChannelRemoveDSP)(DWORD handle, HDSP dsp);
-BOOL BASSDEF(BASS_ChannelSetLink)(DWORD handle, DWORD chan);
-BOOL BASSDEF(BASS_ChannelRemoveLink)(DWORD handle, DWORD chan);
-HFX BASSDEF(BASS_ChannelSetFX)(DWORD handle, DWORD type, int priority);
-BOOL BASSDEF(BASS_ChannelRemoveFX)(DWORD handle, HFX fx);
+  double BASSDEF(BASS_ChannelBytes2Seconds)(DWORD handle, QWORD pos);
+  QWORD BASSDEF(BASS_ChannelSeconds2Bytes)(DWORD handle, double pos);
+  DWORD BASSDEF(BASS_ChannelGetDevice)(DWORD handle);
+  BOOL BASSDEF(BASS_ChannelSetDevice)(DWORD handle, DWORD device);
+  DWORD BASSDEF(BASS_ChannelIsActive)(DWORD handle);
+  BOOL BASSDEF(BASS_ChannelGetInfo)(DWORD handle, BASS_CHANNELINFO *info);
+  const char *BASSDEF(BASS_ChannelGetTags)(DWORD handle, DWORD tags);
+  DWORD BASSDEF(BASS_ChannelFlags)(DWORD handle, DWORD flags, DWORD mask);
+  BOOL BASSDEF(BASS_ChannelUpdate)(DWORD handle, DWORD length);
+  BOOL BASSDEF(BASS_ChannelLock)(DWORD handle, BOOL lock);
+  BOOL BASSDEF(BASS_ChannelPlay)(DWORD handle, BOOL restart);
+  BOOL BASSDEF(BASS_ChannelStop)(DWORD handle);
+  BOOL BASSDEF(BASS_ChannelPause)(DWORD handle);
+  BOOL BASSDEF(BASS_ChannelSetAttribute)(DWORD handle, DWORD attrib,
+                                         float value);
+  BOOL BASSDEF(BASS_ChannelGetAttribute)(DWORD handle, DWORD attrib,
+                                         float *value);
+  BOOL BASSDEF(BASS_ChannelSlideAttribute)(DWORD handle, DWORD attrib,
+                                           float value, DWORD time);
+  BOOL BASSDEF(BASS_ChannelIsSliding)(DWORD handle, DWORD attrib);
+  BOOL BASSDEF(BASS_ChannelSetAttributeEx)(DWORD handle, DWORD attrib,
+                                           void *value, DWORD size);
+  DWORD BASSDEF(BASS_ChannelGetAttributeEx)(DWORD handle, DWORD attrib,
+                                            void *value, DWORD size);
+  BOOL BASSDEF(BASS_ChannelSet3DAttributes)(DWORD handle, int mode, float min,
+                                            float max, int iangle, int oangle,
+                                            float outvol);
+  BOOL BASSDEF(BASS_ChannelGet3DAttributes)(DWORD handle, DWORD *mode,
+                                            float *min, float *max,
+                                            DWORD *iangle, DWORD *oangle,
+                                            float *outvol);
+  BOOL BASSDEF(BASS_ChannelSet3DPosition)(DWORD handle,
+                                          const BASS_3DVECTOR *pos,
+                                          const BASS_3DVECTOR *orient,
+                                          const BASS_3DVECTOR *vel);
+  BOOL BASSDEF(BASS_ChannelGet3DPosition)(DWORD handle, BASS_3DVECTOR *pos,
+                                          BASS_3DVECTOR *orient,
+                                          BASS_3DVECTOR *vel);
+  QWORD BASSDEF(BASS_ChannelGetLength)(DWORD handle, DWORD mode);
+  BOOL BASSDEF(BASS_ChannelSetPosition)(DWORD handle, QWORD pos, DWORD mode);
+  QWORD BASSDEF(BASS_ChannelGetPosition)(DWORD handle, DWORD mode);
+  DWORD BASSDEF(BASS_ChannelGetLevel)(DWORD handle);
+  BOOL BASSDEF(BASS_ChannelGetLevelEx)(DWORD handle, float *levels,
+                                       float length, DWORD flags);
+  DWORD BASSDEF(BASS_ChannelGetData)(DWORD handle, void *buffer, DWORD length);
+  HSYNC BASSDEF(BASS_ChannelSetSync)(DWORD handle, DWORD type, QWORD param,
+                                     SYNCPROC *proc, void *user);
+  BOOL BASSDEF(BASS_ChannelRemoveSync)(DWORD handle, HSYNC sync);
+  HDSP BASSDEF(BASS_ChannelSetDSP)(DWORD handle, DSPPROC *proc, void *user,
+                                   int priority);
+  BOOL BASSDEF(BASS_ChannelRemoveDSP)(DWORD handle, HDSP dsp);
+  BOOL BASSDEF(BASS_ChannelSetLink)(DWORD handle, DWORD chan);
+  BOOL BASSDEF(BASS_ChannelRemoveLink)(DWORD handle, DWORD chan);
+  HFX BASSDEF(BASS_ChannelSetFX)(DWORD handle, DWORD type, int priority);
+  BOOL BASSDEF(BASS_ChannelRemoveFX)(DWORD handle, HFX fx);
 
-BOOL BASSDEF(BASS_FXSetParameters)(HFX handle, const void *params);
-BOOL BASSDEF(BASS_FXGetParameters)(HFX handle, void *params);
-BOOL BASSDEF(BASS_FXReset)(HFX handle);
-BOOL BASSDEF(BASS_FXSetPriority)(HFX handle, int priority);
+  BOOL BASSDEF(BASS_FXSetParameters)(HFX handle, const void *params);
+  BOOL BASSDEF(BASS_FXGetParameters)(HFX handle, void *params);
+  BOOL BASSDEF(BASS_FXReset)(HFX handle);
+  BOOL BASSDEF(BASS_FXSetPriority)(HFX handle, int priority);
 
 #ifdef __cplusplus
 }
@@ -1018,32 +1118,42 @@ BOOL BASSDEF(BASS_FXSetPriority)(HFX handle, int priority);
 #if defined(_WIN32) && !defined(NOBASSOVERLOADS)
 static inline HPLUGIN BASS_PluginLoad(const WCHAR *file, DWORD flags)
 {
-	return BASS_PluginLoad((const char*)file, flags|BASS_UNICODE);
+  return BASS_PluginLoad((const char *)file, flags | BASS_UNICODE);
 }
 
-static inline HMUSIC BASS_MusicLoad(BOOL mem, const WCHAR *file, QWORD offset, DWORD length, DWORD flags, DWORD freq)
+static inline HMUSIC BASS_MusicLoad(BOOL mem, const WCHAR *file, QWORD offset,
+                                    DWORD length, DWORD flags, DWORD freq)
 {
-	return BASS_MusicLoad(mem, (const void*)file, offset, length, flags|BASS_UNICODE, freq);
+  return BASS_MusicLoad(mem, (const void *)file, offset, length,
+                        flags | BASS_UNICODE, freq);
 }
 
-static inline HSAMPLE BASS_SampleLoad(BOOL mem, const WCHAR *file, QWORD offset, DWORD length, DWORD max, DWORD flags)
+static inline HSAMPLE BASS_SampleLoad(BOOL mem, const WCHAR *file, QWORD offset,
+                                      DWORD length, DWORD max, DWORD flags)
 {
-	return BASS_SampleLoad(mem, (const void*)file, offset, length, max, flags|BASS_UNICODE);
+  return BASS_SampleLoad(mem, (const void *)file, offset, length, max,
+                         flags | BASS_UNICODE);
 }
 
-static inline HSTREAM BASS_StreamCreateFile(BOOL mem, const WCHAR *file, QWORD offset, QWORD length, DWORD flags)
+static inline HSTREAM BASS_StreamCreateFile(BOOL mem, const WCHAR *file,
+                                            QWORD offset, QWORD length,
+                                            DWORD flags)
 {
-	return BASS_StreamCreateFile(mem, (const void*)file, offset, length, flags|BASS_UNICODE);
+  return BASS_StreamCreateFile(mem, (const void *)file, offset, length,
+                               flags | BASS_UNICODE);
 }
 
-static inline HSTREAM BASS_StreamCreateURL(const WCHAR *url, DWORD offset, DWORD flags, DOWNLOADPROC *proc, void *user)
+static inline HSTREAM BASS_StreamCreateURL(const WCHAR *url, DWORD offset,
+                                           DWORD flags, DOWNLOADPROC *proc,
+                                           void *user)
 {
-	return BASS_StreamCreateURL((const char*)url, offset, flags|BASS_UNICODE, proc, user);
+  return BASS_StreamCreateURL((const char *)url, offset, flags | BASS_UNICODE,
+                              proc, user);
 }
 
 static inline BOOL BASS_SetConfigPtr(DWORD option, const WCHAR *value)
 {
-	return BASS_SetConfigPtr(option|BASS_UNICODE, (const void*)value);
+  return BASS_SetConfigPtr(option | BASS_UNICODE, (const void *)value);
 }
 #endif
 #endif

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -209,4 +209,7 @@ void Courtroom::char_mouse_entered(AOCharButton *p_caller)
   ui_char_button_selector->show();
 }
 
-void Courtroom::char_mouse_left() { ui_char_button_selector->hide(); }
+void Courtroom::char_mouse_left()
+{
+  ui_char_button_selector->hide();
+}

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -7,195 +7,209 @@
 
 void Courtroom::construct_char_select()
 {
-    ui_char_select_background = new AOImage(this, ao_app);
+  ui_char_select_background = new AOImage(this, ao_app);
 
-    ui_char_buttons = new QWidget(ui_char_select_background);
+  ui_char_buttons = new QWidget(ui_char_select_background);
 
-    ui_char_button_selector = new AOImage(ui_char_buttons, ao_app);
-    ui_char_button_selector->setAttribute(Qt::WA_TransparentForMouseEvents);
-    ui_char_button_selector->resize(62, 62);
+  ui_char_button_selector = new AOImage(ui_char_buttons, ao_app);
+  ui_char_button_selector->setAttribute(Qt::WA_TransparentForMouseEvents);
+  ui_char_button_selector->resize(62, 62);
 
-    ui_back_to_lobby = new AOButton(ui_char_select_background, ao_app);
+  ui_back_to_lobby = new AOButton(ui_char_select_background, ao_app);
 
-    ui_char_select_left  = new AOButton(ui_char_select_background, ao_app);
-    ui_char_select_right = new AOButton(ui_char_select_background, ao_app);
+  ui_char_select_left = new AOButton(ui_char_select_background, ao_app);
+  ui_char_select_right = new AOButton(ui_char_select_background, ao_app);
 
-    ui_spectator = new AOButton(ui_char_select_background, ao_app);
-    ui_spectator->setText("Spectator");
+  ui_spectator = new AOButton(ui_char_select_background, ao_app);
+  ui_spectator->setText("Spectator");
 
-    connect(char_button_mapper, SIGNAL(mapped(int)), this, SLOT(char_clicked(int)));
-    connect(ui_back_to_lobby, SIGNAL(clicked()), this, SLOT(on_back_to_lobby_clicked()));
+  connect(char_button_mapper, SIGNAL(mapped(int)), this,
+          SLOT(char_clicked(int)));
+  connect(ui_back_to_lobby, SIGNAL(clicked()), this,
+          SLOT(on_back_to_lobby_clicked()));
 
-    connect(ui_char_select_left, SIGNAL(clicked()), this, SLOT(on_char_select_left_clicked()));
-    connect(ui_char_select_right, SIGNAL(clicked()), this, SLOT(on_char_select_right_clicked()));
+  connect(ui_char_select_left, SIGNAL(clicked()), this,
+          SLOT(on_char_select_left_clicked()));
+  connect(ui_char_select_right, SIGNAL(clicked()), this,
+          SLOT(on_char_select_right_clicked()));
 
-    connect(ui_spectator, SIGNAL(clicked()), this, SLOT(on_spectator_clicked()));
+  connect(ui_spectator, SIGNAL(clicked()), this, SLOT(on_spectator_clicked()));
 
-    reconstruct_char_select();
+  reconstruct_char_select();
 }
 
 void Courtroom::reconstruct_char_select()
 {
-    while (!ui_char_button_list.isEmpty())
-        delete ui_char_button_list.takeLast();
+  while (!ui_char_button_list.isEmpty())
+    delete ui_char_button_list.takeLast();
 
-    QPoint f_spacing = ao_app->get_button_spacing("char_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing =
+      ao_app->get_button_spacing("char_button_spacing", "courtroom_design.ini");
 
-    const int button_width = 60;
-    int x_spacing          = f_spacing.x();
-    int x_mod_count        = 0;
+  const int button_width = 60;
+  int x_spacing = f_spacing.x();
+  int x_mod_count = 0;
 
-    const int button_height = 60;
-    int y_spacing           = f_spacing.y();
-    int y_mod_count         = 0;
+  const int button_height = 60;
+  int y_spacing = f_spacing.y();
+  int y_mod_count = 0;
 
-    set_size_and_pos(ui_char_buttons, "char_buttons");
+  set_size_and_pos(ui_char_buttons, "char_buttons");
 
-    char_columns = ((ui_char_buttons->width() - button_width) / (x_spacing + button_width)) + 1;
-    char_rows    = ((ui_char_buttons->height() - button_height) / (y_spacing + button_height)) + 1;
+  char_columns =
+      ((ui_char_buttons->width() - button_width) / (x_spacing + button_width)) +
+      1;
+  char_rows = ((ui_char_buttons->height() - button_height) /
+               (y_spacing + button_height)) +
+              1;
 
-    max_chars_on_page = char_columns * char_rows;
+  max_chars_on_page = char_columns * char_rows;
 
-    for (int n = 0; n < max_chars_on_page; ++n)
+  for (int n = 0; n < max_chars_on_page; ++n)
+  {
+    int x_pos = (button_width + x_spacing) * x_mod_count;
+    int y_pos = (button_height + y_spacing) * y_mod_count;
+
+    AOCharButton *button =
+        new AOCharButton(ui_char_buttons, ao_app, x_pos, y_pos);
+    ui_char_button_list.append(button);
+
+    connect(button, SIGNAL(clicked()), char_button_mapper, SLOT(map()));
+    char_button_mapper->setMapping(button, n);
+
+    // mouse events
+    connect(button, SIGNAL(mouse_entered(AOCharButton *)), this,
+            SLOT(char_mouse_entered(AOCharButton *)));
+    connect(button, SIGNAL(mouse_left()), this, SLOT(char_mouse_left()));
+
+    ++x_mod_count;
+
+    if (x_mod_count == char_columns)
     {
-        int x_pos = (button_width + x_spacing) * x_mod_count;
-        int y_pos = (button_height + y_spacing) * y_mod_count;
-
-        AOCharButton *button = new AOCharButton(ui_char_buttons, ao_app, x_pos, y_pos);
-        ui_char_button_list.append(button);
-
-        connect(button, SIGNAL(clicked()), char_button_mapper, SLOT(map()));
-        char_button_mapper->setMapping(button, n);
-
-        // mouse events
-        connect(button, SIGNAL(mouse_entered(AOCharButton *)), this, SLOT(char_mouse_entered(AOCharButton *)));
-        connect(button, SIGNAL(mouse_left()), this, SLOT(char_mouse_left()));
-
-        ++x_mod_count;
-
-        if (x_mod_count == char_columns)
-        {
-            ++y_mod_count;
-            x_mod_count = 0;
-        }
+      ++y_mod_count;
+      x_mod_count = 0;
     }
+  }
 
-    reset_char_select();
+  reset_char_select();
 }
 
 void Courtroom::reset_char_select()
 {
-    current_char_page = 0;
+  current_char_page = 0;
 
-    set_char_select();
-    set_char_select_page();
+  set_char_select();
+  set_char_select_page();
 }
 
 void Courtroom::set_char_select()
 {
-    QString filename = "courtroom_design.ini";
+  QString filename = "courtroom_design.ini";
 
-    pos_size_type f_charselect = ao_app->get_element_dimensions("char_select", filename);
+  pos_size_type f_charselect =
+      ao_app->get_element_dimensions("char_select", filename);
 
-    if (f_charselect.width < 0 || f_charselect.height < 0)
-    {
-        qDebug() << "W: did not find courtroom width or height in courtroom_design.ini!";
-        this->resize(714, 668);
-    }
-    else
-        this->resize(f_charselect.width, f_charselect.height);
+  if (f_charselect.width < 0 || f_charselect.height < 0)
+  {
+    qDebug()
+        << "W: did not find courtroom width or height in courtroom_design.ini!";
+    this->resize(714, 668);
+  }
+  else
+    this->resize(f_charselect.width, f_charselect.height);
 
-    ui_char_select_background->resize(f_charselect.width, f_charselect.height);
-    ui_char_select_background->set_image("charselect_background.png");
+  ui_char_select_background->resize(f_charselect.width, f_charselect.height);
+  ui_char_select_background->set_image("charselect_background.png");
 }
 
 void Courtroom::set_char_select_page()
 {
-    ui_char_select_background->show();
+  ui_char_select_background->show();
 
-    ui_char_select_left->hide();
-    ui_char_select_right->hide();
+  ui_char_select_left->hide();
+  ui_char_select_right->hide();
 
-    for (AOCharButton *button : ui_char_button_list)
-    {
-        button->reset();
-        button->hide();
-    }
+  for (AOCharButton *button : ui_char_button_list)
+  {
+    button->reset();
+    button->hide();
+  }
 
-    int total_pages   = char_list.size() / max_chars_on_page;
-    int chars_on_page = 0;
+  int total_pages = char_list.size() / max_chars_on_page;
+  int chars_on_page = 0;
 
-    if (char_list.size() % max_chars_on_page != 0)
-    {
-        ++total_pages;
-        //i. e. not on the last page
-        if (total_pages > current_char_page + 1)
-            chars_on_page = max_chars_on_page;
-        else
-            chars_on_page = char_list.size() % max_chars_on_page;
-    }
-    else
-        chars_on_page = max_chars_on_page;
-
+  if (char_list.size() % max_chars_on_page != 0)
+  {
+    ++total_pages;
+    // i. e. not on the last page
     if (total_pages > current_char_page + 1)
-        ui_char_select_right->show();
+      chars_on_page = max_chars_on_page;
+    else
+      chars_on_page = char_list.size() % max_chars_on_page;
+  }
+  else
+    chars_on_page = max_chars_on_page;
 
-    if (current_char_page > 0)
-        ui_char_select_left->show();
+  if (total_pages > current_char_page + 1)
+    ui_char_select_right->show();
 
-    // show all buttons for this page
-    for (int n_button = 0; n_button < chars_on_page; ++n_button)
-    {
-        if (char_list.length() <= n_button)
-            continue;
+  if (current_char_page > 0)
+    ui_char_select_left->show();
 
-        int n_real_char        = n_button + current_char_page * max_chars_on_page;
-        AOCharButton *f_button = ui_char_button_list.at(n_button);
+  // show all buttons for this page
+  for (int n_button = 0; n_button < chars_on_page; ++n_button)
+  {
+    if (char_list.length() <= n_button)
+      continue;
 
-        f_button->set_image(char_list.at(n_real_char).name);
-        f_button->show();
+    int n_real_char = n_button + current_char_page * max_chars_on_page;
+    AOCharButton *f_button = ui_char_button_list.at(n_button);
 
-        if (char_list.at(n_real_char).taken)
-            f_button->set_taken();
-    }
+    f_button->set_image(char_list.at(n_real_char).name);
+    f_button->show();
+
+    if (char_list.at(n_real_char).taken)
+      f_button->set_taken();
+  }
 }
 
 void Courtroom::char_clicked(int n_char)
 {
-    int n_real_char = n_char + current_char_page * max_chars_on_page;
+  int n_real_char = n_char + current_char_page * max_chars_on_page;
 
-    QString char_ini_path = ao_app->get_character_path(char_list.at(n_real_char).name) + "char.ini";
-    qDebug() << "char_ini_path" << char_ini_path;
+  QString char_ini_path =
+      ao_app->get_character_path(char_list.at(n_real_char).name) + "char.ini";
+  qDebug() << "char_ini_path" << char_ini_path;
 
-    if (!file_exists(char_ini_path))
-    {
-        qDebug() << "did not find " << char_ini_path;
-        call_notice("Could not find " + char_ini_path);
-        return;
-    }
+  if (!file_exists(char_ini_path))
+  {
+    qDebug() << "did not find " << char_ini_path;
+    call_notice("Could not find " + char_ini_path);
+    return;
+  }
 
-    if (n_real_char == m_cid)
-    {
-        enter_courtroom(m_cid);
-    }
-    else
-    {
-        QString content = "CC#" + QString::number(ao_app->s_pv) + "#" +
-                QString::number(n_real_char) + "#" + get_hdid() + "#%";
-        ao_app->send_server_packet(new AOPacket(content));
-    }
+  if (n_real_char == m_cid)
+  {
+    enter_courtroom(m_cid);
+  }
+  else
+  {
+    QString content = "CC#" + QString::number(ao_app->s_pv) + "#" +
+                      QString::number(n_real_char) + "#" + get_hdid() + "#%";
+    ao_app->send_server_packet(new AOPacket(content));
+  }
 }
 
 void Courtroom::char_mouse_entered(AOCharButton *p_caller)
 {
-    if (p_caller == nullptr)
-        return;
-    ui_char_button_selector->move(p_caller->x() - 1, p_caller->y() - 1);
-    ui_char_button_selector->raise();
-    ui_char_button_selector->show();
+  if (p_caller == nullptr)
+    return;
+  ui_char_button_selector->move(p_caller->x() - 1, p_caller->y() - 1);
+  ui_char_button_selector->raise();
+  ui_char_button_selector->show();
 }
 
 void Courtroom::char_mouse_left()
 {
-    ui_char_button_selector->hide();
+  ui_char_button_selector->hide();
 }

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -5,8 +5,7 @@
 
 #include <QDebug>
 
-void Courtroom::construct_char_select()
-{
+void Courtroom::construct_char_select() {
   ui_char_select_background = new AOImage(this, ao_app);
 
   ui_char_buttons = new QWidget(ui_char_select_background);
@@ -38,8 +37,7 @@ void Courtroom::construct_char_select()
   reconstruct_char_select();
 }
 
-void Courtroom::reconstruct_char_select()
-{
+void Courtroom::reconstruct_char_select() {
   while (!ui_char_button_list.isEmpty())
     delete ui_char_button_list.takeLast();
 
@@ -65,8 +63,7 @@ void Courtroom::reconstruct_char_select()
 
   max_chars_on_page = char_columns * char_rows;
 
-  for (int n = 0; n < max_chars_on_page; ++n)
-  {
+  for (int n = 0; n < max_chars_on_page; ++n) {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
@@ -84,8 +81,7 @@ void Courtroom::reconstruct_char_select()
 
     ++x_mod_count;
 
-    if (x_mod_count == char_columns)
-    {
+    if (x_mod_count == char_columns) {
       ++y_mod_count;
       x_mod_count = 0;
     }
@@ -94,43 +90,37 @@ void Courtroom::reconstruct_char_select()
   reset_char_select();
 }
 
-void Courtroom::reset_char_select()
-{
+void Courtroom::reset_char_select() {
   current_char_page = 0;
 
   set_char_select();
   set_char_select_page();
 }
 
-void Courtroom::set_char_select()
-{
+void Courtroom::set_char_select() {
   QString filename = "courtroom_design.ini";
 
   pos_size_type f_charselect =
       ao_app->get_element_dimensions("char_select", filename);
 
-  if (f_charselect.width < 0 || f_charselect.height < 0)
-  {
+  if (f_charselect.width < 0 || f_charselect.height < 0) {
     qDebug()
         << "W: did not find courtroom width or height in courtroom_design.ini!";
     this->resize(714, 668);
-  }
-  else
+  } else
     this->resize(f_charselect.width, f_charselect.height);
 
   ui_char_select_background->resize(f_charselect.width, f_charselect.height);
   ui_char_select_background->set_image("charselect_background.png");
 }
 
-void Courtroom::set_char_select_page()
-{
+void Courtroom::set_char_select_page() {
   ui_char_select_background->show();
 
   ui_char_select_left->hide();
   ui_char_select_right->hide();
 
-  for (AOCharButton *button : ui_char_button_list)
-  {
+  for (AOCharButton *button : ui_char_button_list) {
     button->reset();
     button->hide();
   }
@@ -138,16 +128,14 @@ void Courtroom::set_char_select_page()
   int total_pages = char_list.size() / max_chars_on_page;
   int chars_on_page = 0;
 
-  if (char_list.size() % max_chars_on_page != 0)
-  {
+  if (char_list.size() % max_chars_on_page != 0) {
     ++total_pages;
     // i. e. not on the last page
     if (total_pages > current_char_page + 1)
       chars_on_page = max_chars_on_page;
     else
       chars_on_page = char_list.size() % max_chars_on_page;
-  }
-  else
+  } else
     chars_on_page = max_chars_on_page;
 
   if (total_pages > current_char_page + 1)
@@ -157,8 +145,7 @@ void Courtroom::set_char_select_page()
     ui_char_select_left->show();
 
   // show all buttons for this page
-  for (int n_button = 0; n_button < chars_on_page; ++n_button)
-  {
+  for (int n_button = 0; n_button < chars_on_page; ++n_button) {
     if (char_list.length() <= n_button)
       continue;
 
@@ -173,35 +160,29 @@ void Courtroom::set_char_select_page()
   }
 }
 
-void Courtroom::char_clicked(int n_char)
-{
+void Courtroom::char_clicked(int n_char) {
   int n_real_char = n_char + current_char_page * max_chars_on_page;
 
   QString char_ini_path =
-      ao_app->get_character_path(char_list.at(n_real_char).name) + "char.ini";
+      ao_app->get_character_path(char_list.at(n_real_char).name, "char.ini");
   qDebug() << "char_ini_path" << char_ini_path;
 
-  if (!file_exists(char_ini_path))
-  {
+  if (!file_exists(char_ini_path)) {
     qDebug() << "did not find " << char_ini_path;
     call_notice("Could not find " + char_ini_path);
     return;
   }
 
-  if (n_real_char == m_cid)
-  {
+  if (n_real_char == m_cid) {
     enter_courtroom(m_cid);
-  }
-  else
-  {
+  } else {
     QString content = "CC#" + QString::number(ao_app->s_pv) + "#" +
                       QString::number(n_real_char) + "#" + get_hdid() + "#%";
     ao_app->send_server_packet(new AOPacket(content));
   }
 }
 
-void Courtroom::char_mouse_entered(AOCharButton *p_caller)
-{
+void Courtroom::char_mouse_entered(AOCharButton *p_caller) {
   if (p_caller == nullptr)
     return;
   ui_char_button_selector->move(p_caller->x() - 1, p_caller->y() - 1);
@@ -209,7 +190,4 @@ void Courtroom::char_mouse_entered(AOCharButton *p_caller)
   ui_char_button_selector->show();
 }
 
-void Courtroom::char_mouse_left()
-{
-  ui_char_button_selector->hide();
-}
+void Courtroom::char_mouse_left() { ui_char_button_selector->hide(); }

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -5,7 +5,8 @@
 
 #include <QDebug>
 
-void Courtroom::construct_char_select() {
+void Courtroom::construct_char_select()
+{
   ui_char_select_background = new AOImage(this, ao_app);
 
   ui_char_buttons = new QWidget(ui_char_select_background);
@@ -37,7 +38,8 @@ void Courtroom::construct_char_select() {
   reconstruct_char_select();
 }
 
-void Courtroom::reconstruct_char_select() {
+void Courtroom::reconstruct_char_select()
+{
   while (!ui_char_button_list.isEmpty())
     delete ui_char_button_list.takeLast();
 
@@ -63,7 +65,8 @@ void Courtroom::reconstruct_char_select() {
 
   max_chars_on_page = char_columns * char_rows;
 
-  for (int n = 0; n < max_chars_on_page; ++n) {
+  for (int n = 0; n < max_chars_on_page; ++n)
+  {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
@@ -81,7 +84,8 @@ void Courtroom::reconstruct_char_select() {
 
     ++x_mod_count;
 
-    if (x_mod_count == char_columns) {
+    if (x_mod_count == char_columns)
+    {
       ++y_mod_count;
       x_mod_count = 0;
     }
@@ -90,37 +94,43 @@ void Courtroom::reconstruct_char_select() {
   reset_char_select();
 }
 
-void Courtroom::reset_char_select() {
+void Courtroom::reset_char_select()
+{
   current_char_page = 0;
 
   set_char_select();
   set_char_select_page();
 }
 
-void Courtroom::set_char_select() {
+void Courtroom::set_char_select()
+{
   QString filename = "courtroom_design.ini";
 
   pos_size_type f_charselect =
       ao_app->get_element_dimensions("char_select", filename);
 
-  if (f_charselect.width < 0 || f_charselect.height < 0) {
+  if (f_charselect.width < 0 || f_charselect.height < 0)
+  {
     qDebug()
         << "W: did not find courtroom width or height in courtroom_design.ini!";
     this->resize(714, 668);
-  } else
+  }
+  else
     this->resize(f_charselect.width, f_charselect.height);
 
   ui_char_select_background->resize(f_charselect.width, f_charselect.height);
   ui_char_select_background->set_image("charselect_background.png");
 }
 
-void Courtroom::set_char_select_page() {
+void Courtroom::set_char_select_page()
+{
   ui_char_select_background->show();
 
   ui_char_select_left->hide();
   ui_char_select_right->hide();
 
-  for (AOCharButton *button : ui_char_button_list) {
+  for (AOCharButton *button : ui_char_button_list)
+  {
     button->reset();
     button->hide();
   }
@@ -128,14 +138,16 @@ void Courtroom::set_char_select_page() {
   int total_pages = char_list.size() / max_chars_on_page;
   int chars_on_page = 0;
 
-  if (char_list.size() % max_chars_on_page != 0) {
+  if (char_list.size() % max_chars_on_page != 0)
+  {
     ++total_pages;
     // i. e. not on the last page
     if (total_pages > current_char_page + 1)
       chars_on_page = max_chars_on_page;
     else
       chars_on_page = char_list.size() % max_chars_on_page;
-  } else
+  }
+  else
     chars_on_page = max_chars_on_page;
 
   if (total_pages > current_char_page + 1)
@@ -145,7 +157,8 @@ void Courtroom::set_char_select_page() {
     ui_char_select_left->show();
 
   // show all buttons for this page
-  for (int n_button = 0; n_button < chars_on_page; ++n_button) {
+  for (int n_button = 0; n_button < chars_on_page; ++n_button)
+  {
     if (char_list.length() <= n_button)
       continue;
 
@@ -160,29 +173,35 @@ void Courtroom::set_char_select_page() {
   }
 }
 
-void Courtroom::char_clicked(int n_char) {
+void Courtroom::char_clicked(int n_char)
+{
   int n_real_char = n_char + current_char_page * max_chars_on_page;
 
   QString char_ini_path =
       ao_app->get_character_path(char_list.at(n_real_char).name, "char.ini");
   qDebug() << "char_ini_path" << char_ini_path;
 
-  if (!file_exists(char_ini_path)) {
+  if (!file_exists(char_ini_path))
+  {
     qDebug() << "did not find " << char_ini_path;
     call_notice("Could not find " + char_ini_path);
     return;
   }
 
-  if (n_real_char == m_cid) {
+  if (n_real_char == m_cid)
+  {
     enter_courtroom(m_cid);
-  } else {
+  }
+  else
+  {
     QString content = "CC#" + QString::number(ao_app->s_pv) + "#" +
                       QString::number(n_real_char) + "#" + get_hdid() + "#%";
     ao_app->send_server_packet(new AOPacket(content));
   }
 }
 
-void Courtroom::char_mouse_entered(AOCharButton *p_caller) {
+void Courtroom::char_mouse_entered(AOCharButton *p_caller)
+{
   if (p_caller == nullptr)
     return;
   ui_char_button_selector->move(p_caller->x() - 1, p_caller->y() - 1);

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1,32 +1,32 @@
 #include "courtroom.h"
 
 #include "aoapplication.h"
-#include "lobby.h"
-#include "hardware_functions.h"
-#include "file_functions.h"
 #include "datatypes.h"
 #include "debug_functions.h"
+#include "file_functions.h"
+#include "hardware_functions.h"
+#include "lobby.h"
 
-#include <QDebug>
-#include <QScrollBar>
-#include <QRegExp>
 #include <QBrush>
-#include <QTextCharFormat>
-#include <QFont>
-#include <QTime>
-#include <QPropertyAnimation>
-#include <QGraphicsOpacityEffect>
+#include <QDebug>
 #include <QDir>
-#include <QMessageBox>
 #include <QFileDialog>
+#include <QFont>
+#include <QGraphicsOpacityEffect>
 #include <QInputDialog>
+#include <QMessageBox>
+#include <QPropertyAnimation>
+#include <QRegExp>
+#include <QScrollBar>
+#include <QTextCharFormat>
+#include <QTime>
 
 Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 {
   ao_app = p_ao_app;
   ao_config = new AOConfig(this);
 
-  //initializing sound device
+  // initializing sound device
   BASS_Init(-1, 48000, BASS_DEVICE_LATENCY, 0, NULL);
   BASS_PluginLoad("bassopus.dll", BASS_UNICODE);
 
@@ -57,10 +57,11 @@ void Courtroom::enter_courtroom(int p_cid)
     f_char = ao_app->get_char_name(char_list.at(m_cid).name);
     QString r_char = f_char;
     // regex for removing non letter (except _) characters
-    QRegularExpression re(QString::fromUtf8("[-`~!@#$%^&*()—+=|:;<>«»,.?/{}\'\"\\[\\]]"));
+    QRegularExpression re(
+        QString::fromUtf8("[-`~!@#$%^&*()—+=|:;<>«»,.?/{}\'\"\\[\\]]"));
     r_char.remove(re);
 
-    if(!rpc_char_list.contains(f_char.toLower()))
+    if (!rpc_char_list.contains(f_char.toLower()))
     {
       ao_app->discord->toggle(1);
     }
@@ -101,9 +102,9 @@ void Courtroom::enter_courtroom(int p_cid)
   set_character_position(ao_app->get_char_side(f_char), changed_character);
 
   // Update widgets first, then check if everything is valid
-  // This will also handle showing the correct shouts, effects and wtce buttons, and cycling
-  // through them if the buttons that are supposed to be displayed do not exist
-  // It will also take care of free blocks
+  // This will also handle showing the correct shouts, effects and wtce buttons,
+  // and cycling through them if the buttons that are supposed to be displayed
+  // do not exist It will also take care of free blocks
   set_widgets();
 
   check_shouts();
@@ -129,14 +130,15 @@ void Courtroom::enter_courtroom(int p_cid)
   list_areas();
   list_sfx();
 
-  ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
+  ui_sfx_list->setCurrentItem(
+      ui_sfx_list->item(0)); // prevents undefined errors
 
   // unmute audio
   set_audio_mute_enabled(false);
 
   testimony_in_progress = false;
 
-  //ui_server_chatlog->setHtml(ui_server_chatlog->toHtml());
+  // ui_server_chatlog->setHtml(ui_server_chatlog->toHtml());
 
   ui_char_select_background->hide();
 
@@ -144,7 +146,7 @@ void Courtroom::enter_courtroom(int p_cid)
   ui_ic_chat_message->setFocus();
 
   for (int i = 0; i < ui_timers.length(); ++i)
-      ui_timers[i]->redraw();
+    ui_timers[i]->redraw();
 
   set_widget_names();
   set_widget_layers();
@@ -172,14 +174,12 @@ void Courtroom::set_window_title(QString p_title)
   this->setWindowTitle(p_title);
 }
 
-
-
 void Courtroom::set_scene()
 {
   if (testimony_in_progress)
     show_testimony();
 
-  //witness is default if pos is invalid
+  // witness is default if pos is invalid
   QString f_background = "witnessempty";
   QString f_desk_image = "stand";
   QString f_desk_mod = m_chatmessage[DESK_MOD];
@@ -242,9 +242,8 @@ void Courtroom::set_scene()
       has_all_desks = true;
 
     if (f_desk_mod == "0" ||
-        (f_desk_mod != "1" && (f_side == "jud" ||
-                              f_side == "hld" ||
-                              f_side == "hlp")))
+        (f_desk_mod != "1" &&
+         (f_side == "jud" || f_side == "hld" || f_side == "hlp")))
       ui_vp_desk->hide();
     else if (!has_all_desks)
       ui_vp_desk->hide();
@@ -262,11 +261,14 @@ void Courtroom::set_char_rpc()
 
   QFile config_file(ao_app->get_base_path() + rpc_ini);
   if (!config_file.open(QIODevice::ReadOnly))
-  { qDebug() << "Error reading" << ao_app->get_base_path() + rpc_ini; return; }
+  {
+    qDebug() << "Error reading" << ao_app->get_base_path() + rpc_ini;
+    return;
+  }
 
   QTextStream in(&config_file);
 
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString f_line = in.readLine().trimmed();
 
@@ -282,7 +284,8 @@ void Courtroom::set_taken(int n_char, bool p_taken)
 {
   if (n_char >= char_list.size())
   {
-    qDebug() << "W: set_taken attempted to set an index bigger than char_list size";
+    qDebug()
+        << "W: set_taken attempted to set an index bigger than char_list size";
     return;
   }
 
@@ -307,19 +310,24 @@ void Courtroom::handle_music_anim()
   QString file_b = fonts_ini;
   pos_size_type res_a = ao_app->get_element_dimensions("music_name", file_a);
   pos_size_type res_b = ao_app->get_element_dimensions("music_area", file_a);
-  float speed = static_cast<float>(ao_app->get_font_property("music_name_speed", file_b));
+  float speed =
+      static_cast<float>(ao_app->get_font_property("music_name_speed", file_b));
 
   QFont f_font = ui_vp_music_name->font();
   QFontMetrics fm(f_font);
   int dist;
-  if ( ao_app->read_theme_ini( "enable_const_music_speed", cc_config_ini ) == "true")
+  if (ao_app->read_theme_ini("enable_const_music_speed", cc_config_ini) ==
+      "true")
     dist = res_b.width;
-  else dist = fm.width(ui_vp_music_name->toPlainText());
-  int time = static_cast<int>(1000000*dist/speed);
+  else
+    dist = fm.width(ui_vp_music_name->toPlainText());
+  int time = static_cast<int>(1000000 * dist / speed);
   music_anim->setLoopCount(-1);
   music_anim->setDuration(time);
-  music_anim->setStartValue(QRect(res_b.width + res_b.x, res_a.y, res_a.width, res_a.height));
-  music_anim->setEndValue(QRect(-dist + res_a.x, res_a.y, res_a.width, res_a.height));
+  music_anim->setStartValue(
+      QRect(res_b.width + res_b.x, res_a.y, res_a.width, res_a.height));
+  music_anim->setEndValue(
+      QRect(-dist + res_a.x, res_a.y, res_a.width, res_a.height));
   music_anim->start();
 }
 
@@ -348,15 +356,16 @@ void Courtroom::list_music()
 
   int n_listed_songs = 0;
 
-  for (int n_song = 0 ; n_song < music_list.size() ; ++n_song)
+  for (int n_song = 0; n_song < music_list.size(); ++n_song)
   {
     QString i_song = music_list.at(n_song);
     bool found = false;
 
-    for (auto& ext : QStringList { "", ".wav", ".ogg", ".mp3" })
+    for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
     {
       QString r_song = i_song + ext;
-      QString song_path = ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
+      QString song_path =
+          ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
       if (file_exists(song_path))
       {
         found = true;
@@ -381,7 +390,7 @@ void Courtroom::list_music()
 void Courtroom::list_areas()
 {
   ui_area_list->clear();
-//  area_names.clear();
+  //  area_names.clear();
 
   QString f_file = "courtroom_design.ini";
 
@@ -395,7 +404,7 @@ void Courtroom::list_areas()
 
   int n_listed_areas = 0;
 
-  for (int n_area = 0 ; n_area < area_list.size() ; ++n_area)
+  for (int n_area = 0; n_area < area_list.size(); ++n_area)
   {
     QString i_area = "";
 
@@ -404,8 +413,7 @@ void Courtroom::list_areas()
     if (i_area.toLower().contains(ui_music_search->text().toLower()))
     {
       ui_area_list->addItem(i_area);
-//      area_names.append(i_);
-
+      //      area_names.append(i_);
 
       ui_area_list->item(n_listed_areas)->setBackground(free_brush);
 
@@ -434,24 +442,27 @@ void Courtroom::list_sfx()
 
   int n_listed_sfxs = 0;
 
-  for (int n_sfx = 0 ; n_sfx < sfx_list.size() ; ++n_sfx)
+  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
   {
     QStringList sfx = sfx_list.at(n_sfx).split("=");
     QString i_sfx = sfx.at(0).trimmed();
     QString d_sfx = "";
     sfx_names.append(i_sfx);
-    if(sfx_list.at(n_sfx).split("=").size() < 2)
+    if (sfx_list.at(n_sfx).split("=").size() < 2)
       d_sfx = i_sfx;
-    else d_sfx = sfx.at(1).trimmed();
+    else
+      d_sfx = sfx.at(1).trimmed();
 
     //    qDebug() << "isfx=" << i_sfx << "dsfx=" << d_sfx << "sfx=" << sfx;
 
     if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
     {
       ui_sfx_list->addItem(d_sfx);
-      ui_sfx_list->item(ui_sfx_list->count()-1)->setStatusTip(QString::number(n_sfx+2));
+      ui_sfx_list->item(ui_sfx_list->count() - 1)
+          ->setStatusTip(QString::number(n_sfx + 2));
 
-      QString sfx_path = ao_app->get_base_path() + "sounds/general/" + i_sfx.toLower();
+      QString sfx_path =
+          ao_app->get_base_path() + "sounds/general/" + i_sfx.toLower();
 
       if (file_exists(sfx_path))
         ui_sfx_list->item(n_listed_sfxs)->setBackground(found_brush);
@@ -467,8 +478,11 @@ void Courtroom::list_note_files()
 {
   QString f_config = ao_app->get_base_path() + file_select_ini;
   QFile f_file(f_config);
-  if(!f_file.open(QIODevice::ReadOnly))
-  { qDebug() << "Couldn't open" << f_config; return; }
+  if (!f_file.open(QIODevice::ReadOnly))
+  {
+    qDebug() << "Couldn't open" << f_config;
+    return;
+  }
 
   note_list.clear();
 
@@ -479,24 +493,25 @@ void Courtroom::list_note_files()
 
   QVBoxLayout *f_layout = ui_note_area->m_layout;
 
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString line = in.readLine().trimmed();
 
     QStringList f_contents = line.split("=");
-    if(f_contents.size() < 2)
+    if (f_contents.size() < 2)
       continue;
 
     int f_index = f_contents.at(0).toInt();
     f_filestring = f_filename = f_contents.at(1).trimmed();
 
-    if(f_contents.size() > 2)
+    if (f_contents.size() > 2)
       f_filename = f_contents.at(2).trimmed();
 
-    while(f_index >= f_layout->count())
+    while (f_index >= f_layout->count())
       on_add_button_clicked();
 
-    AONotePicker *f_notepicker = static_cast<AONotePicker*>(f_layout->itemAt(f_index)->widget());
+    AONotePicker *f_notepicker =
+        static_cast<AONotePicker *>(f_layout->itemAt(f_index)->widget());
     f_notepicker->m_line->setText(f_filename);
     f_notepicker->real_file = f_filestring;
   }
@@ -504,12 +519,12 @@ void Courtroom::list_note_files()
 
 void Courtroom::load_note()
 {
-  //Do not attempt to load anything if no file was chosen. This makes it so that notepad text
-  //is kept in client if the user has decided not to choose a file to save to. Of course, this is
-  //ephimeral storage, it will be erased after the client closes or when the user decides to load
-  //a file.
+  // Do not attempt to load anything if no file was chosen. This makes it so
+  // that notepad text is kept in client if the user has decided not to choose a
+  // file to save to. Of course, this is ephimeral storage, it will be erased
+  // after the client closes or when the user decides to load a file.
   if (current_file.isEmpty())
-      return;
+    return;
   QString f_text = ao_app->read_note(current_file);
   ui_vp_notepad->setText(f_text);
 }
@@ -532,8 +547,9 @@ void Courtroom::save_textlog(QString p_text)
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message)
 {
   ui_server_chatlog->append_chatmessage(p_name, p_message);
-  if(ao_config->log_is_recording_enabled())
-    save_textlog("(OOC)[" + QTime::currentTime().toString() + "] " + p_name + ": " + p_message);
+  if (ao_config->log_is_recording_enabled())
+    save_textlog("(OOC)[" + QTime::currentTime().toString() + "] " + p_name +
+                 ": " + p_message);
 }
 
 void Courtroom::on_chat_return_pressed()
@@ -541,29 +557,29 @@ void Courtroom::on_chat_return_pressed()
   if (ui_ic_chat_message->text() == "" || is_client_muted)
     return;
 
-  if ((anim_state < 3 || text_state < 2) &&
-      m_objection_state == 0)
+  if ((anim_state < 3 || text_state < 2) && m_objection_state == 0)
     return;
 
-  //  qDebug() << "prev_emote = " << prev_emote << "current_emote = " << current_emote;
+  //  qDebug() << "prev_emote = " << prev_emote << "current_emote = " <<
+  //  current_emote;
 
   //  qDebug() << "same_emote = " << same_emote;
-  //MS#
-  //deskmod#
-  //pre-emote#
-  //character#
-  //emote#
-  //message#
-  //side#
-  //sfx-name#
-  //emote_modifier#
-  //char_id#
-  //sfx_delay#
-  //objection_modifier#
-  //evidence#
-  //placeholder#
-  //realization#
-  //text_color#%
+  // MS#
+  // deskmod#
+  // pre-emote#
+  // character#
+  // emote#
+  // message#
+  // side#
+  // sfx-name#
+  // emote_modifier#
+  // char_id#
+  // sfx_delay#
+  // objection_modifier#
+  // evidence#
+  // placeholder#
+  // realization#
+  // text_color#%
 
   QStringList packet_contents;
 
@@ -573,7 +589,8 @@ void Courtroom::on_chat_return_pressed()
 
   if (ao_app->desk_mod_enabled)
   {
-    f_desk_mod = QString::number(ao_app->get_desk_mod(current_char, current_emote));
+    f_desk_mod =
+        QString::number(ao_app->get_desk_mod(current_char, current_emote));
     if (f_desk_mod == "-1")
       f_desk_mod = "chat";
   }
@@ -584,12 +601,10 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(current_char);
 
-  if(ui_hidden->isChecked())
+  if (ui_hidden->isChecked())
     packet_contents.append("../../misc/blank");
   else
     packet_contents.append(ao_app->get_emote(current_char, current_emote));
-
-
 
   packet_contents.append(ui_ic_chat_message->text());
 
@@ -612,7 +627,7 @@ void Courtroom::on_chat_return_pressed()
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
-  //needed or else legacy won't understand what we're saying
+  // needed or else legacy won't understand what we're saying
   if (m_objection_state > 0)
   {
     if (f_emote_mod == 5)
@@ -638,11 +653,13 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(QString::number(f_emote_mod));
   packet_contents.append(QString::number(m_cid));
 
-  packet_contents.append(QString::number(ao_app->get_sfx_delay(current_char, current_emote)));
+  packet_contents.append(
+      QString::number(ao_app->get_sfx_delay(current_char, current_emote)));
 
   QString f_obj_state;
 
-  if (m_objection_state < 0 || (!ao_app->custom_objection_enabled && m_objection_state > 3))
+  if (m_objection_state < 0 ||
+      (!ao_app->custom_objection_enabled && m_objection_state > 3))
     f_obj_state = "0";
   else
     f_obj_state = QString::number(m_objection_state);
@@ -650,8 +667,8 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(f_obj_state);
 
   if (is_presenting_evidence)
-    //the evidence index is shifted by 1 because 0 is no evidence per legacy standards
-    //besides, older clients crash if we pass -1
+    // the evidence index is shifted by 1 because 0 is no evidence per legacy
+    // standards besides, older clients crash if we pass -1
     packet_contents.append(QString::number(current_evidence + 1));
   else
     packet_contents.append("0");
@@ -695,10 +712,11 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   else if (p_contents->size() == 15)
     p_contents->append("");
 
-  for (int n_string = 0 ; n_string < chatmessage_size ; ++n_string)
+  for (int n_string = 0; n_string < chatmessage_size; ++n_string)
   {
     m_chatmessage[n_string] = p_contents->at(n_string);
-    //    qDebug() << "m_chatmessage[" << n_string << "] = " << m_chatmessage[n_string];
+    //    qDebug() << "m_chatmessage[" << n_string << "] = " <<
+    //    m_chatmessage[n_string];
   }
 
   int f_char_id = m_chatmessage[CHAR_ID].toInt();
@@ -709,7 +727,8 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     m_chatmessage[CHAR_ID] = "0";
     f_char_id = 0;
   }
-  else is_system_speaking = false;
+  else
+    is_system_speaking = false;
 
   if (f_char_id < 0 || f_char_id >= char_list.size())
     return;
@@ -717,35 +736,37 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   if (mute_map.value(m_chatmessage[CHAR_ID].toInt()))
     return;
 
-  chatmessage_is_empty = m_chatmessage[MESSAGE] == " " || m_chatmessage[MESSAGE] == "";
+  chatmessage_is_empty =
+      m_chatmessage[MESSAGE] == " " || m_chatmessage[MESSAGE] == "";
   m_msg_is_first_person = false;
 
   // reset our ui state
   if (m_cid == f_char_id && !is_system_speaking)
   {
-      ui_ic_chat_message->clear();
-      ui_sfx_list->setCurrentItem(ui_sfx_list->item(0));
+    ui_ic_chat_message->clear();
+    ui_sfx_list->setCurrentItem(ui_sfx_list->item(0));
 
-      m_objection_state = 0;
-      reset_shout_buttons();
+    m_objection_state = 0;
+    reset_shout_buttons();
 
-      m_effect_state = 0;
-      reset_effect_buttons();
+    m_effect_state = 0;
+    reset_effect_buttons();
 
-      m_wtce_current = 0;
-      reset_judge_wtce_buttons();
+    m_wtce_current = 0;
+    reset_judge_wtce_buttons();
 
-      is_presenting_evidence = false;
-      ui_evidence_present->set_image("present_disabled.png");
+    is_presenting_evidence = false;
+    ui_evidence_present->set_image("present_disabled.png");
 
-      m_msg_is_first_person = ao_app->get_first_person_enabled();
+    m_msg_is_first_person = ao_app->get_first_person_enabled();
   }
 
   QString f_showname;
   qDebug() << "handle_chatmessage";
-  qDebug() << m_chatmessage[SHOWNAME] << ao_app->get_showname(char_list.at(f_char_id).name);
+  qDebug() << m_chatmessage[SHOWNAME]
+           << ao_app->get_showname(char_list.at(f_char_id).name);
 
-  if(m_chatmessage[SHOWNAME].isEmpty())
+  if (m_chatmessage[SHOWNAME].isEmpty())
   {
     f_showname = ao_app->get_showname(char_list.at(f_char_id).name);
   }
@@ -776,29 +797,31 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   else
     append_ic_text(f_showname, m_chatmessage[MESSAGE], false, false);
 
-  if(ao_config->log_is_recording_enabled())
-    save_textlog("[" + QTime::currentTime().toString() + "] " + f_showname + ": " + m_chatmessage[MESSAGE]);
+  if (ao_config->log_is_recording_enabled())
+    save_textlog("[" + QTime::currentTime().toString() + "] " + f_showname +
+                 ": " + m_chatmessage[MESSAGE]);
 
   int objection_mod = m_chatmessage[OBJECTION_MOD].toInt();
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_custom_theme = ao_app->get_char_shouts(f_char);
 
-  //if an objection is used
+  // if an objection is used
   if (objection_mod > 0)
   {
     int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
     if (emote_mod == 0)
       m_chatmessage[EMOTE_MOD] = 1;
 
-    //handles cases 1-8 (5-8 are DRO only)
-    if(objection_mod >= 1 && objection_mod <= ui_shouts.size() && ui_shouts.size() > 0) // check to prevent crashing
+    // handles cases 1-8 (5-8 are DRO only)
+    if (objection_mod >= 1 && objection_mod <= ui_shouts.size() &&
+        ui_shouts.size() > 0) // check to prevent crashing
     {
-      ui_vp_objection->play(shout_names.at(objection_mod-1), f_char, f_custom_theme);
-      m_shouts_player->play(shout_names.at(objection_mod-1) + ".wav", f_char);
+      ui_vp_objection->play(shout_names.at(objection_mod - 1), f_char,
+                            f_custom_theme);
+      m_shouts_player->play(shout_names.at(objection_mod - 1) + ".wav", f_char);
     }
     else
       qDebug() << "W: Shout identifier unknown" << objection_mod;
-
   }
   else
     handle_chatmessage_2();
@@ -820,7 +843,7 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   QString f_showname;
 
-  if(m_chatmessage[SHOWNAME].isEmpty())
+  if (m_chatmessage[SHOWNAME].isEmpty())
   {
     f_showname = ao_app->get_showname(real_name);
   }
@@ -829,8 +852,10 @@ void Courtroom::handle_chatmessage_2() // handles IC
     f_showname = m_chatmessage[SHOWNAME];
   }
 
-  // Check if char.ini has color property, which overrides the theme's default showname color
-  QString f_color = ao_app->read_char_ini(real_name, "color", "[Options]", "[Time]");
+  // Check if char.ini has color property, which overrides the theme's default
+  // showname color
+  QString f_color =
+      ao_app->read_char_ini(real_name, "color", "[Options]", "[Time]");
   set_qtextedit_font(ui_vp_showname, "showname", f_color);
 
   ui_vp_showname->setText(f_showname);
@@ -862,7 +887,7 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   if (!m_msg_is_first_person)
   {
-      set_scene();
+    set_scene();
   }
 
   set_text_color();
@@ -876,20 +901,23 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   switch (emote_mod)
   {
-  case 1: case 2: case 6:
+  case 1:
+  case 2:
+  case 6:
     play_preanim();
     break;
   default:
     qDebug() << "W: invalid emote mod: " << QString::number(emote_mod);
-    //intentional fallthru
-  case 0: case 5:
+    // intentional fallthru
+  case 0:
+  case 5:
     handle_chatmessage_3();
   }
 }
 
 void Courtroom::handle_chatmessage_3()
 {
-   qDebug() << "handle_chatmessage_3";
+  qDebug() << "handle_chatmessage_3";
 
   start_chat_ticking();
 
@@ -898,39 +926,36 @@ void Courtroom::handle_chatmessage_3()
 
   if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size())
   {
-    //shifted by 1 because 0 is no evidence per legacy standards
+    // shifted by 1 because 0 is no evidence per legacy standards
     QString f_image = local_evidence_list.at(f_evi_id - 1).image;
-    //def jud and hlp should display the evidence icon on the RIGHT side
-    bool is_left_side = !(f_side == "def" || f_side == "hlp" || f_side == "jud");
+    // def jud and hlp should display the evidence icon on the RIGHT side
+    bool is_left_side =
+        !(f_side == "def" || f_side == "hlp" || f_side == "jud");
     ui_vp_evidence_display->show_evidence(f_image, is_left_side);
   }
 
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
 
-  if (emote_mod == 5 ||
-      emote_mod == 6)
+  if (emote_mod == 5 || emote_mod == 6)
   {
     QString side = m_chatmessage[SIDE];
     ui_vp_desk->hide();
 
-    if (side == "pro" ||
-        side == "hlp" ||
-        side == "wit")
+    if (side == "pro" || side == "hlp" || side == "wit")
       ui_vp_speedlines->play("prosecution_speedlines");
     else
       ui_vp_speedlines->play("defense_speedlines");
-
   }
 
   int f_anim_state = 0;
-  //BLUE is from an enum in datatypes.h
+  // BLUE is from an enum in datatypes.h
   bool text_is_blue = m_chatmessage[TEXT_COLOR].toInt() == BLUE;
 
   if (!text_is_blue && text_state == 1)
-    //talking
+    // talking
     f_anim_state = 2;
   else
-    //idle
+    // idle
     f_anim_state = 3;
 
   if (f_anim_state <= anim_state)
@@ -943,8 +968,10 @@ void Courtroom::handle_chatmessage_3()
   ui_vp_showname_image->show();
   QVector<QString> exts = {".png", ".jpg", ".bmp"};
 
-  QString ext = file_exists(ao_app->get_character_path(f_char) + "showname", exts);
-  if(ext != "" && !chatmessage_is_empty && ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
+  QString ext =
+      file_exists(ao_app->get_character_path(f_char) + "showname", exts);
+  if (ext != "" && !chatmessage_is_empty &&
+      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
   {
     ui_vp_showname->hide();
     QString path = ao_app->get_character_path(f_char) + "showname" + ext;
@@ -957,36 +984,37 @@ void Courtroom::handle_chatmessage_3()
     ui_vp_showname_image->hide();
   }
 
-
   switch (f_anim_state)
   {
   case 2:
-      if (!m_msg_is_first_person)
-      {
-          ui_vp_player_char->play_talking(f_char, f_emote, true);
-      }
+    if (!m_msg_is_first_person)
+    {
+      ui_vp_player_char->play_talking(f_char, f_emote, true);
+    }
     anim_state = 2;
     break;
   default:
     qDebug() << "W: invalid anim_state: " << f_anim_state;
   case 3:
-      if (!m_msg_is_first_person)
-      {
-          ui_vp_player_char->play_idle(f_char, f_emote, true);
-      }
+    if (!m_msg_is_first_person)
+    {
+      ui_vp_player_char->play_idle(f_char, f_emote, true);
+    }
     anim_state = 3;
   }
 
   int effect = m_chatmessage[EFFECT_STATE].toInt();
   QStringList offset = ao_app->get_effect_offset(f_char, effect);
 
-  ui_vp_effect->move(ui_viewport->x() + offset.at(0).toInt(), ui_viewport->y() + offset.at(1).toInt());
+  ui_vp_effect->move(ui_viewport->x() + offset.at(0).toInt(),
+                     ui_viewport->y() + offset.at(1).toInt());
 
   QStringList overlay = ao_app->get_overlay(f_char, effect);
   QString overlay_name = overlay.at(0);
   QString overlay_sfx = overlay.at(1);
 
-  bool do_it = ao_app->read_theme_ini("non_vanilla_effects", cc_config_ini) == "true";
+  bool do_it =
+      ao_app->read_theme_ini("non_vanilla_effects", cc_config_ini) == "true";
 
   if (effect == 1 && !do_it)
   {
@@ -999,22 +1027,23 @@ void Courtroom::handle_chatmessage_3()
     ui_vp_effect->play(overlay_name, f_char);
     realization_timer->start(60);
   }
-//  else if (effect == 2)
-//  {
-//    if (overlay_sfx == "")
-//      overlay_sfx = ao_app->get_sfx("effect_gloom");
-//    m_sfx_player->play(overlay_sfx);
-//    ui_vp_effect->set_play_once(false);
-//    if (overlay_name == "")
-//      overlay_name = "effect_gloom";
-//    ui_vp_effect->play(overlay_name, f_char);
-//  }
-  else if (do_it && effect > 0 && effect <= ui_effects.size() && effect_names.size() > 0) // check to prevent crashing
+  //  else if (effect == 2)
+  //  {
+  //    if (overlay_sfx == "")
+  //      overlay_sfx = ao_app->get_sfx("effect_gloom");
+  //    m_sfx_player->play(overlay_sfx);
+  //    ui_vp_effect->set_play_once(false);
+  //    if (overlay_name == "")
+  //      overlay_name = "effect_gloom";
+  //    ui_vp_effect->play(overlay_name, f_char);
+  //  }
+  else if (do_it && effect > 0 && effect <= ui_effects.size() &&
+           effect_names.size() > 0) // check to prevent crashing
   {
     QString s_eff = effect_names.at(effect - 1);
     QStringList f_eff = ao_app->get_effect(effect);
 
-//    QString s_eff = f_eff.at(0).trimmed();
+    //    QString s_eff = f_eff.at(0).trimmed();
     bool once = f_eff.at(1).trimmed().toInt();
 
     if (overlay_sfx == "")
@@ -1037,202 +1066,221 @@ void Courtroom::handle_chatmessage_3()
       m_system_player->play(ao_app->get_sfx("word_call"));
       ao_app->alert(this);
       ui_server_chatlog->append_chatmessage(
-            "CLIENT",
-            "[" + QTime::currentTime().toString("HH:mm") + "] " +
-            ui_vp_showname->toPlainText() + " has called you via your callword \"" + word +
-            "\": \"" + f_message + "\"");
+          "CLIENT", "[" + QTime::currentTime().toString("HH:mm") + "] " +
+                        ui_vp_showname->toPlainText() +
+                        " has called you via your callword \"" + word +
+                        "\": \"" + f_message + "\"");
       break;
     }
   }
-
 }
 
 void Courtroom::on_chat_config_changed()
 {
-    // forward declaration for a possible update of the chatlog
-    bool chatlog_changed = false;
+  // forward declaration for a possible update of the chatlog
+  bool chatlog_changed = false;
 
-    int chatlog_limit = ao_config->log_max_lines();
-    // default chatlog_limit?
-    chatlog_limit = chatlog_limit <= 0 ? 200 : chatlog_limit; // TODO declare the default somewhere so it's not a magic number
-    if (chatlog_limit < m_chatlog_limit) // only update if we need to chop away records
-        chatlog_changed = true;
-    m_chatlog_limit = chatlog_limit;
+  int chatlog_limit = ao_config->log_max_lines();
+  // default chatlog_limit?
+  chatlog_limit = chatlog_limit <= 0
+                      ? 200
+                      : chatlog_limit; // TODO declare the default somewhere so
+                                       // it's not a magic number
+  if (chatlog_limit <
+      m_chatlog_limit) // only update if we need to chop away records
+    chatlog_changed = true;
+  m_chatlog_limit = chatlog_limit;
 
-    bool chatlog_scrolldown = ao_config->log_goes_downward_enabled();
-    if (m_chatlog_scrolldown != chatlog_scrolldown)
-        chatlog_changed = true;
-    m_chatlog_scrolldown = chatlog_scrolldown;
+  bool chatlog_scrolldown = ao_config->log_goes_downward_enabled();
+  if (m_chatlog_scrolldown != chatlog_scrolldown)
+    chatlog_changed = true;
+  m_chatlog_scrolldown = chatlog_scrolldown;
 
-    bool chatlog_newline = ao_config->log_uses_newline_enabled();
-    if (m_chatlog_newline != chatlog_newline)
-        chatlog_changed = true;
-    m_chatlog_newline = chatlog_newline;
+  bool chatlog_newline = ao_config->log_uses_newline_enabled();
+  if (m_chatlog_newline != chatlog_newline)
+    chatlog_changed = true;
+  m_chatlog_newline = chatlog_newline;
 
-    // refresh the log if needed
-    if (chatlog_changed)
-        update_ic_log(chatlog_changed);
+  // refresh the log if needed
+  if (chatlog_changed)
+    update_ic_log(chatlog_changed);
 }
 
 void Courtroom::update_ic_log(bool p_reset_log)
 {
-    // resize if needed
-    int len = m_ic_records.length();
-    if (len > m_chatlog_limit)
-        m_ic_records = m_ic_records.mid(len - m_chatlog_limit);
+  // resize if needed
+  int len = m_ic_records.length();
+  if (len > m_chatlog_limit)
+    m_ic_records = m_ic_records.mid(len - m_chatlog_limit);
 
-    /*
-     * first, we figure out whatever we append the last message or if we reset
-     * the entire log
-     * */
-    record_type_array records_to_add;
-    // populate
-    if (p_reset_log)
+  /*
+   * first, we figure out whatever we append the last message or if we reset
+   * the entire log
+   * */
+  record_type_array records_to_add;
+  // populate
+  if (p_reset_log)
+  {
+    // we need the entire recordings
+    records_to_add = m_ic_records;
+
+    // clear log
+    ui_ic_chatlog->clear();
+  }
+  else
+  {
+    records_to_add.append(m_ic_records.last());
+  }
+
+  // prepare the formats we need
+  // default color
+  QColor default_color = ao_app->get_color("ic_chatlog_color", fonts_ini);
+  QColor not_found_color = QColor(255, 255, 255);
+
+  QTextCharFormat name_format = ui_ic_chatlog->currentCharFormat();
+  name_format.setFontWeight(QFont::Bold);
+  QColor showname_color =
+      ao_app->get_color("ic_chatlog_showname_color", fonts_ini);
+  if (showname_color == not_found_color)
+    showname_color = default_color;
+  name_format.setForeground(showname_color);
+
+  QTextCharFormat line_format = ui_ic_chatlog->currentCharFormat();
+  line_format.setFontWeight(QFont::Normal);
+  QColor message_color =
+      ao_app->get_color("ic_chatlog_message_color", fonts_ini);
+  if (message_color == not_found_color)
+    message_color = default_color;
+  line_format.setForeground(message_color);
+
+  QTextCharFormat system_format = ui_ic_chatlog->currentCharFormat();
+  system_format.setFontWeight(QFont::Normal);
+  QColor system_color = ao_app->get_color("ic_chatlog_system_color", fonts_ini);
+  if (system_color == not_found_color)
+    system_color = not_found_color;
+  system_format.setForeground(system_color);
+
+  // need vscroll bar for cache
+  QScrollBar *vscrollbar = ui_ic_chatlog->verticalScrollBar();
+
+  // cache previous values
+  const QTextCursor prev_cursor = ui_ic_chatlog->textCursor();
+  const int scroll_pos = vscrollbar->value();
+  const bool is_scrolled = m_chatlog_scrolldown
+                               ? scroll_pos == vscrollbar->maximum()
+                               : scroll_pos == vscrollbar->minimum();
+
+  // recover cursor
+  QTextCursor cursor = ui_ic_chatlog->textCursor();
+  // figure out if we need to move up or down
+  const QTextCursor::MoveOperation move_type =
+      m_chatlog_scrolldown ? QTextCursor::End : QTextCursor::Start;
+
+  for (record_type_ptr record : records_to_add)
+  {
+    // move cursor
+    cursor.movePosition(move_type);
+
+    if (record->system)
     {
-        // we need the entire recordings
-        records_to_add = m_ic_records;
-
-        // clear log
-        ui_ic_chatlog->clear();
+      cursor.insertText(record->line + QChar::LineFeed, system_format);
     }
     else
     {
-        records_to_add.append(m_ic_records.last());
+      QString separator;
+      if (m_chatlog_newline)
+        separator = QString(QChar::LineFeed);
+      else if (!record->music)
+        separator = ": ";
+      else
+        separator = " ";
+      cursor.insertText(record->name + separator, name_format);
+      cursor.insertText(record->line + QChar::LineFeed +
+                            (m_chatlog_newline ? QChar::LineFeed : QChar()),
+                        line_format);
     }
+  }
 
-    // prepare the formats we need
-    // default color
-    QColor default_color = ao_app->get_color("ic_chatlog_color", fonts_ini);
-    QColor not_found_color = QColor(255, 255, 255);
+  // figure out the number of blocks we need overall
+  // this is always going to amount to at least the current length of records
+  int block_count = m_ic_records.length() + 1; // there's always one extra block
+  // to do that, we need to go through the records
+  for (record_type_ptr record : m_ic_records)
+    if (!record->system)
+      if (m_chatlog_newline)
+        block_count += 2; // if newline is actived, it always inserts two extra
+                          // newlines; therefor two paragraphs
 
-    QTextCharFormat name_format = ui_ic_chatlog->currentCharFormat();
-    name_format.setFontWeight(QFont::Bold);
-    QColor showname_color = ao_app->get_color("ic_chatlog_showname_color", fonts_ini);
-    if (showname_color == not_found_color)
-        showname_color = default_color;
-    name_format.setForeground(showname_color);
+  // there's always one extra block count, so deduce one from block_count
+  int blocks_to_delete = ui_ic_chatlog->document()->blockCount() - block_count;
 
-    QTextCharFormat line_format = ui_ic_chatlog->currentCharFormat();
-    line_format.setFontWeight(QFont::Normal);
-    QColor message_color = ao_app->get_color("ic_chatlog_message_color", fonts_ini);
-    if (message_color == not_found_color)
-        message_color = default_color;
-    line_format.setForeground(message_color);
+  // the orientation at which we need to delete from
+  const QTextCursor::MoveOperation start_location =
+      m_chatlog_scrolldown ? QTextCursor::Start : QTextCursor::End;
+  const QTextCursor::MoveOperation block_orientation =
+      m_chatlog_scrolldown ? QTextCursor::NextBlock
+                           : QTextCursor::PreviousBlock;
 
-    QTextCharFormat system_format = ui_ic_chatlog->currentCharFormat();
-    system_format.setFontWeight(QFont::Normal);
-    QColor system_color = ao_app->get_color("ic_chatlog_system_color", fonts_ini);
-    if (system_color == not_found_color)
-        system_color = not_found_color;
-    system_format.setForeground(system_color);
+  /* Blocks appear like this
+   * textQChar(0x2029)
+   * additionaltextQChar(0x2029)
+   * moretextQChar(0x2029)
+   * where QChar(0x2029) is the paragraph break block.
+   * Do note that the above example has FOUR blocks: text, additionaltext,
+   * moretext, and an empty block. That is because QTextCursor separates blocks
+   * by paragraph break block (which is why the above code has a -1) and does
+   * not consider this break character as part of the block (which is why we
+   * move Left in the loop, to 'be in the block'). Finally, BlockUnderCursor
+   * does NOT select the break character, so we deleteChar after removing the
+   * selection to remove the straggling newline.
+   * */
 
-    // need vscroll bar for cache
-    QScrollBar *vscrollbar = ui_ic_chatlog->verticalScrollBar();
+  // move our cursor at the start
+  cursor.movePosition(start_location);
 
-    // cache previous values
-    const QTextCursor prev_cursor = ui_ic_chatlog->textCursor();
-    const int scroll_pos = vscrollbar->value();
-    const bool is_scrolled = m_chatlog_scrolldown ? scroll_pos == vscrollbar->maximum() : scroll_pos == vscrollbar->minimum();
+  // move the cursor around, depending on the orientation we need
+  for (int i = 0; i < blocks_to_delete; ++i)
+    cursor.movePosition(block_orientation, QTextCursor::KeepAnchor);
 
-    // recover cursor
-    QTextCursor cursor = ui_ic_chatlog->textCursor();
-    // figure out if we need to move up or down
-    const QTextCursor::MoveOperation move_type = m_chatlog_scrolldown ? QTextCursor::End : QTextCursor::Start;
+  // now that everything is selected, delete it
+  cursor.removeSelectedText();
 
-    for (record_type_ptr record : records_to_add)
-    {
-        // move cursor
-        cursor.movePosition(move_type);
+  /*
+   * However, if we do this, we also remove the last newline of the last block
+   * that remains, which will make it difficult to append new blocks to
+   * it/figure out the amount of blocks if we have a scroll up log, so we add it
+   * again if we removed any break characters at all
+   * */
+  if (!m_chatlog_scrolldown && blocks_to_delete > 0)
+    cursor.insertBlock();
 
-        if (record->system)
-        {
-            cursor.insertText(record->line + QChar::LineFeed, system_format);
-        }
-        else
-        {
-            QString separator;
-            if (m_chatlog_newline)
-              separator = QString(QChar::LineFeed);
-            else if (!record->music)
-              separator = ": ";
-            else
-              separator = " ";
-            cursor.insertText(record->name + separator, name_format);
-            cursor.insertText(record->line + QChar::LineFeed + (m_chatlog_newline ? QChar::LineFeed : QChar()), line_format);
-        }
-    }
-
-    // figure out the number of blocks we need overall
-    // this is always going to amount to at least the current length of records
-    int block_count = m_ic_records.length() + 1; // there's always one extra block
-    // to do that, we need to go through the records
-    for (record_type_ptr record : m_ic_records)
-        if (!record->system)
-            if (m_chatlog_newline)
-                block_count += 2; // if newline is actived, it always inserts two extra newlines; therefor two paragraphs
-
-    // there's always one extra block count, so deduce one from block_count
-    int blocks_to_delete = ui_ic_chatlog->document()->blockCount() - block_count;
-
-    // the orientation at which we need to delete from
-    const QTextCursor::MoveOperation start_location = m_chatlog_scrolldown ? QTextCursor::Start : QTextCursor::End;
-    const QTextCursor::MoveOperation block_orientation = m_chatlog_scrolldown ? QTextCursor::NextBlock : QTextCursor::PreviousBlock;
-
-    /* Blocks appear like this
-     * textQChar(0x2029)
-     * additionaltextQChar(0x2029)
-     * moretextQChar(0x2029)
-     * where QChar(0x2029) is the paragraph break block.
-     * Do note that the above example has FOUR blocks: text, additionaltext, moretext, and
-     * an empty block. That is because QTextCursor separates blocks by paragraph break block
-     * (which is why the above code has a -1) and does not consider this break character as
-     * part of the block (which is why we move Left in the loop, to 'be in the block').
-     * Finally, BlockUnderCursor does NOT select the break character, so we deleteChar after
-     * removing the selection to remove the straggling newline.
-     * */
-
-    // move our cursor at the start
-    cursor.movePosition(start_location);
-
-    // move the cursor around, depending on the orientation we need
-    for (int i = 0; i < blocks_to_delete; ++i)
-        cursor.movePosition(block_orientation, QTextCursor::KeepAnchor);
-
-    // now that everything is selected, delete it
-    cursor.removeSelectedText();
-
-    /*
-    * However, if we do this, we also remove the last newline of the last block that remains,
-    * which will make it difficult to append new blocks to it/figure out the amount of blocks
-    * if we have a scroll up log, so we add it again if we removed any break characters at all
-    * */
-    if (!m_chatlog_scrolldown && blocks_to_delete > 0)
-        cursor.insertBlock();
-
-    /*
-    * Unfortunately, the simplest alternative, that is, move cursor to the last block, remove
-    * the block under it and delete the last char does not work, as this also removes the last
-    * character of the block that remains. That's why we have to do this whole complicated
-    * process.
-    * */
-    if (prev_cursor.hasSelection() || !is_scrolled)
-    {
-        // restore previous selection and vscrollbar
-        ui_ic_chatlog->setTextCursor(prev_cursor);
-        vscrollbar->setValue(scroll_pos);
-    }
-    // scroll up/down depending on context
-    else
-    {
-        ui_ic_chatlog->moveCursor(move_type);
-        vscrollbar->setValue(m_chatlog_scrolldown ? vscrollbar->maximum() : vscrollbar->minimum());
-    }
+  /*
+   * Unfortunately, the simplest alternative, that is, move cursor to the last
+   * block, remove the block under it and delete the last char does not work, as
+   * this also removes the last character of the block that remains. That's why
+   * we have to do this whole complicated process.
+   * */
+  if (prev_cursor.hasSelection() || !is_scrolled)
+  {
+    // restore previous selection and vscrollbar
+    ui_ic_chatlog->setTextCursor(prev_cursor);
+    vscrollbar->setValue(scroll_pos);
+  }
+  // scroll up/down depending on context
+  else
+  {
+    ui_ic_chatlog->moveCursor(move_type);
+    vscrollbar->setValue(m_chatlog_scrolldown ? vscrollbar->maximum()
+                                              : vscrollbar->minimum());
+  }
 }
 
-void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music)
+void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system,
+                               bool p_music)
 {
   // record new entry
-  m_ic_records.append(std::make_shared<record_type>(p_name, p_line, "", p_system, p_music));
+  m_ic_records.append(
+      std::make_shared<record_type>(p_name, p_line, "", p_system, p_music));
 
   // update
   update_ic_log(false);
@@ -1250,7 +1298,8 @@ void Courtroom::play_preanim()
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
-  //all time values in char.inis are multiplied by a constant(time_mod) to get the actual time
+  // all time values in char.inis are multiplied by a constant(time_mod) to get
+  // the actual time
   int text_delay = ao_app->get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * 60;
 
@@ -1261,19 +1310,20 @@ void Courtroom::play_preanim()
 
   if (!m_msg_is_first_person)
   {
-      QString f_anim_path = ao_app->get_character_path(f_char) + f_preanim.toLower();
-      if (ui_vp_player_char->play_pre(f_char, f_preanim, true))
-      {
-          if (text_delay >= 0)
-              text_delay_timer->start(text_delay);
+    QString f_anim_path =
+        ao_app->get_character_path(f_char) + f_preanim.toLower();
+    if (ui_vp_player_char->play_pre(f_char, f_preanim, true))
+    {
+      if (text_delay >= 0)
+        text_delay_timer->start(text_delay);
 
-          // finished
-          return;
-      }
-      else
-      {
-          qDebug() << "could not find " + f_anim_path;
-      }
+      // finished
+      return;
+    }
+    else
+    {
+      qDebug() << "could not find " + f_anim_path;
+    }
   }
 
   // no animation, continue
@@ -1296,13 +1346,14 @@ void Courtroom::start_chat_ticking()
 
   set_text_color();
   rainbow_counter = 0;
-  //we need to ensure that the text isn't already ticking because this function can be called by two logic paths
+  // we need to ensure that the text isn't already ticking because this function
+  // can be called by two logic paths
   if (text_state != 0)
     return;
 
   if (chatmessage_is_empty)
   {
-    //since the message is empty, it's technically done ticking
+    // since the message is empty, it's technically done ticking
     text_state = 2;
     return;
   }
@@ -1318,14 +1369,14 @@ void Courtroom::start_chat_ticking()
   //  m_blip_player->set_file(f_gender);
   m_blips_player->set_blips("sfx-blip" + f_gender + ".wav");
 
-  //means text is currently ticking
+  // means text is currently ticking
   text_state = 1;
 }
 
 void Courtroom::chat_tick()
 {
-  //note: this is called fairly often(every 60 ms when char is talking)
-  //do not perform heavy operations here
+  // note: this is called fairly often(every 60 ms when char is talking)
+  // do not perform heavy operations here
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
   if (ao_app->get_font_property("message_outline", fonts_ini) == 1)
     vp_message_format.setTextOutline(QPen(Qt::black, 1));
@@ -1342,7 +1393,8 @@ void Courtroom::chat_tick()
 
     if (!m_msg_is_first_person)
     {
-        ui_vp_player_char->play_idle(m_chatmessage[CHAR_NAME], m_chatmessage[EMOTE], true);
+      ui_vp_player_char->play_idle(m_chatmessage[CHAR_NAME],
+                                   m_chatmessage[EMOTE], true);
     }
 
     m_string_color = "";
@@ -1386,18 +1438,21 @@ void Courtroom::chat_tick()
 
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
     }
-    else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) == "true")
+    else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) ==
+             "true")
     {
       bool highlight_found = false;
       bool render_character = true;
-      // render_character should only be false if the character is a highlight character
-      // specifically marked as a character that should not be rendered.
+      // render_character should only be false if the character is a highlight
+      // character specifically marked as a character that should not be
+      // rendered.
       QVector<QStringList> f_vec = ao_app->get_highlight_color();
-      if(m_color_stack.isEmpty()) m_color_stack.push("");
+      if (m_color_stack.isEmpty())
+        m_color_stack.push("");
 
-      for(const auto& col : f_vec)
+      for (const auto &col : f_vec)
       {
-        if(f_character == col[0][0] && m_string_color != col[1])
+        if (f_character == col[0][0] && m_string_color != col[1])
         {
           m_color_stack.push(col[1]);
           m_string_color = m_color_stack.top();
@@ -1419,11 +1474,12 @@ void Courtroom::chat_tick()
 
       QString m_future_string_color = m_string_color;
 
-      for(const auto& col : f_vec)
+      for (const auto &col : f_vec)
       {
-        if(f_character == col[0][1] && !highlight_found)
+        if (f_character == col[0][1] && !highlight_found)
         {
-          if(m_color_stack.size() > 1) m_color_stack.pop();
+          if (m_color_stack.size() > 1)
+            m_color_stack.pop();
           m_future_string_color = m_color_stack.top();
           highlight_found = true;
           render_character = (col[2] != "0");
@@ -1489,7 +1545,7 @@ void Courtroom::play_sfx()
   if (sfx_name == "1")
     return;
 
-  QVector<QString> extensions{ "", ".ogg", ".wav", ".mp3"};
+  QVector<QString> extensions{"", ".ogg", ".wav", ".mp3"};
   QString general_path = ao_app->get_base_path() + "/sounds/general/";
 
   QString f_ext = file_exists(general_path + sfx_name, extensions);
@@ -1589,10 +1645,11 @@ void Courtroom::handle_song(QStringList *p_contents)
   QString f_song = f_contents.at(0);
   int n_char = f_contents.at(1).toInt();
 
-  for (auto& ext : QStringList { "", ".wav", ".ogg", ".mp3" })
+  for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
   {
     QString r_song = f_song + ext;
-    QString song_path = ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
+    QString song_path =
+        ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
     if (file_exists(song_path))
     {
       f_song = r_song;
@@ -1608,8 +1665,8 @@ void Courtroom::handle_song(QStringList *p_contents)
   {
     // This 2th argument corresponds to the showname to use when displaying the
     // music change message in IC
-    // Backwards compatibility is explicitly kept for older versions of tsuserver
-    // that do not send such an argument by assuming an empty showname
+    // Backwards compatibility is explicitly kept for older versions of
+    // tsuserver that do not send such an argument by assuming an empty showname
     // If there is an empty showname, the client will use instead the default
     // showname of the character.
     QString f_showname;
@@ -1655,13 +1712,14 @@ void Courtroom::handle_wtce(QString p_wtce)
   QString sfx_file = cc_sounds_ini;
 
   int index = p_wtce.at(p_wtce.size() - 1).digitValue();
-  if (index > 0 && index < wtce_names.size() + 1 && wtce_names.size() > 0) // check to prevent crash
+  if (index > 0 && index < wtce_names.size() + 1 &&
+      wtce_names.size() > 0) // check to prevent crash
   {
     p_wtce.chop(1); // looking for the 'testimony' part
     if (p_wtce == "testimony")
     {
-      m_effects_player->play(ao_app->get_sfx(wtce_names[index-1]));
-      ui_vp_wtce->play(wtce_names[index-1]);
+      m_effects_player->play(ao_app->get_sfx(wtce_names[index - 1]));
+      ui_vp_wtce->play(wtce_names[index - 1]);
       if (index == 1)
       {
         testimony_in_progress = true;
@@ -1684,7 +1742,8 @@ void Courtroom::set_hp_bar(int p_bar, int p_state)
   }
   else if (p_bar == 2)
   {
-    ui_prosecution_bar->set_image("prosecutionbar" + QString::number(p_state) + ".png");
+    ui_prosecution_bar->set_image("prosecutionbar" + QString::number(p_state) +
+                                  ".png");
     prosecution_bar_state = p_state;
   }
 }
@@ -1716,8 +1775,7 @@ void Courtroom::on_ooc_return_pressed()
 
   if (ooc_message.isEmpty())
   {
-    append_server_chatmessage(
-           "CLIENT", "You cannot send an empty message.");
+    append_server_chatmessage("CLIENT", "You cannot send an empty message.");
     return;
   }
   if (ooc_name.isEmpty())
@@ -1726,18 +1784,18 @@ void Courtroom::on_ooc_return_pressed()
     QString name;
     do
     {
-      ooc_name = QInputDialog::getText(this,
-                                       "Enter a name",
-                                       "You must have a name to talk in OOC chat. Enter a name: ",
-                                       QLineEdit::Normal,
-                                       "user", &ok);
+      ooc_name = QInputDialog::getText(
+          this, "Enter a name",
+          "You must have a name to talk in OOC chat. Enter a name: ",
+          QLineEdit::Normal, "user", &ok);
     } while (ok && ooc_name.isEmpty());
     if (!ok)
       return;
 
     ao_config->set_username(ooc_name);
   }
-  else if (ooc_message.startsWith("/rainbow") && ao_app->yellow_text_enabled && !rainbow_appended)
+  else if (ooc_message.startsWith("/rainbow") && ao_app->yellow_text_enabled &&
+           !rainbow_appended)
   {
     ui_text_color->addItem("Rainbow");
     ui_ooc_chat_message->clear();
@@ -1746,21 +1804,21 @@ void Courtroom::on_ooc_return_pressed()
   }
   else if (ooc_message.startsWith("/switch_am"))
   {
-      on_switch_area_music_clicked();
-      ui_ooc_chat_message->clear();
-      return;
+    on_switch_area_music_clicked();
+    ui_ooc_chat_message->clear();
+    return;
   }
   else if (ooc_message.startsWith("/rollp"))
   {
-   m_effects_player->play(ao_app->get_sfx("dice"));
+    m_effects_player->play(ao_app->get_sfx("dice"));
   }
   else if (ooc_message.startsWith("/roll"))
   {
-   m_effects_player->play(ao_app->get_sfx("dice"));
+    m_effects_player->play(ao_app->get_sfx("dice"));
   }
   else if (ooc_message.startsWith("/coinflip"))
   {
-   m_effects_player->play(ao_app->get_sfx("coinflip"));
+    m_effects_player->play(ao_app->get_sfx("coinflip"));
   }
   else if (ooc_message.startsWith("/tr "))
   {
@@ -1771,7 +1829,7 @@ void Courtroom::on_ooc_return_pressed()
     if (space_location == -1)
       timer_id = 0;
     else
-     timer_id = ooc_message.mid(space_location+1).toInt();
+      timer_id = ooc_message.mid(space_location + 1).toInt();
     resume_timer(timer_id);
   }
   else if (ooc_message.startsWith("/ts "))
@@ -1780,14 +1838,15 @@ void Courtroom::on_ooc_return_pressed()
     QStringList arguments = ooc_message.split(" ");
     int size = arguments.size();
 
-    // Note arguments[0] == "/ts", so every index (and thus length) is off by one.
+    // Note arguments[0] == "/ts", so every index (and thus length) is off by
+    // one.
     if (size > 5)
       return;
 
     int timer_id = (size > 1 ? arguments[1].toInt() : 0);
-    int new_time = (size > 2 ? arguments[2].toInt() : 300)*1000;
-    int timestep_length = (size > 3 ? arguments[3].toDouble() : -.016)*1000;
-    int firing_interval = (size > 4 ? arguments[4].toDouble() : .016)*1000;
+    int new_time = (size > 2 ? arguments[2].toInt() : 300) * 1000;
+    int timestep_length = (size > 3 ? arguments[3].toDouble() : -.016) * 1000;
+    int firing_interval = (size > 4 ? arguments[4].toDouble() : .016) * 1000;
     set_timer_time(timer_id, new_time);
     set_timer_timestep(timer_id, timestep_length);
     set_timer_firing(timer_id, firing_interval);
@@ -1801,7 +1860,7 @@ void Courtroom::on_ooc_return_pressed()
     if (space_location == -1)
       timer_id = 0;
     else
-     timer_id = ooc_message.mid(space_location+1).toInt();
+      timer_id = ooc_message.mid(space_location + 1).toInt();
     pause_timer(timer_id);
   }
   QStringList packet_contents;
@@ -1819,7 +1878,7 @@ void Courtroom::on_ooc_return_pressed()
 
 void Courtroom::on_music_search_edited(QString p_text)
 {
-  //preventing compiler warnings
+  // preventing compiler warnings
   p_text += "a";
   list_music();
   list_areas();
@@ -1827,7 +1886,7 @@ void Courtroom::on_music_search_edited(QString p_text)
 
 void Courtroom::on_sfx_search_edited(QString p_text)
 {
-  //preventing compiler warnings
+  // preventing compiler warnings
   p_text += "a";
   list_sfx();
 }
@@ -1870,10 +1929,11 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
 
   set_judge_enabled(f_pos == "jud");
 
-  ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
+  ao_app->send_server_packet(
+      new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
   // Uncomment later and remove above
   // Will only work in TSDR 4.3+ servers
-  //ao_app->send_server_packet(new AOPacket("SP#" + f_pos + "#%"));
+  // ao_app->send_server_packet(new AOPacket("SP#" + f_pos + "#%"));
 }
 
 void Courtroom::on_mute_list_clicked(QModelIndex p_index)
@@ -1889,7 +1949,7 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
 
   int f_cid = -1;
 
-  for (int n_char = 0 ; n_char < char_list.size() ; n_char++)
+  for (int n_char = 0; n_char < char_list.size(); n_char++)
   {
     if (char_list.at(n_char).name == real_char)
       f_cid = n_char;
@@ -1911,8 +1971,6 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
     mute_map.insert(f_cid, true);
     f_item->setText(real_char + " [x]");
   }
-
-
 
   /*
   if (f_char.endsWith(" [x]"))
@@ -1949,7 +2007,9 @@ void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
 
   QString p_song = ui_music_list->item(p_model.row())->text();
 
-  ao_app->send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"), false);
+  ao_app->send_server_packet(
+      new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"),
+      false);
 
   ui_ic_chat_message->setFocus();
 }
@@ -1958,23 +2018,27 @@ void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
 {
   QString p_area = ui_area_list->item(p_model.row())->text();
 
-  ao_app->send_server_packet(new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"), false);
+  ao_app->send_server_packet(
+      new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"),
+      false);
 
   ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::reset_shout_buttons()
 {
-  for(int i = 0; i < ui_shouts.size(); ++i)
+  for (int i = 0; i < ui_shouts.size(); ++i)
     ui_shouts[i]->set_image(shout_names.at(i) + ".png");
 
-  if(m_objection_state != 0 && ui_shouts.size() > 0) // check to prevent crashing
-    ui_shouts.at(m_objection_state-1)->set_image(shout_names.at(m_objection_state-1) + "_selected.png");
+  if (m_objection_state != 0 &&
+      ui_shouts.size() > 0) // check to prevent crashing
+    ui_shouts.at(m_objection_state - 1)
+        ->set_image(shout_names.at(m_objection_state - 1) + "_selected.png");
 }
 
 void Courtroom::on_shout_clicked()
 {
-  AOButton *f_shout_button = static_cast<AOButton*>(sender());
+  AOButton *f_shout_button = static_cast<AOButton *>(sender());
   int f_shout_id = f_shout_button->property("shout_id").toInt();
 
   // update based on current button selected
@@ -1990,10 +2054,10 @@ void Courtroom::on_shout_clicked()
 
 void Courtroom::on_cycle_clicked()
 {
-  AOButton *f_cycle_button = static_cast<AOButton*>(sender());
+  AOButton *f_cycle_button = static_cast<AOButton *>(sender());
   int f_cycle_id = f_cycle_button->property("cycle_id").toInt();
 
-  switch(f_cycle_id)
+  switch (f_cycle_id)
   {
   case 5:
     cycle_wtce(-1);
@@ -2027,7 +2091,10 @@ void Courtroom::on_cycle_clicked()
 void Courtroom::cycle_shout(int p_index)
 {
   int n = ui_shouts.size();
-  do { m_shout_state = (m_shout_state - p_index + n) % n; } while( !shouts_enabled[m_shout_state] );
+  do
+  {
+    m_shout_state = (m_shout_state - p_index + n) % n;
+  } while (!shouts_enabled[m_shout_state]);
 
   set_shouts();
 }
@@ -2035,7 +2102,10 @@ void Courtroom::cycle_shout(int p_index)
 void Courtroom::cycle_effect(int p_index)
 {
   int n = ui_effects.size();
-  do { m_effect_current = (m_effect_current - p_index + n) % n; } while( !effects_enabled[m_effect_current] );
+  do
+  {
+    m_effect_current = (m_effect_current - p_index + n) % n;
+  } while (!effects_enabled[m_effect_current]);
 
   set_effects();
 }
@@ -2043,7 +2113,10 @@ void Courtroom::cycle_effect(int p_index)
 void Courtroom::cycle_wtce(int p_index)
 {
   int n = ui_wtce.size();
-  do { m_wtce_current = (m_wtce_current - p_index + n) % n; } while ( !wtce_enabled[m_wtce_current] );
+  do
+  {
+    m_wtce_current = (m_wtce_current - p_index + n) % n;
+  } while (!wtce_enabled[m_wtce_current]);
 
   set_judge_wtce();
 }
@@ -2051,19 +2124,20 @@ void Courtroom::cycle_wtce(int p_index)
 void Courtroom::reset_effect_buttons()
 {
   // effect names does not necessarily have the same size as ui effects
-  for(int i = 0; i < effect_names.size(); ++i)
+  for (int i = 0; i < effect_names.size(); ++i)
   {
     // qDebug() << effect_names << i;
     ui_effects[i]->set_image(effect_names.at(i) + ".png");
   }
 
-  if(m_effect_state != 0 && ui_effects.size() > 0) // check to prevent crashing
-    ui_effects[m_effect_state-1]->set_image(effect_names.at(m_effect_state-1) + "_pressed.png");
+  if (m_effect_state != 0 && ui_effects.size() > 0) // check to prevent crashing
+    ui_effects[m_effect_state - 1]->set_image(
+        effect_names.at(m_effect_state - 1) + "_pressed.png");
 }
 
 void Courtroom::on_effect_button_clicked()
 {
-  AOButton *f_button = static_cast<AOButton*>(this->sender());
+  AOButton *f_button = static_cast<AOButton *>(this->sender());
 
   int f_effect_id = f_button->property("effect_id").toInt();
   if (m_effect_state == f_effect_id)
@@ -2095,7 +2169,8 @@ void Courtroom::on_defense_minus_clicked()
   int f_state = defense_bar_state - 1;
 
   if (f_state >= 0)
-    ao_app->send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    ao_app->send_server_packet(
+        new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_defense_plus_clicked()
@@ -2103,7 +2178,8 @@ void Courtroom::on_defense_plus_clicked()
   int f_state = defense_bar_state + 1;
 
   if (f_state <= 10)
-    ao_app->send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    ao_app->send_server_packet(
+        new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_minus_clicked()
@@ -2111,7 +2187,8 @@ void Courtroom::on_prosecution_minus_clicked()
   int f_state = prosecution_bar_state - 1;
 
   if (f_state >= 0)
-    ao_app->send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    ao_app->send_server_packet(
+        new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_plus_clicked()
@@ -2119,7 +2196,8 @@ void Courtroom::on_prosecution_plus_clicked()
   int f_state = prosecution_bar_state + 1;
 
   if (f_state <= 10)
-    ao_app->send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    ao_app->send_server_packet(
+        new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_text_color_changed(int p_color)
@@ -2148,9 +2226,12 @@ void Courtroom::on_cross_examination_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::reset_judge_wtce_buttons() // kind of an unnecessary function, but I added it just in case
+void Courtroom::reset_judge_wtce_buttons() // kind of an unnecessary function,
+                                           // but I added it just in case
 {
-  for(int i = 0; i < wtce_names.size(); ++i) // effect names does not necessarily have the same size as ui effects
+  for (int i = 0; i < wtce_names.size();
+       ++i) // effect names does not necessarily have the same size as ui
+            // effects
   {
     ui_wtce[i]->set_image(wtce_names.at(i) + ".png");
   }
@@ -2158,11 +2239,11 @@ void Courtroom::reset_judge_wtce_buttons() // kind of an unnecessary function, b
 
 void Courtroom::on_wtce_clicked()
 {
-//  qDebug() << "AA: wtce clicked!";
+  //  qDebug() << "AA: wtce clicked!";
   if (is_client_muted)
     return;
 
-  AOButton* f_sig = static_cast<AOButton*>(sender());
+  AOButton *f_sig = static_cast<AOButton *>(sender());
   QString id = f_sig->property("wtce_id").toString();
 
   QString packet = QString("RT#testimony%1#%").arg(id);
@@ -2184,27 +2265,27 @@ void Courtroom::on_change_character_clicked()
 
 void Courtroom::on_app_reload_theme_requested()
 {
-    load_shouts();
-    load_effects();
-    load_wtce();
-    load_free_blocks();
+  load_shouts();
+  load_effects();
+  load_wtce();
+  load_free_blocks();
 
-    //to update status on the background
-    set_background(current_background);
-    enter_courtroom(m_cid);
-    anim_state = 4;
-    text_state = 3;
+  // to update status on the background
+  set_background(current_background);
+  enter_courtroom(m_cid);
+  anim_state = 4;
+  text_state = 3;
 }
 
 void Courtroom::on_back_to_lobby_clicked()
 {
-    // hide so we don't get the 'disconnected from server' prompt
-    hide();
+  // hide so we don't get the 'disconnected from server' prompt
+  hide();
 
-    ao_app->construct_lobby();
-    ao_app->w_lobby->list_servers();
-    ao_app->w_lobby->set_choose_a_server();
-    ao_app->destruct_courtroom();
+  ao_app->construct_lobby();
+  ao_app->w_lobby->list_servers();
+  ao_app->w_lobby->set_choose_a_server();
+  ao_app->destruct_courtroom();
 }
 
 void Courtroom::on_char_select_left_clicked()
@@ -2221,7 +2302,8 @@ void Courtroom::on_char_select_right_clicked()
 
 void Courtroom::on_spectator_clicked()
 {
-  QString content = "CC#" + QString::number(ao_app->s_pv) + "#-1#" + get_hdid() + "#%";
+  QString content =
+      "CC#" + QString::number(ao_app->s_pv) + "#-1#" + get_hdid() + "#%";
   ao_app->send_server_packet(new AOPacket(content));
   enter_courtroom(-1);
 
@@ -2233,10 +2315,13 @@ void Courtroom::on_spectator_clicked()
 void Courtroom::on_call_mod_clicked()
 {
   QMessageBox::StandardButton reply;
-  QString warning = "Are you sure you want to call a mod? They will get angry at you if the reason is no good.";
-  reply = QMessageBox::warning(this, "Warning", warning, QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+  QString warning = "Are you sure you want to call a mod? They will get angry "
+                    "at you if the reason is no good.";
+  reply =
+      QMessageBox::warning(this, "Warning", warning,
+                           QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
-  if(reply == QMessageBox::Yes)
+  if (reply == QMessageBox::Yes)
   {
     ao_app->send_server_packet(new AOPacket("ZZ#%"));
     qDebug() << "Called mod";
@@ -2249,18 +2334,17 @@ void Courtroom::on_call_mod_clicked()
 
 void Courtroom::on_switch_area_music_clicked()
 {
-    if (ui_area_list->isHidden())
-    {
-        ui_area_list->show();
-        ui_music_list->hide();
-    }
-    else
-    {
-        ui_area_list->hide();
-        ui_music_list->show();
-    }
+  if (ui_area_list->isHidden())
+  {
+    ui_area_list->show();
+    ui_music_list->hide();
+  }
+  else
+  {
+    ui_area_list->hide();
+    ui_music_list->show();
+  }
 }
-
 
 void Courtroom::on_pre_clicked()
 {
@@ -2292,13 +2376,13 @@ void Courtroom::on_evidence_button_clicked()
 
 void Courtroom::on_config_panel_clicked()
 {
-    ao_app->toggle_config_panel();
-    ui_ic_chat_message->setFocus();
+  ao_app->toggle_config_panel();
+  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::on_note_button_clicked()
 {
-  if(!note_shown)
+  if (!note_shown)
   {
     load_note();
     ui_vp_notepad_image->show();
@@ -2323,23 +2407,24 @@ void Courtroom::on_note_text_changed()
 
 void Courtroom::ping_server()
 {
-  ao_app->send_server_packet(new AOPacket("CH#" + QString::number(m_cid) + "#%"));
+  ao_app->send_server_packet(
+      new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }
 
 void Courtroom::closeEvent(QCloseEvent *event)
 {
-    emit closing();
-    QMainWindow::closeEvent(event);
+  emit closing();
+  QMainWindow::closeEvent(event);
 }
 
 void Courtroom::on_sfx_list_clicked()
 {
-    ui_ic_chat_message->setFocus();
+  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::on_set_notes_clicked()
 {
-  if(note_scroll_area->isHidden())
+  if (note_scroll_area->isHidden())
     note_scroll_area->show();
   else
     note_scroll_area->hide();

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -283,7 +283,10 @@ void Courtroom::set_char_rpc()
 }
 
 #if (defined(_WIN32) || defined(_WIN64))
-void Courtroom::load_bass_opus_plugin() { BASS_PluginLoad("bassopus.dll", 0); }
+void Courtroom::load_bass_opus_plugin()
+{
+  BASS_PluginLoad("bassopus.dll", 0);
+}
 #elif (defined(LINUX) || defined(__linux__))
 void Courtroom::load_bass_opus_plugin()
 {
@@ -845,7 +848,10 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     handle_chatmessage_2();
 }
 
-void Courtroom::objection_done() { handle_chatmessage_2(); }
+void Courtroom::objection_done()
+{
+  handle_chatmessage_2();
+}
 
 void Courtroom::handle_chatmessage_2() // handles IC
 {
@@ -1346,9 +1352,15 @@ void Courtroom::play_preanim()
   preanim_done();
 }
 
-void Courtroom::preanim_done() { handle_chatmessage_3(); }
+void Courtroom::preanim_done()
+{
+  handle_chatmessage_3();
+}
 
-void Courtroom::realization_done() { ui_vp_effect->stop(); }
+void Courtroom::realization_done()
+{
+  ui_vp_effect->stop();
+}
 
 void Courtroom::start_chat_ticking()
 {
@@ -2000,9 +2012,15 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
   */
 }
 
-void Courtroom::on_music_list_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_music_list_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
-void Courtroom::on_area_list_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_area_list_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
 void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
 {
@@ -2350,11 +2368,20 @@ void Courtroom::on_switch_area_music_clicked()
   }
 }
 
-void Courtroom::on_pre_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_pre_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
-void Courtroom::on_flip_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_flip_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
-void Courtroom::on_hidden_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_hidden_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
 void Courtroom::on_evidence_button_clicked()
 {
@@ -2412,7 +2439,10 @@ void Courtroom::closeEvent(QCloseEvent *event)
   QMainWindow::closeEvent(event);
 }
 
-void Courtroom::on_sfx_list_clicked() { ui_ic_chat_message->setFocus(); }
+void Courtroom::on_sfx_list_clicked()
+{
+  ui_ic_chat_message->setFocus();
+}
 
 void Courtroom::on_set_notes_clicked()
 {

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -21,7 +21,8 @@
 #include <QTextCharFormat>
 #include <QTime>
 
-Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow() {
+Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
+{
   ao_app = p_ao_app;
   ao_config = new AOConfig(this);
 
@@ -37,7 +38,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow() {
   set_widget_names();
 }
 
-void Courtroom::enter_courtroom(int p_cid) {
+void Courtroom::enter_courtroom(int p_cid)
+{
   bool changed_character = (m_cid != p_cid);
   m_cid = p_cid;
 
@@ -45,10 +47,13 @@ void Courtroom::enter_courtroom(int p_cid) {
 
   set_char_rpc();
 
-  if (m_cid == -1) {
+  if (m_cid == -1)
+  {
     ao_app->discord->state_spectate();
     f_char = "";
-  } else {
+  }
+  else
+  {
     f_char = ao_app->get_char_name(char_list.at(m_cid).name);
     QString r_char = f_char;
     // regex for removing non letter (except _) characters
@@ -56,9 +61,12 @@ void Courtroom::enter_courtroom(int p_cid) {
         QString::fromUtf8("[-`~!@#$%^&*()—+=|:;<>«»,.?/{}\'\"\\[\\]]"));
     r_char.remove(re);
 
-    if (!rpc_char_list.contains(f_char.toLower())) {
+    if (!rpc_char_list.contains(f_char.toLower()))
+    {
       ao_app->discord->toggle(1);
-    } else {
+    }
+    else
+    {
       ao_app->discord->toggle(0);
     }
 
@@ -144,7 +152,8 @@ void Courtroom::enter_courtroom(int p_cid) {
   set_widget_layers();
 }
 
-void Courtroom::done_received() {
+void Courtroom::done_received()
+{
   m_cid = -1;
 
   set_audio_mute_enabled(true);
@@ -160,11 +169,13 @@ void Courtroom::done_received() {
   ui_spectator->show();
 }
 
-void Courtroom::set_window_title(QString p_title) {
+void Courtroom::set_window_title(QString p_title)
+{
   this->setWindowTitle(p_title);
 }
 
-void Courtroom::set_scene() {
+void Courtroom::set_scene()
+{
   if (testimony_in_progress)
     show_testimony();
 
@@ -175,7 +186,8 @@ void Courtroom::set_scene() {
   QString f_side = m_chatmessage[SIDE];
   QString ini_path = ao_app->get_background_path("backgrounds.ini");
 
-  if (file_exists(ini_path)) {
+  if (file_exists(ini_path))
+  {
     f_background = ao_app->read_design_ini(f_side, ini_path);
     f_desk_image = ao_app->read_design_ini(f_side + "_desk", ini_path);
 
@@ -183,23 +195,36 @@ void Courtroom::set_scene() {
     {
       ui_vp_desk->hide();
     }
-  } else {
-    if (f_side == "def") {
+  }
+  else
+  {
+    if (f_side == "def")
+    {
       f_background = "defenseempty";
       f_desk_image = "defensedesk";
-    } else if (f_side == "pro") {
+    }
+    else if (f_side == "pro")
+    {
       f_background = "prosecutorempty";
       f_desk_image = "prosecutiondesk";
-    } else if (f_side == "jud") {
+    }
+    else if (f_side == "jud")
+    {
       f_background = "judgestand";
       f_desk_image = "judgedesk";
-    } else if (f_side == "hld") {
+    }
+    else if (f_side == "hld")
+    {
       f_background = "helperstand";
       f_desk_image = "helperdesk";
-    } else if (f_side == "hlp") {
+    }
+    else if (f_side == "hlp")
+    {
       f_background = "prohelperstand";
       f_desk_image = "prohelperdesk";
-    } else {
+    }
+    else
+    {
       f_desk_image = "stand";
     }
 
@@ -232,18 +257,21 @@ void Courtroom::set_scene() {
   ui_vp_desk->set_image(f_desk_image);
 }
 
-void Courtroom::set_char_rpc() {
+void Courtroom::set_char_rpc()
+{
   rpc_char_list.clear();
 
   QFile config_file(ao_app->get_base_path() + rpc_ini);
-  if (!config_file.open(QIODevice::ReadOnly)) {
+  if (!config_file.open(QIODevice::ReadOnly))
+  {
     qDebug() << "Error reading" << ao_app->get_base_path() + rpc_ini;
     return;
   }
 
   QTextStream in(&config_file);
 
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString f_line = in.readLine().trimmed();
 
     QStringList line_elements = f_line.split("-");
@@ -257,19 +285,23 @@ void Courtroom::set_char_rpc() {
 #if (defined(_WIN32) || defined(_WIN64))
 void Courtroom::load_bass_opus_plugin() { BASS_PluginLoad("bassopus.dll", 0); }
 #elif (defined(LINUX) || defined(__linux__))
-void Courtroom::load_bass_opus_plugin() {
+void Courtroom::load_bass_opus_plugin()
+{
   BASS_PluginLoad("libbassopus.so", 0);
 }
 #elif defined __APPLE__
-void Courtroom::load_bass_opus_plugin() {
+void Courtroom::load_bass_opus_plugin()
+{
   BASS_PluginLoad("libbassopus.dylib", 0);
 }
 #else
 #error This operating system is unsupported for BASS plugins.
 #endif
 
-void Courtroom::set_taken(int n_char, bool p_taken) {
-  if (n_char >= char_list.size()) {
+void Courtroom::set_taken(int n_char, bool p_taken)
+{
+  if (n_char >= char_list.size())
+  {
     qDebug()
         << "W: set_taken attempted to set an index bigger than char_list size";
     return;
@@ -284,12 +316,14 @@ void Courtroom::set_taken(int n_char, bool p_taken) {
   char_list.replace(n_char, f_char);
 }
 
-void Courtroom::set_background(QString p_background) {
+void Courtroom::set_background(QString p_background)
+{
   testimony_in_progress = false;
   current_background = p_background;
 }
 
-void Courtroom::handle_music_anim() {
+void Courtroom::handle_music_anim()
+{
   QString file_a = design_ini;
   QString file_b = fonts_ini;
   pos_size_type res_a = ao_app->get_element_dimensions("music_name", file_a);
@@ -315,7 +349,8 @@ void Courtroom::handle_music_anim() {
   music_anim->start();
 }
 
-void Courtroom::handle_clock(QString time) {
+void Courtroom::handle_clock(QString time)
+{
   current_clock = time.toInt();
 
   QString string = "hours\\" + time; // expected to be 0, 1, 2...
@@ -323,11 +358,13 @@ void Courtroom::handle_clock(QString time) {
   ui_vp_clock->play(string);
 }
 
-void Courtroom::handle_theme_variant(QString theme_variant) {
+void Courtroom::handle_theme_variant(QString theme_variant)
+{
   ao_app->set_theme_variant(theme_variant);
   on_app_reload_theme_requested();
 }
-void Courtroom::list_music() {
+void Courtroom::list_music()
+{
   ui_music_list->clear();
 
   QString f_file = design_ini;
@@ -337,21 +374,25 @@ void Courtroom::list_music() {
 
   int n_listed_songs = 0;
 
-  for (int n_song = 0; n_song < music_list.size(); ++n_song) {
+  for (int n_song = 0; n_song < music_list.size(); ++n_song)
+  {
     QString i_song = music_list.at(n_song);
     bool found = false;
 
-    for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"}) {
+    for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
+    {
       QString r_song = i_song + ext;
       QString song_path =
           ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
-      if (file_exists(song_path)) {
+      if (file_exists(song_path))
+      {
         found = true;
         break;
       }
     }
 
-    if (i_song.toLower().contains(ui_music_search->text().toLower())) {
+    if (i_song.toLower().contains(ui_music_search->text().toLower()))
+    {
       ui_music_list->addItem(i_song);
 
       if (found)
@@ -364,7 +405,8 @@ void Courtroom::list_music() {
   }
 }
 
-void Courtroom::list_areas() {
+void Courtroom::list_areas()
+{
   ui_area_list->clear();
   //  area_names.clear();
 
@@ -380,12 +422,14 @@ void Courtroom::list_areas() {
 
   int n_listed_areas = 0;
 
-  for (int n_area = 0; n_area < area_list.size(); ++n_area) {
+  for (int n_area = 0; n_area < area_list.size(); ++n_area)
+  {
     QString i_area = "";
 
     i_area.append(area_list.at(n_area));
 
-    if (i_area.toLower().contains(ui_music_search->text().toLower())) {
+    if (i_area.toLower().contains(ui_music_search->text().toLower()))
+    {
       ui_area_list->addItem(i_area);
       //      area_names.append(i_);
 
@@ -396,7 +440,8 @@ void Courtroom::list_areas() {
   }
 }
 
-void Courtroom::list_sfx() {
+void Courtroom::list_sfx()
+{
   ui_sfx_list->clear();
   sfx_names.clear();
 
@@ -415,7 +460,8 @@ void Courtroom::list_sfx() {
 
   int n_listed_sfxs = 0;
 
-  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx) {
+  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
+  {
     QStringList sfx = sfx_list.at(n_sfx).split("=");
     QString i_sfx = sfx.at(0).trimmed();
     QString d_sfx = "";
@@ -427,7 +473,8 @@ void Courtroom::list_sfx() {
 
     //    qDebug() << "isfx=" << i_sfx << "dsfx=" << d_sfx << "sfx=" << sfx;
 
-    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower())) {
+    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
+    {
       ui_sfx_list->addItem(d_sfx);
       ui_sfx_list->item(ui_sfx_list->count() - 1)
           ->setStatusTip(QString::number(n_sfx + 2));
@@ -445,10 +492,12 @@ void Courtroom::list_sfx() {
   }
 }
 
-void Courtroom::list_note_files() {
+void Courtroom::list_note_files()
+{
   QString f_config = ao_app->get_base_path() + file_select_ini;
   QFile f_file(f_config);
-  if (!f_file.open(QIODevice::ReadOnly)) {
+  if (!f_file.open(QIODevice::ReadOnly))
+  {
     qDebug() << "Couldn't open" << f_config;
     return;
   }
@@ -462,7 +511,8 @@ void Courtroom::list_note_files() {
 
   QVBoxLayout *f_layout = ui_note_area->m_layout;
 
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString line = in.readLine().trimmed();
 
     QStringList f_contents = line.split("=");
@@ -485,7 +535,8 @@ void Courtroom::list_note_files() {
   }
 }
 
-void Courtroom::load_note() {
+void Courtroom::load_note()
+{
   // Do not attempt to load anything if no file was chosen. This makes it so
   // that notepad text is kept in client if the user has decided not to choose a
   // file to save to. Of course, this is ephimeral storage, it will be erased
@@ -496,27 +547,31 @@ void Courtroom::load_note() {
   ui_vp_notepad->setText(f_text);
 }
 
-void Courtroom::save_note() {
+void Courtroom::save_note()
+{
 
   QString f_text = ui_vp_notepad->toPlainText();
 
   ao_app->write_note(f_text, current_file);
 }
 
-void Courtroom::save_textlog(QString p_text) {
+void Courtroom::save_textlog(QString p_text)
+{
   QString f_file = ao_app->get_base_path() + icchatlogsfilename;
 
   ao_app->append_note(p_text, f_file);
 }
 
-void Courtroom::append_server_chatmessage(QString p_name, QString p_message) {
+void Courtroom::append_server_chatmessage(QString p_name, QString p_message)
+{
   ui_server_chatlog->append_chatmessage(p_name, p_message);
   if (ao_config->log_is_recording_enabled())
     save_textlog("(OOC)[" + QTime::currentTime().toString() + "] " + p_name +
                  ": " + p_message);
 }
 
-void Courtroom::on_chat_return_pressed() {
+void Courtroom::on_chat_return_pressed()
+{
   if (ui_ic_chat_message->text() == "" || is_client_muted)
     return;
 
@@ -550,7 +605,8 @@ void Courtroom::on_chat_return_pressed() {
 
   QString f_desk_mod = "chat";
 
-  if (ao_app->desk_mod_enabled) {
+  if (ao_app->desk_mod_enabled)
+  {
     f_desk_mod =
         QString::number(ao_app->get_desk_mod(current_char, current_emote));
     if (f_desk_mod == "-1")
@@ -590,17 +646,22 @@ void Courtroom::on_chat_return_pressed() {
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
   // needed or else legacy won't understand what we're saying
-  if (m_objection_state > 0) {
+  if (m_objection_state > 0)
+  {
     if (f_emote_mod == 5)
       f_emote_mod = 6;
     else
       f_emote_mod = 2;
-  } else if (ui_pre->isChecked()) {
+  }
+  else if (ui_pre->isChecked())
+  {
     if (f_emote_mod == 0)
       f_emote_mod = 1;
     else if (f_emote_mod == 5 && ao_app->prezoom_enabled)
       f_emote_mod = 4;
-  } else {
+  }
+  else
+  {
     if (f_emote_mod == 1)
       f_emote_mod = 0;
     else if (f_emote_mod == 4)
@@ -632,12 +693,14 @@ void Courtroom::on_chat_return_pressed() {
 
   QString f_flip;
 
-  if (ao_app->flipping_enabled) {
+  if (ao_app->flipping_enabled)
+  {
     if (ui_flip->isChecked())
       f_flip = "1";
     else
       f_flip = "0";
-  } else
+  }
+  else
     f_flip = QString::number(m_cid);
 
   packet_contents.append(f_flip);
@@ -660,13 +723,15 @@ void Courtroom::on_chat_return_pressed() {
   ao_app->send_server_packet(new AOPacket("MS", packet_contents));
 }
 
-void Courtroom::handle_chatmessage(QStringList *p_contents) {
+void Courtroom::handle_chatmessage(QStringList *p_contents)
+{
   if (p_contents->size() < 15)
     return;
   else if (p_contents->size() == 15)
     p_contents->append("");
 
-  for (int n_string = 0; n_string < chatmessage_size; ++n_string) {
+  for (int n_string = 0; n_string < chatmessage_size; ++n_string)
+  {
     m_chatmessage[n_string] = p_contents->at(n_string);
     //    qDebug() << "m_chatmessage[" << n_string << "] = " <<
     //    m_chatmessage[n_string];
@@ -674,11 +739,13 @@ void Courtroom::handle_chatmessage(QStringList *p_contents) {
 
   int f_char_id = m_chatmessage[CHAR_ID].toInt();
 
-  if (f_char_id == -1) {
+  if (f_char_id == -1)
+  {
     is_system_speaking = true;
     m_chatmessage[CHAR_ID] = "0";
     f_char_id = 0;
-  } else
+  }
+  else
     is_system_speaking = false;
 
   if (f_char_id < 0 || f_char_id >= char_list.size())
@@ -692,7 +759,8 @@ void Courtroom::handle_chatmessage(QStringList *p_contents) {
   m_msg_is_first_person = false;
 
   // reset our ui state
-  if (m_cid == f_char_id && !is_system_speaking) {
+  if (m_cid == f_char_id && !is_system_speaking)
+  {
     ui_ic_chat_message->clear();
     ui_sfx_list->setCurrentItem(ui_sfx_list->item(0));
 
@@ -716,9 +784,12 @@ void Courtroom::handle_chatmessage(QStringList *p_contents) {
   qDebug() << m_chatmessage[SHOWNAME]
            << ao_app->get_showname(char_list.at(f_char_id).name);
 
-  if (m_chatmessage[SHOWNAME].isEmpty()) {
+  if (m_chatmessage[SHOWNAME].isEmpty())
+  {
     f_showname = ao_app->get_showname(char_list.at(f_char_id).name);
-  } else {
+  }
+  else
+  {
     f_showname = m_chatmessage[SHOWNAME];
   }
 
@@ -753,7 +824,8 @@ void Courtroom::handle_chatmessage(QStringList *p_contents) {
   QString f_custom_theme = ao_app->get_char_shouts(f_char);
 
   // if an objection is used
-  if (objection_mod > 0) {
+  if (objection_mod > 0)
+  {
     int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
     if (emote_mod == 0)
       m_chatmessage[EMOTE_MOD] = 1;
@@ -765,10 +837,11 @@ void Courtroom::handle_chatmessage(QStringList *p_contents) {
       ui_vp_objection->play(shout_names.at(objection_mod - 1), f_char,
                             f_custom_theme);
       m_shouts_player->play(shout_names.at(objection_mod - 1) + ".wav", f_char);
-    } else
+    }
+    else
       qDebug() << "W: Shout identifier unknown" << objection_mod;
-
-  } else
+  }
+  else
     handle_chatmessage_2();
 }
 
@@ -785,9 +858,12 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   QString f_showname;
 
-  if (m_chatmessage[SHOWNAME].isEmpty()) {
+  if (m_chatmessage[SHOWNAME].isEmpty())
+  {
     f_showname = ao_app->get_showname(real_name);
-  } else {
+  }
+  else
+  {
     f_showname = m_chatmessage[SHOWNAME];
   }
 
@@ -807,21 +883,25 @@ void Courtroom::handle_chatmessage_2() // handles IC
   QString chatbox = ao_app->get_chat(m_chatmessage[CHAR_NAME]);
 
   if (chatbox == "")
-    if (ao_app->read_theme_ini("daynight_theme", cc_config_ini) == "true") {
+    if (ao_app->read_theme_ini("daynight_theme", cc_config_ini) == "true")
+    {
       if (current_clock < 0)
         ui_vp_chatbox->set_image("chatmed.png");
       else if (current_clock >= 7 && current_clock < 22)
         ui_vp_chatbox->set_image("chatmed_day.png");
       else
         ui_vp_chatbox->set_image("chatmed_night.png");
-    } else
+    }
+    else
       ui_vp_chatbox->set_image("chatmed.png");
-  else {
+  else
+  {
     QString chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + ".png";
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 
-  if (!m_msg_is_first_person) {
+  if (!m_msg_is_first_person)
+  {
     set_scene();
   }
 
@@ -834,7 +914,8 @@ void Courtroom::handle_chatmessage_2() // handles IC
   else
     ui_vp_player_char->set_mirror_enabled(false);
 
-  switch (emote_mod) {
+  switch (emote_mod)
+  {
   case 1:
   case 2:
   case 6:
@@ -849,7 +930,8 @@ void Courtroom::handle_chatmessage_2() // handles IC
   }
 }
 
-void Courtroom::handle_chatmessage_3() {
+void Courtroom::handle_chatmessage_3()
+{
   qDebug() << "handle_chatmessage_3";
 
   start_chat_ticking();
@@ -857,7 +939,8 @@ void Courtroom::handle_chatmessage_3() {
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
   QString f_side = m_chatmessage[SIDE];
 
-  if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size()) {
+  if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size())
+  {
     // shifted by 1 because 0 is no evidence per legacy standards
     QString f_image = local_evidence_list.at(f_evi_id - 1).image;
     // def jud and hlp should display the evidence icon on the RIGHT side
@@ -868,7 +951,8 @@ void Courtroom::handle_chatmessage_3() {
 
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
 
-  if (emote_mod == 5 || emote_mod == 6) {
+  if (emote_mod == 5 || emote_mod == 6)
+  {
     QString side = m_chatmessage[SIDE];
     ui_vp_desk->hide();
 
@@ -902,20 +986,24 @@ void Courtroom::handle_chatmessage_3() {
   QString ext = ao_app->get_file_extension(
       ao_app->get_character_path(f_char, "showname"), exts);
   if (ext != "" && !chatmessage_is_empty &&
-      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) ==
-          "true") {
+      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
+  {
     ui_vp_showname->hide();
     QString path = ao_app->get_character_path(f_char, "showname" + ext);
     ui_vp_showname_image->set_image_from_path(path);
     ui_vp_showname_image->show();
-  } else {
+  }
+  else
+  {
     ui_vp_showname->show();
     ui_vp_showname_image->hide();
   }
 
-  switch (f_anim_state) {
+  switch (f_anim_state)
+  {
   case 2:
-    if (!m_msg_is_first_person) {
+    if (!m_msg_is_first_person)
+    {
       ui_vp_player_char->play_talking(f_char, f_emote, true);
     }
     anim_state = 2;
@@ -923,7 +1011,8 @@ void Courtroom::handle_chatmessage_3() {
   default:
     qDebug() << "W: invalid anim_state: " << f_anim_state;
   case 3:
-    if (!m_msg_is_first_person) {
+    if (!m_msg_is_first_person)
+    {
       ui_vp_player_char->play_idle(f_char, f_emote, true);
     }
     anim_state = 3;
@@ -942,7 +1031,8 @@ void Courtroom::handle_chatmessage_3() {
   bool do_it =
       ao_app->read_theme_ini("non_vanilla_effects", cc_config_ini) == "true";
 
-  if (effect == 1 && !do_it) {
+  if (effect == 1 && !do_it)
+  {
     if (overlay_sfx == "")
       overlay_sfx = ao_app->get_sfx("effect_flash");
     m_effects_player->play(overlay_sfx);
@@ -984,8 +1074,10 @@ void Courtroom::handle_chatmessage_3() {
   QString f_message = m_chatmessage[MESSAGE];
   QStringList callwords = ao_app->get_callwords();
 
-  for (QString word : callwords) {
-    if (f_message.contains(word, Qt::CaseInsensitive)) {
+  for (QString word : callwords)
+  {
+    if (f_message.contains(word, Qt::CaseInsensitive))
+    {
       m_system_player->play(ao_app->get_sfx("word_call"));
       ao_app->alert(this);
       ui_server_chatlog->append_chatmessage(
@@ -998,7 +1090,8 @@ void Courtroom::handle_chatmessage_3() {
   }
 }
 
-void Courtroom::on_chat_config_changed() {
+void Courtroom::on_chat_config_changed()
+{
   // forward declaration for a possible update of the chatlog
   bool chatlog_changed = false;
 
@@ -1028,7 +1121,8 @@ void Courtroom::on_chat_config_changed() {
     update_ic_log(chatlog_changed);
 }
 
-void Courtroom::update_ic_log(bool p_reset_log) {
+void Courtroom::update_ic_log(bool p_reset_log)
+{
   // resize if needed
   int len = m_ic_records.length();
   if (len > m_chatlog_limit)
@@ -1040,13 +1134,16 @@ void Courtroom::update_ic_log(bool p_reset_log) {
    * */
   record_type_array records_to_add;
   // populate
-  if (p_reset_log) {
+  if (p_reset_log)
+  {
     // we need the entire recordings
     records_to_add = m_ic_records;
 
     // clear log
     ui_ic_chatlog->clear();
-  } else {
+  }
+  else
+  {
     records_to_add.append(m_ic_records.last());
   }
 
@@ -1094,13 +1191,17 @@ void Courtroom::update_ic_log(bool p_reset_log) {
   const QTextCursor::MoveOperation move_type =
       m_chatlog_scrolldown ? QTextCursor::End : QTextCursor::Start;
 
-  for (record_type_ptr record : records_to_add) {
+  for (record_type_ptr record : records_to_add)
+  {
     // move cursor
     cursor.movePosition(move_type);
 
-    if (record->system) {
+    if (record->system)
+    {
       cursor.insertText(record->line + QChar::LineFeed, system_format);
-    } else {
+    }
+    else
+    {
       QString separator;
       if (m_chatlog_newline)
         separator = QString(QChar::LineFeed);
@@ -1176,13 +1277,15 @@ void Courtroom::update_ic_log(bool p_reset_log) {
    * this also removes the last character of the block that remains. That's why
    * we have to do this whole complicated process.
    * */
-  if (prev_cursor.hasSelection() || !is_scrolled) {
+  if (prev_cursor.hasSelection() || !is_scrolled)
+  {
     // restore previous selection and vscrollbar
     ui_ic_chatlog->setTextCursor(prev_cursor);
     vscrollbar->setValue(scroll_pos);
   }
   // scroll up/down depending on context
-  else {
+  else
+  {
     ui_ic_chatlog->moveCursor(move_type);
     vscrollbar->setValue(m_chatlog_scrolldown ? vscrollbar->maximum()
                                               : vscrollbar->minimum());
@@ -1190,7 +1293,8 @@ void Courtroom::update_ic_log(bool p_reset_log) {
 }
 
 void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system,
-                               bool p_music) {
+                               bool p_music)
+{
   // record new entry
   m_ic_records.append(
       std::make_shared<record_type>(p_name, p_line, "", p_system, p_music));
@@ -1199,13 +1303,15 @@ void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system,
   update_ic_log(false);
 }
 
-void Courtroom::append_system_text(QString p_line) {
+void Courtroom::append_system_text(QString p_line)
+{
   if (chatmessage_is_empty)
     return;
   append_ic_text("", p_line, true, false);
 }
 
-void Courtroom::play_preanim() {
+void Courtroom::play_preanim()
+{
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
@@ -1219,15 +1325,19 @@ void Courtroom::play_preanim() {
   // set state
   anim_state = 1;
 
-  if (!m_msg_is_first_person) {
+  if (!m_msg_is_first_person)
+  {
     QString f_anim_path = ao_app->get_character_path(f_char, f_preanim);
-    if (ui_vp_player_char->play_pre(f_char, f_preanim, true)) {
+    if (ui_vp_player_char->play_pre(f_char, f_preanim, true))
+    {
       if (text_delay >= 0)
         text_delay_timer->start(text_delay);
 
       // finished
       return;
-    } else {
+    }
+    else
+    {
       qDebug() << "could not find " + f_anim_path;
     }
   }
@@ -1240,7 +1350,8 @@ void Courtroom::preanim_done() { handle_chatmessage_3(); }
 
 void Courtroom::realization_done() { ui_vp_effect->stop(); }
 
-void Courtroom::start_chat_ticking() {
+void Courtroom::start_chat_ticking()
+{
   ui_vp_message->clear();
 
   set_text_color();
@@ -1250,7 +1361,8 @@ void Courtroom::start_chat_ticking() {
   if (text_state != 0)
     return;
 
-  if (chatmessage_is_empty) {
+  if (chatmessage_is_empty)
+  {
     // since the message is empty, it's technically done ticking
     text_state = 2;
     return;
@@ -1271,7 +1383,8 @@ void Courtroom::start_chat_ticking() {
   text_state = 1;
 }
 
-void Courtroom::chat_tick() {
+void Courtroom::chat_tick()
+{
   // note: this is called fairly often(every 60 ms when char is talking)
   // do not perform heavy operations here
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
@@ -1282,12 +1395,14 @@ void Courtroom::chat_tick() {
 
   QString f_message = m_chatmessage[MESSAGE];
 
-  if (tick_pos >= f_message.size()) {
+  if (tick_pos >= f_message.size())
+  {
     text_state = 2;
     chat_tick_timer->stop();
     anim_state = 3;
 
-    if (!m_msg_is_first_person) {
+    if (!m_msg_is_first_person)
+    {
       ui_vp_player_char->play_idle(m_chatmessage[CHAR_NAME],
                                    m_chatmessage[EMOTE], true);
     }
@@ -1296,15 +1411,18 @@ void Courtroom::chat_tick() {
     m_color_stack.clear();
   }
 
-  else {
+  else
+  {
     QString f_character = f_message.at(tick_pos);
 
     if (f_character == " ")
       ui_vp_message->insertPlainText(" ");
-    else if (m_chatmessage[TEXT_COLOR].toInt() == RAINBOW) {
+    else if (m_chatmessage[TEXT_COLOR].toInt() == RAINBOW)
+    {
       QString html_color;
 
-      switch (rainbow_counter) {
+      switch (rainbow_counter)
+      {
       case 0:
         html_color = "#BA1518";
         break;
@@ -1329,8 +1447,10 @@ void Courtroom::chat_tick() {
       vp_message_format.setForeground(text_color);
 
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
-    } else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) ==
-               "true") {
+    }
+    else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) ==
+             "true")
+    {
       bool highlight_found = false;
       bool render_character = true;
       // render_character should only be false if the character is a highlight
@@ -1340,8 +1460,10 @@ void Courtroom::chat_tick() {
       if (m_color_stack.isEmpty())
         m_color_stack.push("");
 
-      for (const auto &col : f_vec) {
-        if (f_character == col[0][0] && m_string_color != col[1]) {
+      for (const auto &col : f_vec)
+      {
+        if (f_character == col[0][0] && m_string_color != col[1])
+        {
           m_color_stack.push(col[1]);
           m_string_color = m_color_stack.top();
           highlight_found = true;
@@ -1353,7 +1475,8 @@ void Courtroom::chat_tick() {
       // Apply color to the next character
       if (m_string_color.isEmpty())
         vp_message_format.setForeground(m_base_string_color);
-      else {
+      else
+      {
         QColor textColor;
         textColor.setNamedColor(m_string_color);
         vp_message_format.setForeground(textColor);
@@ -1361,8 +1484,10 @@ void Courtroom::chat_tick() {
 
       QString m_future_string_color = m_string_color;
 
-      for (const auto &col : f_vec) {
-        if (f_character == col[0][1] && !highlight_found) {
+      for (const auto &col : f_vec)
+      {
+        if (f_character == col[0][1] && !highlight_found)
+        {
           if (m_color_stack.size() > 1)
             m_color_stack.pop();
           m_future_string_color = m_color_stack.top();
@@ -1376,16 +1501,20 @@ void Courtroom::chat_tick() {
         ui_vp_message->textCursor().insertText(f_character, vp_message_format);
 
       m_string_color = m_future_string_color;
-    } else {
+    }
+    else
+    {
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
     }
 
     QScrollBar *scroll = ui_vp_message->verticalScrollBar();
     scroll->setValue(scroll->maximum());
 
-    if ((f_message.at(tick_pos) != ' ' || ao_config->blank_blips_enabled())) {
+    if ((f_message.at(tick_pos) != ' ' || ao_config->blank_blips_enabled()))
+    {
 
-      if (blip_pos % ao_app->read_blip_rate() == 0) {
+      if (blip_pos % ao_app->read_blip_rate() == 0)
+      {
         blip_pos = 0;
 
         // play blip
@@ -1400,7 +1529,8 @@ void Courtroom::chat_tick() {
   }
 }
 
-void Courtroom::show_testimony() {
+void Courtroom::show_testimony()
+{
   if (!testimony_in_progress || m_chatmessage[SIDE] != "wit")
     return;
 
@@ -1409,7 +1539,8 @@ void Courtroom::show_testimony() {
   testimony_show_timer->start(testimony_show_time);
 }
 
-void Courtroom::hide_testimony() {
+void Courtroom::hide_testimony()
+{
   ui_vp_testimony->hide();
 
   if (!testimony_in_progress)
@@ -1418,7 +1549,8 @@ void Courtroom::hide_testimony() {
   testimony_hide_timer->start(testimony_hide_time);
 }
 
-void Courtroom::play_sfx() {
+void Courtroom::play_sfx()
+{
   QString sfx_name = m_chatmessage[SFX_NAME];
   if (sfx_name == "1")
     return;
@@ -1431,9 +1563,11 @@ void Courtroom::play_sfx() {
   m_effects_player->play(f_file);
 }
 
-void Courtroom::set_text_color() {
+void Courtroom::set_text_color()
+{
 
-  switch (m_chatmessage[TEXT_COLOR].toInt()) {
+  switch (m_chatmessage[TEXT_COLOR].toInt())
+  {
   case GREEN:
     ui_vp_message->setStyleSheet("background-color: rgba(0, 0, 0, 0)");
     m_base_string_color.setRgb(101, 200, 86);
@@ -1472,19 +1606,22 @@ void Courtroom::set_text_color() {
   }
 }
 
-void Courtroom::set_ip_list(QString p_list) {
+void Courtroom::set_ip_list(QString p_list)
+{
   QString f_list = p_list.replace("|", ":").replace("*", "\n");
 
   ui_server_chatlog->append(f_list);
 }
 
-void Courtroom::set_mute(bool p_muted, int p_cid) {
+void Courtroom::set_mute(bool p_muted, int p_cid)
+{
   if (p_cid != m_cid && p_cid != -1)
     return;
 
   if (p_muted)
     ui_muted->show();
-  else {
+  else
+  {
     ui_muted->hide();
     ui_ic_chat_message->setFocus();
   }
@@ -1496,7 +1633,8 @@ void Courtroom::set_mute(bool p_muted, int p_cid) {
   ui_ic_chat_message->setEnabled(!p_muted);
 }
 
-void Courtroom::set_ban(int p_cid) {
+void Courtroom::set_ban(int p_cid)
+{
   if (p_cid != m_cid && p_cid != -1)
     return;
 
@@ -1506,7 +1644,8 @@ void Courtroom::set_ban(int p_cid) {
   ao_app->destruct_courtroom();
 }
 
-void Courtroom::handle_song(QStringList *p_contents) {
+void Courtroom::handle_song(QStringList *p_contents)
+{
 
   QStringList f_contents = *p_contents;
 
@@ -1516,19 +1655,24 @@ void Courtroom::handle_song(QStringList *p_contents) {
   QString f_song = f_contents.at(0);
   int n_char = f_contents.at(1).toInt();
 
-  for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"}) {
+  for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
+  {
     QString r_song = f_song + ext;
     QString song_path =
         ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
-    if (file_exists(song_path)) {
+    if (file_exists(song_path))
+    {
       f_song = r_song;
       break;
     }
   }
 
-  if (n_char < 0 || n_char >= char_list.size()) {
+  if (n_char < 0 || n_char >= char_list.size())
+  {
     m_music_player->play(f_song);
-  } else {
+  }
+  else
+  {
     // This 2th argument corresponds to the showname to use when displaying the
     // music change message in IC
     // Backwards compatibility is explicitly kept for older versions of
@@ -1536,21 +1680,29 @@ void Courtroom::handle_song(QStringList *p_contents) {
     // If there is an empty showname, the client will use instead the default
     // showname of the character.
     QString f_showname;
-    if (f_contents.size() == 3) {
+    if (f_contents.size() == 3)
+    {
       f_showname = f_contents.at(2);
-    } else {
+    }
+    else
+    {
       f_showname = "";
     }
 
     QString str_char;
-    if (f_showname.isEmpty()) {
+    if (f_showname.isEmpty())
+    {
       str_char = ao_app->get_showname(char_list.at(n_char).name);
-    } else {
+    }
+    else
+    {
       str_char = f_showname;
     }
 
-    if (!mute_map.value(n_char)) {
-      if (ao_app->get_music_change_log_enabled()) {
+    if (!mute_map.value(n_char))
+    {
+      if (ao_app->get_music_change_log_enabled())
+      {
         append_ic_text(str_char, "has played a song: " + f_song, false, true);
       }
       m_music_player->play(f_song);
@@ -1565,7 +1717,8 @@ void Courtroom::handle_song(QStringList *p_contents) {
   handle_music_anim();
 }
 
-void Courtroom::handle_wtce(QString p_wtce) {
+void Courtroom::handle_wtce(QString p_wtce)
+{
   QString sfx_file = cc_sounds_ini;
 
   int index = p_wtce.at(p_wtce.size() - 1).digitValue();
@@ -1573,32 +1726,40 @@ void Courtroom::handle_wtce(QString p_wtce) {
       wtce_names.size() > 0) // check to prevent crash
   {
     p_wtce.chop(1); // looking for the 'testimony' part
-    if (p_wtce == "testimony") {
+    if (p_wtce == "testimony")
+    {
       m_effects_player->play(ao_app->get_sfx(wtce_names[index - 1]));
       ui_vp_wtce->play(wtce_names[index - 1]);
-      if (index == 1) {
+      if (index == 1)
+      {
         testimony_in_progress = true;
-      } else if (index == 2)
+      }
+      else if (index == 2)
         testimony_in_progress = false;
     }
   }
 }
 
-void Courtroom::set_hp_bar(int p_bar, int p_state) {
+void Courtroom::set_hp_bar(int p_bar, int p_state)
+{
   if (p_state < 0 || p_state > 10)
     return;
 
-  if (p_bar == 1) {
+  if (p_bar == 1)
+  {
     ui_defense_bar->set_image("defensebar" + QString::number(p_state) + ".png");
     defense_bar_state = p_state;
-  } else if (p_bar == 2) {
+  }
+  else if (p_bar == 2)
+  {
     ui_prosecution_bar->set_image("prosecutionbar" + QString::number(p_state) +
                                   ".png");
     prosecution_bar_state = p_state;
   }
 }
 
-void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown) {
+void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown)
+{
   int index = ui_pos_dropdown->findData(p_pos);
   if (index != -1 && refresh_dropdown)
     ui_pos_dropdown->setCurrentIndex(index);
@@ -1607,26 +1768,32 @@ void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown) {
   set_judge_enabled(p_pos == "jud");
 }
 
-void Courtroom::mod_called(QString p_ip) {
+void Courtroom::mod_called(QString p_ip)
+{
   ui_server_chatlog->append(p_ip);
-  if (ao_app->get_server_alerts_enabled()) {
+  if (ao_app->get_server_alerts_enabled())
+  {
     m_system_player->play(ao_app->get_sfx("mod_call"));
     ao_app->alert(this);
   }
 }
 
-void Courtroom::on_ooc_return_pressed() {
+void Courtroom::on_ooc_return_pressed()
+{
   QString ooc_name = ui_ooc_chat_name->text();
   QString ooc_message = ui_ooc_chat_message->text();
 
-  if (ooc_message.isEmpty()) {
+  if (ooc_message.isEmpty())
+  {
     append_server_chatmessage("CLIENT", "You cannot send an empty message.");
     return;
   }
-  if (ooc_name.isEmpty()) {
+  if (ooc_name.isEmpty())
+  {
     bool ok;
     QString name;
-    do {
+    do
+    {
       ooc_name = QInputDialog::getText(
           this, "Enter a name",
           "You must have a name to talk in OOC chat. Enter a name: ",
@@ -1636,23 +1803,35 @@ void Courtroom::on_ooc_return_pressed() {
       return;
 
     ao_config->set_username(ooc_name);
-  } else if (ooc_message.startsWith("/rainbow") &&
-             ao_app->yellow_text_enabled && !rainbow_appended) {
+  }
+  else if (ooc_message.startsWith("/rainbow") && ao_app->yellow_text_enabled &&
+           !rainbow_appended)
+  {
     ui_text_color->addItem("Rainbow");
     ui_ooc_chat_message->clear();
     rainbow_appended = true;
     return;
-  } else if (ooc_message.startsWith("/switch_am")) {
+  }
+  else if (ooc_message.startsWith("/switch_am"))
+  {
     on_switch_area_music_clicked();
     ui_ooc_chat_message->clear();
     return;
-  } else if (ooc_message.startsWith("/rollp")) {
+  }
+  else if (ooc_message.startsWith("/rollp"))
+  {
     m_effects_player->play(ao_app->get_sfx("dice"));
-  } else if (ooc_message.startsWith("/roll")) {
+  }
+  else if (ooc_message.startsWith("/roll"))
+  {
     m_effects_player->play(ao_app->get_sfx("dice"));
-  } else if (ooc_message.startsWith("/coinflip")) {
+  }
+  else if (ooc_message.startsWith("/coinflip"))
+  {
     m_effects_player->play(ao_app->get_sfx("coinflip"));
-  } else if (ooc_message.startsWith("/tr ")) {
+  }
+  else if (ooc_message.startsWith("/tr "))
+  {
     // Timer resume
     int space_location = ooc_message.indexOf(" ");
 
@@ -1662,7 +1841,9 @@ void Courtroom::on_ooc_return_pressed() {
     else
       timer_id = ooc_message.mid(space_location + 1).toInt();
     resume_timer(timer_id);
-  } else if (ooc_message.startsWith("/ts ")) {
+  }
+  else if (ooc_message.startsWith("/ts "))
+  {
     // Timer set
     QStringList arguments = ooc_message.split(" ");
     int size = arguments.size();
@@ -1679,7 +1860,9 @@ void Courtroom::on_ooc_return_pressed() {
     set_timer_time(timer_id, new_time);
     set_timer_timestep(timer_id, timestep_length);
     set_timer_firing(timer_id, firing_interval);
-  } else if (ooc_message.startsWith("/tp ")) {
+  }
+  else if (ooc_message.startsWith("/tp "))
+  {
     // Timer pause
     int space_location = ooc_message.indexOf(" ");
 
@@ -1703,20 +1886,23 @@ void Courtroom::on_ooc_return_pressed() {
   ui_ooc_chat_message->setFocus();
 }
 
-void Courtroom::on_music_search_edited(QString p_text) {
+void Courtroom::on_music_search_edited(QString p_text)
+{
   // preventing compiler warnings
   p_text += "a";
   list_music();
   list_areas();
 }
 
-void Courtroom::on_sfx_search_edited(QString p_text) {
+void Courtroom::on_sfx_search_edited(QString p_text)
+{
   // preventing compiler warnings
   p_text += "a";
   list_sfx();
 }
 
-void Courtroom::on_pos_dropdown_changed(int p_index) {
+void Courtroom::on_pos_dropdown_changed(int p_index)
+{
   ui_ic_chat_message->setFocus();
 
   if (p_index < 0 || p_index > 5)
@@ -1724,7 +1910,8 @@ void Courtroom::on_pos_dropdown_changed(int p_index) {
 
   QString f_pos;
 
-  switch (p_index) {
+  switch (p_index)
+  {
   case 0:
     f_pos = "wit";
     break;
@@ -1759,7 +1946,8 @@ void Courtroom::on_pos_dropdown_changed(int p_index) {
   // ao_app->send_server_packet(new AOPacket("SP#" + f_pos + "#%"));
 }
 
-void Courtroom::on_mute_list_clicked(QModelIndex p_index) {
+void Courtroom::on_mute_list_clicked(QModelIndex p_index)
+{
   QListWidgetItem *f_item = ui_mute_list->item(p_index.row());
   QString f_char = f_item->text();
   QString real_char;
@@ -1771,20 +1959,25 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index) {
 
   int f_cid = -1;
 
-  for (int n_char = 0; n_char < char_list.size(); n_char++) {
+  for (int n_char = 0; n_char < char_list.size(); n_char++)
+  {
     if (char_list.at(n_char).name == real_char)
       f_cid = n_char;
   }
 
-  if (f_cid < 0 || f_cid >= char_list.size()) {
+  if (f_cid < 0 || f_cid >= char_list.size())
+  {
     qDebug() << "W: " << real_char << " not present in char_list";
     return;
   }
 
-  if (mute_map.value(f_cid)) {
+  if (mute_map.value(f_cid))
+  {
     mute_map.insert(f_cid, false);
     f_item->setText(real_char);
-  } else {
+  }
+  else
+  {
     mute_map.insert(f_cid, true);
     f_item->setText(real_char + " [x]");
   }
@@ -1811,7 +2004,8 @@ void Courtroom::on_music_list_clicked() { ui_ic_chat_message->setFocus(); }
 
 void Courtroom::on_area_list_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_music_list_double_clicked(QModelIndex p_model) {
+void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
+{
   if (is_client_muted)
     return;
 
@@ -1824,7 +2018,8 @@ void Courtroom::on_music_list_double_clicked(QModelIndex p_model) {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_area_list_double_clicked(QModelIndex p_model) {
+void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
+{
   QString p_area = ui_area_list->item(p_model.row())->text();
 
   ao_app->send_server_packet(
@@ -1834,7 +2029,8 @@ void Courtroom::on_area_list_double_clicked(QModelIndex p_model) {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::reset_shout_buttons() {
+void Courtroom::reset_shout_buttons()
+{
   for (int i = 0; i < ui_shouts.size(); ++i)
     ui_shouts[i]->set_image(shout_names.at(i) + ".png");
 
@@ -1844,7 +2040,8 @@ void Courtroom::reset_shout_buttons() {
         ->set_image(shout_names.at(m_objection_state - 1) + "_selected.png");
 }
 
-void Courtroom::on_shout_clicked() {
+void Courtroom::on_shout_clicked()
+{
   AOButton *f_shout_button = static_cast<AOButton *>(sender());
   int f_shout_id = f_shout_button->property("shout_id").toInt();
 
@@ -1859,11 +2056,13 @@ void Courtroom::on_shout_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_cycle_clicked() {
+void Courtroom::on_cycle_clicked()
+{
   AOButton *f_cycle_button = static_cast<AOButton *>(sender());
   int f_cycle_id = f_cycle_button->property("cycle_id").toInt();
 
-  switch (f_cycle_id) {
+  switch (f_cycle_id)
+  {
   case 5:
     cycle_wtce(-1);
     break;
@@ -1893,36 +2092,44 @@ void Courtroom::on_cycle_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::cycle_shout(int p_index) {
+void Courtroom::cycle_shout(int p_index)
+{
   int n = ui_shouts.size();
-  do {
+  do
+  {
     m_shout_state = (m_shout_state - p_index + n) % n;
   } while (!shouts_enabled[m_shout_state]);
 
   set_shouts();
 }
 
-void Courtroom::cycle_effect(int p_index) {
+void Courtroom::cycle_effect(int p_index)
+{
   int n = ui_effects.size();
-  do {
+  do
+  {
     m_effect_current = (m_effect_current - p_index + n) % n;
   } while (!effects_enabled[m_effect_current]);
 
   set_effects();
 }
 
-void Courtroom::cycle_wtce(int p_index) {
+void Courtroom::cycle_wtce(int p_index)
+{
   int n = ui_wtce.size();
-  do {
+  do
+  {
     m_wtce_current = (m_wtce_current - p_index + n) % n;
   } while (!wtce_enabled[m_wtce_current]);
 
   set_judge_wtce();
 }
 
-void Courtroom::reset_effect_buttons() {
+void Courtroom::reset_effect_buttons()
+{
   // effect names does not necessarily have the same size as ui effects
-  for (int i = 0; i < effect_names.size(); ++i) {
+  for (int i = 0; i < effect_names.size(); ++i)
+  {
     // qDebug() << effect_names << i;
     ui_effects[i]->set_image(effect_names.at(i) + ".png");
   }
@@ -1932,7 +2139,8 @@ void Courtroom::reset_effect_buttons() {
         effect_names.at(m_effect_state - 1) + "_pressed.png");
 }
 
-void Courtroom::on_effect_button_clicked() {
+void Courtroom::on_effect_button_clicked()
+{
   AOButton *f_button = static_cast<AOButton *>(this->sender());
 
   int f_effect_id = f_button->property("effect_id").toInt();
@@ -1946,17 +2154,22 @@ void Courtroom::on_effect_button_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_mute_clicked() {
-  if (ui_mute_list->isHidden()) {
+void Courtroom::on_mute_clicked()
+{
+  if (ui_mute_list->isHidden())
+  {
     ui_mute_list->show();
     ui_mute->set_image("mute_pressed.png");
-  } else {
+  }
+  else
+  {
     ui_mute_list->hide();
     ui_mute->set_image("mute.png");
   }
 }
 
-void Courtroom::on_defense_minus_clicked() {
+void Courtroom::on_defense_minus_clicked()
+{
   int f_state = defense_bar_state - 1;
 
   if (f_state >= 0)
@@ -1964,7 +2177,8 @@ void Courtroom::on_defense_minus_clicked() {
         new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_defense_plus_clicked() {
+void Courtroom::on_defense_plus_clicked()
+{
   int f_state = defense_bar_state + 1;
 
   if (f_state <= 10)
@@ -1972,7 +2186,8 @@ void Courtroom::on_defense_plus_clicked() {
         new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_prosecution_minus_clicked() {
+void Courtroom::on_prosecution_minus_clicked()
+{
   int f_state = prosecution_bar_state - 1;
 
   if (f_state >= 0)
@@ -1980,7 +2195,8 @@ void Courtroom::on_prosecution_minus_clicked() {
         new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_prosecution_plus_clicked() {
+void Courtroom::on_prosecution_plus_clicked()
+{
   int f_state = prosecution_bar_state + 1;
 
   if (f_state <= 10)
@@ -1988,12 +2204,14 @@ void Courtroom::on_prosecution_plus_clicked() {
         new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_text_color_changed(int p_color) {
+void Courtroom::on_text_color_changed(int p_color)
+{
   m_text_color = p_color;
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_witness_testimony_clicked() {
+void Courtroom::on_witness_testimony_clicked()
+{
   if (is_client_muted)
     return;
 
@@ -2002,7 +2220,8 @@ void Courtroom::on_witness_testimony_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_cross_examination_clicked() {
+void Courtroom::on_cross_examination_clicked()
+{
   if (is_client_muted)
     return;
 
@@ -2022,7 +2241,8 @@ void Courtroom::reset_judge_wtce_buttons() // kind of an unnecessary function,
   }
 }
 
-void Courtroom::on_wtce_clicked() {
+void Courtroom::on_wtce_clicked()
+{
   //  qDebug() << "AA: wtce clicked!";
   if (is_client_muted)
     return;
@@ -2037,7 +2257,8 @@ void Courtroom::on_wtce_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_change_character_clicked() {
+void Courtroom::on_change_character_clicked()
+{
   set_audio_mute_enabled(true);
 
   set_char_select();
@@ -2046,7 +2267,8 @@ void Courtroom::on_change_character_clicked() {
   ui_spectator->show();
 }
 
-void Courtroom::on_app_reload_theme_requested() {
+void Courtroom::on_app_reload_theme_requested()
+{
   load_shouts();
   load_effects();
   load_wtce();
@@ -2059,7 +2281,8 @@ void Courtroom::on_app_reload_theme_requested() {
   text_state = 3;
 }
 
-void Courtroom::on_back_to_lobby_clicked() {
+void Courtroom::on_back_to_lobby_clicked()
+{
   // hide so we don't get the 'disconnected from server' prompt
   hide();
 
@@ -2069,17 +2292,20 @@ void Courtroom::on_back_to_lobby_clicked() {
   ao_app->destruct_courtroom();
 }
 
-void Courtroom::on_char_select_left_clicked() {
+void Courtroom::on_char_select_left_clicked()
+{
   --current_char_page;
   set_char_select_page();
 }
 
-void Courtroom::on_char_select_right_clicked() {
+void Courtroom::on_char_select_right_clicked()
+{
   ++current_char_page;
   set_char_select_page();
 }
 
-void Courtroom::on_spectator_clicked() {
+void Courtroom::on_spectator_clicked()
+{
   QString content =
       "CC#" + QString::number(ao_app->s_pv) + "#-1#" + get_hdid() + "#%";
   ao_app->send_server_packet(new AOPacket(content));
@@ -2090,7 +2316,8 @@ void Courtroom::on_spectator_clicked() {
   ui_char_select_background->hide();
 }
 
-void Courtroom::on_call_mod_clicked() {
+void Courtroom::on_call_mod_clicked()
+{
   QMessageBox::StandardButton reply;
   QString warning = "Are you sure you want to call a mod? They will get angry "
                     "at you if the reason is no good.";
@@ -2098,20 +2325,26 @@ void Courtroom::on_call_mod_clicked() {
       QMessageBox::warning(this, "Warning", warning,
                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
-  if (reply == QMessageBox::Yes) {
+  if (reply == QMessageBox::Yes)
+  {
     ao_app->send_server_packet(new AOPacket("ZZ#%"));
     qDebug() << "Called mod";
-  } else
+  }
+  else
     qDebug() << "Did not call mod";
 
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_switch_area_music_clicked() {
-  if (ui_area_list->isHidden()) {
+void Courtroom::on_switch_area_music_clicked()
+{
+  if (ui_area_list->isHidden())
+  {
     ui_area_list->show();
     ui_music_list->hide();
-  } else {
+  }
+  else
+  {
     ui_area_list->hide();
     ui_music_list->show();
   }
@@ -2123,28 +2356,37 @@ void Courtroom::on_flip_clicked() { ui_ic_chat_message->setFocus(); }
 
 void Courtroom::on_hidden_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_evidence_button_clicked() {
-  if (ui_evidence->isHidden()) {
+void Courtroom::on_evidence_button_clicked()
+{
+  if (ui_evidence->isHidden())
+  {
     ui_evidence->show();
     ui_evidence_overlay->hide();
-  } else {
+  }
+  else
+  {
     ui_evidence->hide();
   }
 }
 
-void Courtroom::on_config_panel_clicked() {
+void Courtroom::on_config_panel_clicked()
+{
   ao_app->toggle_config_panel();
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_note_button_clicked() {
-  if (!note_shown) {
+void Courtroom::on_note_button_clicked()
+{
+  if (!note_shown)
+  {
     load_note();
     ui_vp_notepad_image->show();
     ui_vp_notepad->show();
     ui_vp_notepad->setFocus();
     note_shown = true;
-  } else {
+  }
+  else
+  {
     save_note();
     ui_vp_notepad_image->hide();
     ui_vp_notepad->hide();
@@ -2153,58 +2395,67 @@ void Courtroom::on_note_button_clicked() {
   }
 }
 
-void Courtroom::on_note_text_changed() {
+void Courtroom::on_note_text_changed()
+{
   ao_app->write_note(ui_vp_notepad->toPlainText(), current_file);
 }
 
-void Courtroom::ping_server() {
+void Courtroom::ping_server()
+{
   ao_app->send_server_packet(
       new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }
 
-void Courtroom::closeEvent(QCloseEvent *event) {
+void Courtroom::closeEvent(QCloseEvent *event)
+{
   emit closing();
   QMainWindow::closeEvent(event);
 }
 
 void Courtroom::on_sfx_list_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_set_notes_clicked() {
+void Courtroom::on_set_notes_clicked()
+{
   if (note_scroll_area->isHidden())
     note_scroll_area->show();
   else
     note_scroll_area->hide();
 }
 
-void Courtroom::resume_timer(int timer_id) {
+void Courtroom::resume_timer(int timer_id)
+{
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->resume();
 }
 
-void Courtroom::set_timer_time(int timer_id, int new_time) {
+void Courtroom::set_timer_time(int timer_id, int new_time)
+{
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_time(QTime(0, 0).addMSecs(new_time));
 }
 
-void Courtroom::set_timer_timestep(int timer_id, int timestep_length) {
+void Courtroom::set_timer_timestep(int timer_id, int timestep_length)
+{
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_timestep_length(timestep_length);
 }
 
-void Courtroom::set_timer_firing(int timer_id, int firing_interval) {
+void Courtroom::set_timer_firing(int timer_id, int firing_interval)
+{
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_firing_interval(firing_interval);
 }
 
-void Courtroom::pause_timer(int timer_id) {
+void Courtroom::pause_timer(int timer_id)
+{
   if (timer_id >= timer_number)
     return;
 

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -21,8 +21,7 @@
 #include <QTextCharFormat>
 #include <QTime>
 
-Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
-{
+Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow() {
   ao_app = p_ao_app;
   ao_config = new AOConfig(this);
 
@@ -38,8 +37,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   set_widget_names();
 }
 
-void Courtroom::enter_courtroom(int p_cid)
-{
+void Courtroom::enter_courtroom(int p_cid) {
   bool changed_character = (m_cid != p_cid);
   m_cid = p_cid;
 
@@ -47,13 +45,10 @@ void Courtroom::enter_courtroom(int p_cid)
 
   set_char_rpc();
 
-  if (m_cid == -1)
-  {
+  if (m_cid == -1) {
     ao_app->discord->state_spectate();
     f_char = "";
-  }
-  else
-  {
+  } else {
     f_char = ao_app->get_char_name(char_list.at(m_cid).name);
     QString r_char = f_char;
     // regex for removing non letter (except _) characters
@@ -61,12 +56,9 @@ void Courtroom::enter_courtroom(int p_cid)
         QString::fromUtf8("[-`~!@#$%^&*()—+=|:;<>«»,.?/{}\'\"\\[\\]]"));
     r_char.remove(re);
 
-    if (!rpc_char_list.contains(f_char.toLower()))
-    {
+    if (!rpc_char_list.contains(f_char.toLower())) {
       ao_app->discord->toggle(1);
-    }
-    else
-    {
+    } else {
       ao_app->discord->toggle(0);
     }
 
@@ -152,8 +144,7 @@ void Courtroom::enter_courtroom(int p_cid)
   set_widget_layers();
 }
 
-void Courtroom::done_received()
-{
+void Courtroom::done_received() {
   m_cid = -1;
 
   set_audio_mute_enabled(true);
@@ -169,13 +160,11 @@ void Courtroom::done_received()
   ui_spectator->show();
 }
 
-void Courtroom::set_window_title(QString p_title)
-{
+void Courtroom::set_window_title(QString p_title) {
   this->setWindowTitle(p_title);
 }
 
-void Courtroom::set_scene()
-{
+void Courtroom::set_scene() {
   if (testimony_in_progress)
     show_testimony();
 
@@ -184,10 +173,9 @@ void Courtroom::set_scene()
   QString f_desk_image = "stand";
   QString f_desk_mod = m_chatmessage[DESK_MOD];
   QString f_side = m_chatmessage[SIDE];
-  QString ini_path = ao_app->get_background_path() + "backgrounds.ini";
+  QString ini_path = ao_app->get_background_path("backgrounds.ini");
 
-  if (file_exists(ini_path))
-  {
+  if (file_exists(ini_path)) {
     f_background = ao_app->read_design_ini(f_side, ini_path);
     f_desk_image = ao_app->read_design_ini(f_side + "_desk", ini_path);
 
@@ -195,48 +183,37 @@ void Courtroom::set_scene()
     {
       ui_vp_desk->hide();
     }
-  }
-  else
-  {
-    if (f_side == "def")
-    {
+  } else {
+    if (f_side == "def") {
       f_background = "defenseempty";
       f_desk_image = "defensedesk";
-    }
-    else if (f_side == "pro")
-    {
+    } else if (f_side == "pro") {
       f_background = "prosecutorempty";
       f_desk_image = "prosecutiondesk";
-    }
-    else if (f_side == "jud")
-    {
+    } else if (f_side == "jud") {
       f_background = "judgestand";
       f_desk_image = "judgedesk";
-    }
-    else if (f_side == "hld")
-    {
+    } else if (f_side == "hld") {
       f_background = "helperstand";
       f_desk_image = "helperdesk";
-    }
-    else if (f_side == "hlp")
-    {
+    } else if (f_side == "hlp") {
       f_background = "prohelperstand";
       f_desk_image = "prohelperdesk";
-    }
-    else
-    {
+    } else {
       f_desk_image = "stand";
     }
 
-    QString bg_path = get_background_path();
     QVector<QString> exts{".webp", ".apng", ".gif", ".png"};
 
     bool has_all_desks;
-    if (file_exists(bg_path + "defensedesk", exts) == "")
+    if (ao_app->get_file_extension(get_background_path("defensedesk"), exts) ==
+        "")
       has_all_desks = false;
-    else if (file_exists(bg_path + "prosecutiondesk", exts) == "")
+    else if (ao_app->get_file_extension(get_background_path("prosecutiondesk"),
+                                        exts) == "")
       has_all_desks = false;
-    else if (file_exists(bg_path + "stand", exts) == "")
+    else if (ao_app->get_file_extension(get_background_path("stand"), exts) ==
+             "")
       has_all_desks = false;
     else
       has_all_desks = true;
@@ -255,21 +232,18 @@ void Courtroom::set_scene()
   ui_vp_desk->set_image(f_desk_image);
 }
 
-void Courtroom::set_char_rpc()
-{
+void Courtroom::set_char_rpc() {
   rpc_char_list.clear();
 
   QFile config_file(ao_app->get_base_path() + rpc_ini);
-  if (!config_file.open(QIODevice::ReadOnly))
-  {
+  if (!config_file.open(QIODevice::ReadOnly)) {
     qDebug() << "Error reading" << ao_app->get_base_path() + rpc_ini;
     return;
   }
 
   QTextStream in(&config_file);
 
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString f_line = in.readLine().trimmed();
 
     QStringList line_elements = f_line.split("-");
@@ -280,10 +254,8 @@ void Courtroom::set_char_rpc()
   config_file.close();
 }
 
-void Courtroom::set_taken(int n_char, bool p_taken)
-{
-  if (n_char >= char_list.size())
-  {
+void Courtroom::set_taken(int n_char, bool p_taken) {
+  if (n_char >= char_list.size()) {
     qDebug()
         << "W: set_taken attempted to set an index bigger than char_list size";
     return;
@@ -298,14 +270,12 @@ void Courtroom::set_taken(int n_char, bool p_taken)
   char_list.replace(n_char, f_char);
 }
 
-void Courtroom::set_background(QString p_background)
-{
+void Courtroom::set_background(QString p_background) {
   testimony_in_progress = false;
   current_background = p_background;
 }
 
-void Courtroom::handle_music_anim()
-{
+void Courtroom::handle_music_anim() {
   QString file_a = design_ini;
   QString file_b = fonts_ini;
   pos_size_type res_a = ao_app->get_element_dimensions("music_name", file_a);
@@ -331,8 +301,7 @@ void Courtroom::handle_music_anim()
   music_anim->start();
 }
 
-void Courtroom::handle_clock(QString time)
-{
+void Courtroom::handle_clock(QString time) {
   current_clock = time.toInt();
 
   QString string = "hours\\" + time; // expected to be 0, 1, 2...
@@ -340,13 +309,11 @@ void Courtroom::handle_clock(QString time)
   ui_vp_clock->play(string);
 }
 
-void Courtroom::handle_theme_variant(QString theme_variant)
-{
+void Courtroom::handle_theme_variant(QString theme_variant) {
   ao_app->set_theme_variant(theme_variant);
   on_app_reload_theme_requested();
 }
-void Courtroom::list_music()
-{
+void Courtroom::list_music() {
   ui_music_list->clear();
 
   QString f_file = design_ini;
@@ -356,25 +323,21 @@ void Courtroom::list_music()
 
   int n_listed_songs = 0;
 
-  for (int n_song = 0; n_song < music_list.size(); ++n_song)
-  {
+  for (int n_song = 0; n_song < music_list.size(); ++n_song) {
     QString i_song = music_list.at(n_song);
     bool found = false;
 
-    for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
-    {
+    for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"}) {
       QString r_song = i_song + ext;
       QString song_path =
           ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
-      if (file_exists(song_path))
-      {
+      if (file_exists(song_path)) {
         found = true;
         break;
       }
     }
 
-    if (i_song.toLower().contains(ui_music_search->text().toLower()))
-    {
+    if (i_song.toLower().contains(ui_music_search->text().toLower())) {
       ui_music_list->addItem(i_song);
 
       if (found)
@@ -387,8 +350,7 @@ void Courtroom::list_music()
   }
 }
 
-void Courtroom::list_areas()
-{
+void Courtroom::list_areas() {
   ui_area_list->clear();
   //  area_names.clear();
 
@@ -404,14 +366,12 @@ void Courtroom::list_areas()
 
   int n_listed_areas = 0;
 
-  for (int n_area = 0; n_area < area_list.size(); ++n_area)
-  {
+  for (int n_area = 0; n_area < area_list.size(); ++n_area) {
     QString i_area = "";
 
     i_area.append(area_list.at(n_area));
 
-    if (i_area.toLower().contains(ui_music_search->text().toLower()))
-    {
+    if (i_area.toLower().contains(ui_music_search->text().toLower())) {
       ui_area_list->addItem(i_area);
       //      area_names.append(i_);
 
@@ -422,8 +382,7 @@ void Courtroom::list_areas()
   }
 }
 
-void Courtroom::list_sfx()
-{
+void Courtroom::list_sfx() {
   ui_sfx_list->clear();
   sfx_names.clear();
 
@@ -442,8 +401,7 @@ void Courtroom::list_sfx()
 
   int n_listed_sfxs = 0;
 
-  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
-  {
+  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx) {
     QStringList sfx = sfx_list.at(n_sfx).split("=");
     QString i_sfx = sfx.at(0).trimmed();
     QString d_sfx = "";
@@ -455,8 +413,7 @@ void Courtroom::list_sfx()
 
     //    qDebug() << "isfx=" << i_sfx << "dsfx=" << d_sfx << "sfx=" << sfx;
 
-    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
-    {
+    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower())) {
       ui_sfx_list->addItem(d_sfx);
       ui_sfx_list->item(ui_sfx_list->count() - 1)
           ->setStatusTip(QString::number(n_sfx + 2));
@@ -474,12 +431,10 @@ void Courtroom::list_sfx()
   }
 }
 
-void Courtroom::list_note_files()
-{
+void Courtroom::list_note_files() {
   QString f_config = ao_app->get_base_path() + file_select_ini;
   QFile f_file(f_config);
-  if (!f_file.open(QIODevice::ReadOnly))
-  {
+  if (!f_file.open(QIODevice::ReadOnly)) {
     qDebug() << "Couldn't open" << f_config;
     return;
   }
@@ -493,8 +448,7 @@ void Courtroom::list_note_files()
 
   QVBoxLayout *f_layout = ui_note_area->m_layout;
 
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString line = in.readLine().trimmed();
 
     QStringList f_contents = line.split("=");
@@ -517,8 +471,7 @@ void Courtroom::list_note_files()
   }
 }
 
-void Courtroom::load_note()
-{
+void Courtroom::load_note() {
   // Do not attempt to load anything if no file was chosen. This makes it so
   // that notepad text is kept in client if the user has decided not to choose a
   // file to save to. Of course, this is ephimeral storage, it will be erased
@@ -529,31 +482,27 @@ void Courtroom::load_note()
   ui_vp_notepad->setText(f_text);
 }
 
-void Courtroom::save_note()
-{
+void Courtroom::save_note() {
 
   QString f_text = ui_vp_notepad->toPlainText();
 
   ao_app->write_note(f_text, current_file);
 }
 
-void Courtroom::save_textlog(QString p_text)
-{
+void Courtroom::save_textlog(QString p_text) {
   QString f_file = ao_app->get_base_path() + icchatlogsfilename;
 
   ao_app->append_note(p_text, f_file);
 }
 
-void Courtroom::append_server_chatmessage(QString p_name, QString p_message)
-{
+void Courtroom::append_server_chatmessage(QString p_name, QString p_message) {
   ui_server_chatlog->append_chatmessage(p_name, p_message);
   if (ao_config->log_is_recording_enabled())
     save_textlog("(OOC)[" + QTime::currentTime().toString() + "] " + p_name +
                  ": " + p_message);
 }
 
-void Courtroom::on_chat_return_pressed()
-{
+void Courtroom::on_chat_return_pressed() {
   if (ui_ic_chat_message->text() == "" || is_client_muted)
     return;
 
@@ -587,8 +536,7 @@ void Courtroom::on_chat_return_pressed()
 
   QString f_desk_mod = "chat";
 
-  if (ao_app->desk_mod_enabled)
-  {
+  if (ao_app->desk_mod_enabled) {
     f_desk_mod =
         QString::number(ao_app->get_desk_mod(current_char, current_emote));
     if (f_desk_mod == "-1")
@@ -628,22 +576,17 @@ void Courtroom::on_chat_return_pressed()
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
   // needed or else legacy won't understand what we're saying
-  if (m_objection_state > 0)
-  {
+  if (m_objection_state > 0) {
     if (f_emote_mod == 5)
       f_emote_mod = 6;
     else
       f_emote_mod = 2;
-  }
-  else if (ui_pre->isChecked())
-  {
+  } else if (ui_pre->isChecked()) {
     if (f_emote_mod == 0)
       f_emote_mod = 1;
     else if (f_emote_mod == 5 && ao_app->prezoom_enabled)
       f_emote_mod = 4;
-  }
-  else
-  {
+  } else {
     if (f_emote_mod == 1)
       f_emote_mod = 0;
     else if (f_emote_mod == 4)
@@ -675,14 +618,12 @@ void Courtroom::on_chat_return_pressed()
 
   QString f_flip;
 
-  if (ao_app->flipping_enabled)
-  {
+  if (ao_app->flipping_enabled) {
     if (ui_flip->isChecked())
       f_flip = "1";
     else
       f_flip = "0";
-  }
-  else
+  } else
     f_flip = QString::number(m_cid);
 
   packet_contents.append(f_flip);
@@ -705,15 +646,13 @@ void Courtroom::on_chat_return_pressed()
   ao_app->send_server_packet(new AOPacket("MS", packet_contents));
 }
 
-void Courtroom::handle_chatmessage(QStringList *p_contents)
-{
+void Courtroom::handle_chatmessage(QStringList *p_contents) {
   if (p_contents->size() < 15)
     return;
   else if (p_contents->size() == 15)
     p_contents->append("");
 
-  for (int n_string = 0; n_string < chatmessage_size; ++n_string)
-  {
+  for (int n_string = 0; n_string < chatmessage_size; ++n_string) {
     m_chatmessage[n_string] = p_contents->at(n_string);
     //    qDebug() << "m_chatmessage[" << n_string << "] = " <<
     //    m_chatmessage[n_string];
@@ -721,13 +660,11 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
 
   int f_char_id = m_chatmessage[CHAR_ID].toInt();
 
-  if (f_char_id == -1)
-  {
+  if (f_char_id == -1) {
     is_system_speaking = true;
     m_chatmessage[CHAR_ID] = "0";
     f_char_id = 0;
-  }
-  else
+  } else
     is_system_speaking = false;
 
   if (f_char_id < 0 || f_char_id >= char_list.size())
@@ -741,8 +678,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   m_msg_is_first_person = false;
 
   // reset our ui state
-  if (m_cid == f_char_id && !is_system_speaking)
-  {
+  if (m_cid == f_char_id && !is_system_speaking) {
     ui_ic_chat_message->clear();
     ui_sfx_list->setCurrentItem(ui_sfx_list->item(0));
 
@@ -766,12 +702,9 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   qDebug() << m_chatmessage[SHOWNAME]
            << ao_app->get_showname(char_list.at(f_char_id).name);
 
-  if (m_chatmessage[SHOWNAME].isEmpty())
-  {
+  if (m_chatmessage[SHOWNAME].isEmpty()) {
     f_showname = ao_app->get_showname(char_list.at(f_char_id).name);
-  }
-  else
-  {
+  } else {
     f_showname = m_chatmessage[SHOWNAME];
   }
 
@@ -806,8 +739,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   QString f_custom_theme = ao_app->get_char_shouts(f_char);
 
   // if an objection is used
-  if (objection_mod > 0)
-  {
+  if (objection_mod > 0) {
     int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
     if (emote_mod == 0)
       m_chatmessage[EMOTE_MOD] = 1;
@@ -819,18 +751,14 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
       ui_vp_objection->play(shout_names.at(objection_mod - 1), f_char,
                             f_custom_theme);
       m_shouts_player->play(shout_names.at(objection_mod - 1) + ".wav", f_char);
-    }
-    else
+    } else
       qDebug() << "W: Shout identifier unknown" << objection_mod;
-  }
-  else
+
+  } else
     handle_chatmessage_2();
 }
 
-void Courtroom::objection_done()
-{
-  handle_chatmessage_2();
-}
+void Courtroom::objection_done() { handle_chatmessage_2(); }
 
 void Courtroom::handle_chatmessage_2() // handles IC
 {
@@ -843,12 +771,9 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   QString f_showname;
 
-  if (m_chatmessage[SHOWNAME].isEmpty())
-  {
+  if (m_chatmessage[SHOWNAME].isEmpty()) {
     f_showname = ao_app->get_showname(real_name);
-  }
-  else
-  {
+  } else {
     f_showname = m_chatmessage[SHOWNAME];
   }
 
@@ -868,25 +793,21 @@ void Courtroom::handle_chatmessage_2() // handles IC
   QString chatbox = ao_app->get_chat(m_chatmessage[CHAR_NAME]);
 
   if (chatbox == "")
-    if (ao_app->read_theme_ini("daynight_theme", cc_config_ini) == "true")
-    {
+    if (ao_app->read_theme_ini("daynight_theme", cc_config_ini) == "true") {
       if (current_clock < 0)
         ui_vp_chatbox->set_image("chatmed.png");
       else if (current_clock >= 7 && current_clock < 22)
         ui_vp_chatbox->set_image("chatmed_day.png");
       else
         ui_vp_chatbox->set_image("chatmed_night.png");
-    }
-    else
+    } else
       ui_vp_chatbox->set_image("chatmed.png");
-  else
-  {
+  else {
     QString chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + ".png";
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 
-  if (!m_msg_is_first_person)
-  {
+  if (!m_msg_is_first_person) {
     set_scene();
   }
 
@@ -899,8 +820,7 @@ void Courtroom::handle_chatmessage_2() // handles IC
   else
     ui_vp_player_char->set_mirror_enabled(false);
 
-  switch (emote_mod)
-  {
+  switch (emote_mod) {
   case 1:
   case 2:
   case 6:
@@ -915,8 +835,7 @@ void Courtroom::handle_chatmessage_2() // handles IC
   }
 }
 
-void Courtroom::handle_chatmessage_3()
-{
+void Courtroom::handle_chatmessage_3() {
   qDebug() << "handle_chatmessage_3";
 
   start_chat_ticking();
@@ -924,8 +843,7 @@ void Courtroom::handle_chatmessage_3()
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
   QString f_side = m_chatmessage[SIDE];
 
-  if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size())
-  {
+  if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size()) {
     // shifted by 1 because 0 is no evidence per legacy standards
     QString f_image = local_evidence_list.at(f_evi_id - 1).image;
     // def jud and hlp should display the evidence icon on the RIGHT side
@@ -936,8 +854,7 @@ void Courtroom::handle_chatmessage_3()
 
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
 
-  if (emote_mod == 5 || emote_mod == 6)
-  {
+  if (emote_mod == 5 || emote_mod == 6) {
     QString side = m_chatmessage[SIDE];
     ui_vp_desk->hide();
 
@@ -968,27 +885,23 @@ void Courtroom::handle_chatmessage_3()
   ui_vp_showname_image->show();
   QVector<QString> exts = {".png", ".jpg", ".bmp"};
 
-  QString ext =
-      file_exists(ao_app->get_character_path(f_char) + "showname", exts);
+  QString ext = ao_app->get_file_extension(
+      ao_app->get_character_path(f_char, "showname"), exts);
   if (ext != "" && !chatmessage_is_empty &&
-      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
-  {
+      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) ==
+          "true") {
     ui_vp_showname->hide();
-    QString path = ao_app->get_character_path(f_char) + "showname" + ext;
+    QString path = ao_app->get_character_path(f_char, "showname" + ext);
     ui_vp_showname_image->set_image_from_path(path);
     ui_vp_showname_image->show();
-  }
-  else
-  {
+  } else {
     ui_vp_showname->show();
     ui_vp_showname_image->hide();
   }
 
-  switch (f_anim_state)
-  {
+  switch (f_anim_state) {
   case 2:
-    if (!m_msg_is_first_person)
-    {
+    if (!m_msg_is_first_person) {
       ui_vp_player_char->play_talking(f_char, f_emote, true);
     }
     anim_state = 2;
@@ -996,8 +909,7 @@ void Courtroom::handle_chatmessage_3()
   default:
     qDebug() << "W: invalid anim_state: " << f_anim_state;
   case 3:
-    if (!m_msg_is_first_person)
-    {
+    if (!m_msg_is_first_person) {
       ui_vp_player_char->play_idle(f_char, f_emote, true);
     }
     anim_state = 3;
@@ -1016,8 +928,7 @@ void Courtroom::handle_chatmessage_3()
   bool do_it =
       ao_app->read_theme_ini("non_vanilla_effects", cc_config_ini) == "true";
 
-  if (effect == 1 && !do_it)
-  {
+  if (effect == 1 && !do_it) {
     if (overlay_sfx == "")
       overlay_sfx = ao_app->get_sfx("effect_flash");
     m_effects_player->play(overlay_sfx);
@@ -1059,10 +970,8 @@ void Courtroom::handle_chatmessage_3()
   QString f_message = m_chatmessage[MESSAGE];
   QStringList callwords = ao_app->get_callwords();
 
-  for (QString word : callwords)
-  {
-    if (f_message.contains(word, Qt::CaseInsensitive))
-    {
+  for (QString word : callwords) {
+    if (f_message.contains(word, Qt::CaseInsensitive)) {
       m_system_player->play(ao_app->get_sfx("word_call"));
       ao_app->alert(this);
       ui_server_chatlog->append_chatmessage(
@@ -1075,8 +984,7 @@ void Courtroom::handle_chatmessage_3()
   }
 }
 
-void Courtroom::on_chat_config_changed()
-{
+void Courtroom::on_chat_config_changed() {
   // forward declaration for a possible update of the chatlog
   bool chatlog_changed = false;
 
@@ -1106,8 +1014,7 @@ void Courtroom::on_chat_config_changed()
     update_ic_log(chatlog_changed);
 }
 
-void Courtroom::update_ic_log(bool p_reset_log)
-{
+void Courtroom::update_ic_log(bool p_reset_log) {
   // resize if needed
   int len = m_ic_records.length();
   if (len > m_chatlog_limit)
@@ -1119,16 +1026,13 @@ void Courtroom::update_ic_log(bool p_reset_log)
    * */
   record_type_array records_to_add;
   // populate
-  if (p_reset_log)
-  {
+  if (p_reset_log) {
     // we need the entire recordings
     records_to_add = m_ic_records;
 
     // clear log
     ui_ic_chatlog->clear();
-  }
-  else
-  {
+  } else {
     records_to_add.append(m_ic_records.last());
   }
 
@@ -1176,17 +1080,13 @@ void Courtroom::update_ic_log(bool p_reset_log)
   const QTextCursor::MoveOperation move_type =
       m_chatlog_scrolldown ? QTextCursor::End : QTextCursor::Start;
 
-  for (record_type_ptr record : records_to_add)
-  {
+  for (record_type_ptr record : records_to_add) {
     // move cursor
     cursor.movePosition(move_type);
 
-    if (record->system)
-    {
+    if (record->system) {
       cursor.insertText(record->line + QChar::LineFeed, system_format);
-    }
-    else
-    {
+    } else {
       QString separator;
       if (m_chatlog_newline)
         separator = QString(QChar::LineFeed);
@@ -1260,15 +1160,13 @@ void Courtroom::update_ic_log(bool p_reset_log)
    * this also removes the last character of the block that remains. That's why
    * we have to do this whole complicated process.
    * */
-  if (prev_cursor.hasSelection() || !is_scrolled)
-  {
+  if (prev_cursor.hasSelection() || !is_scrolled) {
     // restore previous selection and vscrollbar
     ui_ic_chatlog->setTextCursor(prev_cursor);
     vscrollbar->setValue(scroll_pos);
   }
   // scroll up/down depending on context
-  else
-  {
+  else {
     ui_ic_chatlog->moveCursor(move_type);
     vscrollbar->setValue(m_chatlog_scrolldown ? vscrollbar->maximum()
                                               : vscrollbar->minimum());
@@ -1276,8 +1174,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
 }
 
 void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system,
-                               bool p_music)
-{
+                               bool p_music) {
   // record new entry
   m_ic_records.append(
       std::make_shared<record_type>(p_name, p_line, "", p_system, p_music));
@@ -1286,15 +1183,13 @@ void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system,
   update_ic_log(false);
 }
 
-void Courtroom::append_system_text(QString p_line)
-{
+void Courtroom::append_system_text(QString p_line) {
   if (chatmessage_is_empty)
     return;
   append_ic_text("", p_line, true, false);
 }
 
-void Courtroom::play_preanim()
-{
+void Courtroom::play_preanim() {
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
@@ -1308,20 +1203,15 @@ void Courtroom::play_preanim()
   // set state
   anim_state = 1;
 
-  if (!m_msg_is_first_person)
-  {
-    QString f_anim_path =
-        ao_app->get_character_path(f_char) + f_preanim.toLower();
-    if (ui_vp_player_char->play_pre(f_char, f_preanim, true))
-    {
+  if (!m_msg_is_first_person) {
+    QString f_anim_path = ao_app->get_character_path(f_char, f_preanim);
+    if (ui_vp_player_char->play_pre(f_char, f_preanim, true)) {
       if (text_delay >= 0)
         text_delay_timer->start(text_delay);
 
       // finished
       return;
-    }
-    else
-    {
+    } else {
       qDebug() << "could not find " + f_anim_path;
     }
   }
@@ -1330,18 +1220,11 @@ void Courtroom::play_preanim()
   preanim_done();
 }
 
-void Courtroom::preanim_done()
-{
-  handle_chatmessage_3();
-}
+void Courtroom::preanim_done() { handle_chatmessage_3(); }
 
-void Courtroom::realization_done()
-{
-  ui_vp_effect->stop();
-}
+void Courtroom::realization_done() { ui_vp_effect->stop(); }
 
-void Courtroom::start_chat_ticking()
-{
+void Courtroom::start_chat_ticking() {
   ui_vp_message->clear();
 
   set_text_color();
@@ -1351,8 +1234,7 @@ void Courtroom::start_chat_ticking()
   if (text_state != 0)
     return;
 
-  if (chatmessage_is_empty)
-  {
+  if (chatmessage_is_empty) {
     // since the message is empty, it's technically done ticking
     text_state = 2;
     return;
@@ -1373,8 +1255,7 @@ void Courtroom::start_chat_ticking()
   text_state = 1;
 }
 
-void Courtroom::chat_tick()
-{
+void Courtroom::chat_tick() {
   // note: this is called fairly often(every 60 ms when char is talking)
   // do not perform heavy operations here
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
@@ -1385,14 +1266,12 @@ void Courtroom::chat_tick()
 
   QString f_message = m_chatmessage[MESSAGE];
 
-  if (tick_pos >= f_message.size())
-  {
+  if (tick_pos >= f_message.size()) {
     text_state = 2;
     chat_tick_timer->stop();
     anim_state = 3;
 
-    if (!m_msg_is_first_person)
-    {
+    if (!m_msg_is_first_person) {
       ui_vp_player_char->play_idle(m_chatmessage[CHAR_NAME],
                                    m_chatmessage[EMOTE], true);
     }
@@ -1401,18 +1280,15 @@ void Courtroom::chat_tick()
     m_color_stack.clear();
   }
 
-  else
-  {
+  else {
     QString f_character = f_message.at(tick_pos);
 
     if (f_character == " ")
       ui_vp_message->insertPlainText(" ");
-    else if (m_chatmessage[TEXT_COLOR].toInt() == RAINBOW)
-    {
+    else if (m_chatmessage[TEXT_COLOR].toInt() == RAINBOW) {
       QString html_color;
 
-      switch (rainbow_counter)
-      {
+      switch (rainbow_counter) {
       case 0:
         html_color = "#BA1518";
         break;
@@ -1437,10 +1313,8 @@ void Courtroom::chat_tick()
       vp_message_format.setForeground(text_color);
 
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
-    }
-    else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) ==
-             "true")
-    {
+    } else if (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) ==
+               "true") {
       bool highlight_found = false;
       bool render_character = true;
       // render_character should only be false if the character is a highlight
@@ -1450,10 +1324,8 @@ void Courtroom::chat_tick()
       if (m_color_stack.isEmpty())
         m_color_stack.push("");
 
-      for (const auto &col : f_vec)
-      {
-        if (f_character == col[0][0] && m_string_color != col[1])
-        {
+      for (const auto &col : f_vec) {
+        if (f_character == col[0][0] && m_string_color != col[1]) {
           m_color_stack.push(col[1]);
           m_string_color = m_color_stack.top();
           highlight_found = true;
@@ -1465,8 +1337,7 @@ void Courtroom::chat_tick()
       // Apply color to the next character
       if (m_string_color.isEmpty())
         vp_message_format.setForeground(m_base_string_color);
-      else
-      {
+      else {
         QColor textColor;
         textColor.setNamedColor(m_string_color);
         vp_message_format.setForeground(textColor);
@@ -1474,10 +1345,8 @@ void Courtroom::chat_tick()
 
       QString m_future_string_color = m_string_color;
 
-      for (const auto &col : f_vec)
-      {
-        if (f_character == col[0][1] && !highlight_found)
-        {
+      for (const auto &col : f_vec) {
+        if (f_character == col[0][1] && !highlight_found) {
           if (m_color_stack.size() > 1)
             m_color_stack.pop();
           m_future_string_color = m_color_stack.top();
@@ -1491,20 +1360,16 @@ void Courtroom::chat_tick()
         ui_vp_message->textCursor().insertText(f_character, vp_message_format);
 
       m_string_color = m_future_string_color;
-    }
-    else
-    {
+    } else {
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
     }
 
     QScrollBar *scroll = ui_vp_message->verticalScrollBar();
     scroll->setValue(scroll->maximum());
 
-    if ((f_message.at(tick_pos) != ' ' || ao_config->blank_blips_enabled()))
-    {
+    if ((f_message.at(tick_pos) != ' ' || ao_config->blank_blips_enabled())) {
 
-      if (blip_pos % ao_app->read_blip_rate() == 0)
-      {
+      if (blip_pos % ao_app->read_blip_rate() == 0) {
         blip_pos = 0;
 
         // play blip
@@ -1519,8 +1384,7 @@ void Courtroom::chat_tick()
   }
 }
 
-void Courtroom::show_testimony()
-{
+void Courtroom::show_testimony() {
   if (!testimony_in_progress || m_chatmessage[SIDE] != "wit")
     return;
 
@@ -1529,8 +1393,7 @@ void Courtroom::show_testimony()
   testimony_show_timer->start(testimony_show_time);
 }
 
-void Courtroom::hide_testimony()
-{
+void Courtroom::hide_testimony() {
   ui_vp_testimony->hide();
 
   if (!testimony_in_progress)
@@ -1539,25 +1402,22 @@ void Courtroom::hide_testimony()
   testimony_hide_timer->start(testimony_hide_time);
 }
 
-void Courtroom::play_sfx()
-{
+void Courtroom::play_sfx() {
   QString sfx_name = m_chatmessage[SFX_NAME];
   if (sfx_name == "1")
     return;
 
   QVector<QString> extensions{"", ".ogg", ".wav", ".mp3"};
-  QString general_path = ao_app->get_base_path() + "/sounds/general/";
 
-  QString f_ext = file_exists(general_path + sfx_name, extensions);
+  QString f_file =
+      ao_app->get_file_extension(ao_app->get_sounds_path(sfx_name), extensions);
 
-  m_effects_player->play(sfx_name + f_ext);
+  m_effects_player->play(f_file);
 }
 
-void Courtroom::set_text_color()
-{
+void Courtroom::set_text_color() {
 
-  switch (m_chatmessage[TEXT_COLOR].toInt())
-  {
+  switch (m_chatmessage[TEXT_COLOR].toInt()) {
   case GREEN:
     ui_vp_message->setStyleSheet("background-color: rgba(0, 0, 0, 0)");
     m_base_string_color.setRgb(101, 200, 86);
@@ -1596,22 +1456,19 @@ void Courtroom::set_text_color()
   }
 }
 
-void Courtroom::set_ip_list(QString p_list)
-{
+void Courtroom::set_ip_list(QString p_list) {
   QString f_list = p_list.replace("|", ":").replace("*", "\n");
 
   ui_server_chatlog->append(f_list);
 }
 
-void Courtroom::set_mute(bool p_muted, int p_cid)
-{
+void Courtroom::set_mute(bool p_muted, int p_cid) {
   if (p_cid != m_cid && p_cid != -1)
     return;
 
   if (p_muted)
     ui_muted->show();
-  else
-  {
+  else {
     ui_muted->hide();
     ui_ic_chat_message->setFocus();
   }
@@ -1623,8 +1480,7 @@ void Courtroom::set_mute(bool p_muted, int p_cid)
   ui_ic_chat_message->setEnabled(!p_muted);
 }
 
-void Courtroom::set_ban(int p_cid)
-{
+void Courtroom::set_ban(int p_cid) {
   if (p_cid != m_cid && p_cid != -1)
     return;
 
@@ -1634,8 +1490,7 @@ void Courtroom::set_ban(int p_cid)
   ao_app->destruct_courtroom();
 }
 
-void Courtroom::handle_song(QStringList *p_contents)
-{
+void Courtroom::handle_song(QStringList *p_contents) {
 
   QStringList f_contents = *p_contents;
 
@@ -1645,24 +1500,19 @@ void Courtroom::handle_song(QStringList *p_contents)
   QString f_song = f_contents.at(0);
   int n_char = f_contents.at(1).toInt();
 
-  for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"})
-  {
+  for (auto &ext : QStringList{"", ".wav", ".ogg", ".mp3"}) {
     QString r_song = f_song + ext;
     QString song_path =
         ao_app->get_base_path() + "sounds/music/" + r_song.toLower();
-    if (file_exists(song_path))
-    {
+    if (file_exists(song_path)) {
       f_song = r_song;
       break;
     }
   }
 
-  if (n_char < 0 || n_char >= char_list.size())
-  {
+  if (n_char < 0 || n_char >= char_list.size()) {
     m_music_player->play(f_song);
-  }
-  else
-  {
+  } else {
     // This 2th argument corresponds to the showname to use when displaying the
     // music change message in IC
     // Backwards compatibility is explicitly kept for older versions of
@@ -1670,29 +1520,21 @@ void Courtroom::handle_song(QStringList *p_contents)
     // If there is an empty showname, the client will use instead the default
     // showname of the character.
     QString f_showname;
-    if (f_contents.size() == 3)
-    {
+    if (f_contents.size() == 3) {
       f_showname = f_contents.at(2);
-    }
-    else
-    {
+    } else {
       f_showname = "";
     }
 
     QString str_char;
-    if (f_showname.isEmpty())
-    {
+    if (f_showname.isEmpty()) {
       str_char = ao_app->get_showname(char_list.at(n_char).name);
-    }
-    else
-    {
+    } else {
       str_char = f_showname;
     }
 
-    if (!mute_map.value(n_char))
-    {
-      if (ao_app->get_music_change_log_enabled())
-      {
+    if (!mute_map.value(n_char)) {
+      if (ao_app->get_music_change_log_enabled()) {
         append_ic_text(str_char, "has played a song: " + f_song, false, true);
       }
       m_music_player->play(f_song);
@@ -1707,8 +1549,7 @@ void Courtroom::handle_song(QStringList *p_contents)
   handle_music_anim();
 }
 
-void Courtroom::handle_wtce(QString p_wtce)
-{
+void Courtroom::handle_wtce(QString p_wtce) {
   QString sfx_file = cc_sounds_ini;
 
   int index = p_wtce.at(p_wtce.size() - 1).digitValue();
@@ -1716,40 +1557,32 @@ void Courtroom::handle_wtce(QString p_wtce)
       wtce_names.size() > 0) // check to prevent crash
   {
     p_wtce.chop(1); // looking for the 'testimony' part
-    if (p_wtce == "testimony")
-    {
+    if (p_wtce == "testimony") {
       m_effects_player->play(ao_app->get_sfx(wtce_names[index - 1]));
       ui_vp_wtce->play(wtce_names[index - 1]);
-      if (index == 1)
-      {
+      if (index == 1) {
         testimony_in_progress = true;
-      }
-      else if (index == 2)
+      } else if (index == 2)
         testimony_in_progress = false;
     }
   }
 }
 
-void Courtroom::set_hp_bar(int p_bar, int p_state)
-{
+void Courtroom::set_hp_bar(int p_bar, int p_state) {
   if (p_state < 0 || p_state > 10)
     return;
 
-  if (p_bar == 1)
-  {
+  if (p_bar == 1) {
     ui_defense_bar->set_image("defensebar" + QString::number(p_state) + ".png");
     defense_bar_state = p_state;
-  }
-  else if (p_bar == 2)
-  {
+  } else if (p_bar == 2) {
     ui_prosecution_bar->set_image("prosecutionbar" + QString::number(p_state) +
                                   ".png");
     prosecution_bar_state = p_state;
   }
 }
 
-void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown)
-{
+void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown) {
   int index = ui_pos_dropdown->findData(p_pos);
   if (index != -1 && refresh_dropdown)
     ui_pos_dropdown->setCurrentIndex(index);
@@ -1758,32 +1591,26 @@ void Courtroom::set_character_position(QString p_pos, bool refresh_dropdown)
   set_judge_enabled(p_pos == "jud");
 }
 
-void Courtroom::mod_called(QString p_ip)
-{
+void Courtroom::mod_called(QString p_ip) {
   ui_server_chatlog->append(p_ip);
-  if (ao_app->get_server_alerts_enabled())
-  {
+  if (ao_app->get_server_alerts_enabled()) {
     m_system_player->play(ao_app->get_sfx("mod_call"));
     ao_app->alert(this);
   }
 }
 
-void Courtroom::on_ooc_return_pressed()
-{
+void Courtroom::on_ooc_return_pressed() {
   QString ooc_name = ui_ooc_chat_name->text();
   QString ooc_message = ui_ooc_chat_message->text();
 
-  if (ooc_message.isEmpty())
-  {
+  if (ooc_message.isEmpty()) {
     append_server_chatmessage("CLIENT", "You cannot send an empty message.");
     return;
   }
-  if (ooc_name.isEmpty())
-  {
+  if (ooc_name.isEmpty()) {
     bool ok;
     QString name;
-    do
-    {
+    do {
       ooc_name = QInputDialog::getText(
           this, "Enter a name",
           "You must have a name to talk in OOC chat. Enter a name: ",
@@ -1793,35 +1620,23 @@ void Courtroom::on_ooc_return_pressed()
       return;
 
     ao_config->set_username(ooc_name);
-  }
-  else if (ooc_message.startsWith("/rainbow") && ao_app->yellow_text_enabled &&
-           !rainbow_appended)
-  {
+  } else if (ooc_message.startsWith("/rainbow") &&
+             ao_app->yellow_text_enabled && !rainbow_appended) {
     ui_text_color->addItem("Rainbow");
     ui_ooc_chat_message->clear();
     rainbow_appended = true;
     return;
-  }
-  else if (ooc_message.startsWith("/switch_am"))
-  {
+  } else if (ooc_message.startsWith("/switch_am")) {
     on_switch_area_music_clicked();
     ui_ooc_chat_message->clear();
     return;
-  }
-  else if (ooc_message.startsWith("/rollp"))
-  {
+  } else if (ooc_message.startsWith("/rollp")) {
     m_effects_player->play(ao_app->get_sfx("dice"));
-  }
-  else if (ooc_message.startsWith("/roll"))
-  {
+  } else if (ooc_message.startsWith("/roll")) {
     m_effects_player->play(ao_app->get_sfx("dice"));
-  }
-  else if (ooc_message.startsWith("/coinflip"))
-  {
+  } else if (ooc_message.startsWith("/coinflip")) {
     m_effects_player->play(ao_app->get_sfx("coinflip"));
-  }
-  else if (ooc_message.startsWith("/tr "))
-  {
+  } else if (ooc_message.startsWith("/tr ")) {
     // Timer resume
     int space_location = ooc_message.indexOf(" ");
 
@@ -1831,9 +1646,7 @@ void Courtroom::on_ooc_return_pressed()
     else
       timer_id = ooc_message.mid(space_location + 1).toInt();
     resume_timer(timer_id);
-  }
-  else if (ooc_message.startsWith("/ts "))
-  {
+  } else if (ooc_message.startsWith("/ts ")) {
     // Timer set
     QStringList arguments = ooc_message.split(" ");
     int size = arguments.size();
@@ -1850,9 +1663,7 @@ void Courtroom::on_ooc_return_pressed()
     set_timer_time(timer_id, new_time);
     set_timer_timestep(timer_id, timestep_length);
     set_timer_firing(timer_id, firing_interval);
-  }
-  else if (ooc_message.startsWith("/tp "))
-  {
+  } else if (ooc_message.startsWith("/tp ")) {
     // Timer pause
     int space_location = ooc_message.indexOf(" ");
 
@@ -1876,23 +1687,20 @@ void Courtroom::on_ooc_return_pressed()
   ui_ooc_chat_message->setFocus();
 }
 
-void Courtroom::on_music_search_edited(QString p_text)
-{
+void Courtroom::on_music_search_edited(QString p_text) {
   // preventing compiler warnings
   p_text += "a";
   list_music();
   list_areas();
 }
 
-void Courtroom::on_sfx_search_edited(QString p_text)
-{
+void Courtroom::on_sfx_search_edited(QString p_text) {
   // preventing compiler warnings
   p_text += "a";
   list_sfx();
 }
 
-void Courtroom::on_pos_dropdown_changed(int p_index)
-{
+void Courtroom::on_pos_dropdown_changed(int p_index) {
   ui_ic_chat_message->setFocus();
 
   if (p_index < 0 || p_index > 5)
@@ -1900,8 +1708,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
 
   QString f_pos;
 
-  switch (p_index)
-  {
+  switch (p_index) {
   case 0:
     f_pos = "wit";
     break;
@@ -1936,8 +1743,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
   // ao_app->send_server_packet(new AOPacket("SP#" + f_pos + "#%"));
 }
 
-void Courtroom::on_mute_list_clicked(QModelIndex p_index)
-{
+void Courtroom::on_mute_list_clicked(QModelIndex p_index) {
   QListWidgetItem *f_item = ui_mute_list->item(p_index.row());
   QString f_char = f_item->text();
   QString real_char;
@@ -1949,25 +1755,20 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
 
   int f_cid = -1;
 
-  for (int n_char = 0; n_char < char_list.size(); n_char++)
-  {
+  for (int n_char = 0; n_char < char_list.size(); n_char++) {
     if (char_list.at(n_char).name == real_char)
       f_cid = n_char;
   }
 
-  if (f_cid < 0 || f_cid >= char_list.size())
-  {
+  if (f_cid < 0 || f_cid >= char_list.size()) {
     qDebug() << "W: " << real_char << " not present in char_list";
     return;
   }
 
-  if (mute_map.value(f_cid))
-  {
+  if (mute_map.value(f_cid)) {
     mute_map.insert(f_cid, false);
     f_item->setText(real_char);
-  }
-  else
-  {
+  } else {
     mute_map.insert(f_cid, true);
     f_item->setText(real_char + " [x]");
   }
@@ -1990,18 +1791,11 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
   */
 }
 
-void Courtroom::on_music_list_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_music_list_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_area_list_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_area_list_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
-{
+void Courtroom::on_music_list_double_clicked(QModelIndex p_model) {
   if (is_client_muted)
     return;
 
@@ -2014,8 +1808,7 @@ void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
-{
+void Courtroom::on_area_list_double_clicked(QModelIndex p_model) {
   QString p_area = ui_area_list->item(p_model.row())->text();
 
   ao_app->send_server_packet(
@@ -2025,8 +1818,7 @@ void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::reset_shout_buttons()
-{
+void Courtroom::reset_shout_buttons() {
   for (int i = 0; i < ui_shouts.size(); ++i)
     ui_shouts[i]->set_image(shout_names.at(i) + ".png");
 
@@ -2036,8 +1828,7 @@ void Courtroom::reset_shout_buttons()
         ->set_image(shout_names.at(m_objection_state - 1) + "_selected.png");
 }
 
-void Courtroom::on_shout_clicked()
-{
+void Courtroom::on_shout_clicked() {
   AOButton *f_shout_button = static_cast<AOButton *>(sender());
   int f_shout_id = f_shout_button->property("shout_id").toInt();
 
@@ -2052,13 +1843,11 @@ void Courtroom::on_shout_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_cycle_clicked()
-{
+void Courtroom::on_cycle_clicked() {
   AOButton *f_cycle_button = static_cast<AOButton *>(sender());
   int f_cycle_id = f_cycle_button->property("cycle_id").toInt();
 
-  switch (f_cycle_id)
-  {
+  switch (f_cycle_id) {
   case 5:
     cycle_wtce(-1);
     break;
@@ -2088,44 +1877,36 @@ void Courtroom::on_cycle_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::cycle_shout(int p_index)
-{
+void Courtroom::cycle_shout(int p_index) {
   int n = ui_shouts.size();
-  do
-  {
+  do {
     m_shout_state = (m_shout_state - p_index + n) % n;
   } while (!shouts_enabled[m_shout_state]);
 
   set_shouts();
 }
 
-void Courtroom::cycle_effect(int p_index)
-{
+void Courtroom::cycle_effect(int p_index) {
   int n = ui_effects.size();
-  do
-  {
+  do {
     m_effect_current = (m_effect_current - p_index + n) % n;
   } while (!effects_enabled[m_effect_current]);
 
   set_effects();
 }
 
-void Courtroom::cycle_wtce(int p_index)
-{
+void Courtroom::cycle_wtce(int p_index) {
   int n = ui_wtce.size();
-  do
-  {
+  do {
     m_wtce_current = (m_wtce_current - p_index + n) % n;
   } while (!wtce_enabled[m_wtce_current]);
 
   set_judge_wtce();
 }
 
-void Courtroom::reset_effect_buttons()
-{
+void Courtroom::reset_effect_buttons() {
   // effect names does not necessarily have the same size as ui effects
-  for (int i = 0; i < effect_names.size(); ++i)
-  {
+  for (int i = 0; i < effect_names.size(); ++i) {
     // qDebug() << effect_names << i;
     ui_effects[i]->set_image(effect_names.at(i) + ".png");
   }
@@ -2135,8 +1916,7 @@ void Courtroom::reset_effect_buttons()
         effect_names.at(m_effect_state - 1) + "_pressed.png");
 }
 
-void Courtroom::on_effect_button_clicked()
-{
+void Courtroom::on_effect_button_clicked() {
   AOButton *f_button = static_cast<AOButton *>(this->sender());
 
   int f_effect_id = f_button->property("effect_id").toInt();
@@ -2150,22 +1930,17 @@ void Courtroom::on_effect_button_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_mute_clicked()
-{
-  if (ui_mute_list->isHidden())
-  {
+void Courtroom::on_mute_clicked() {
+  if (ui_mute_list->isHidden()) {
     ui_mute_list->show();
     ui_mute->set_image("mute_pressed.png");
-  }
-  else
-  {
+  } else {
     ui_mute_list->hide();
     ui_mute->set_image("mute.png");
   }
 }
 
-void Courtroom::on_defense_minus_clicked()
-{
+void Courtroom::on_defense_minus_clicked() {
   int f_state = defense_bar_state - 1;
 
   if (f_state >= 0)
@@ -2173,8 +1948,7 @@ void Courtroom::on_defense_minus_clicked()
         new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_defense_plus_clicked()
-{
+void Courtroom::on_defense_plus_clicked() {
   int f_state = defense_bar_state + 1;
 
   if (f_state <= 10)
@@ -2182,8 +1956,7 @@ void Courtroom::on_defense_plus_clicked()
         new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_prosecution_minus_clicked()
-{
+void Courtroom::on_prosecution_minus_clicked() {
   int f_state = prosecution_bar_state - 1;
 
   if (f_state >= 0)
@@ -2191,8 +1964,7 @@ void Courtroom::on_prosecution_minus_clicked()
         new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_prosecution_plus_clicked()
-{
+void Courtroom::on_prosecution_plus_clicked() {
   int f_state = prosecution_bar_state + 1;
 
   if (f_state <= 10)
@@ -2200,14 +1972,12 @@ void Courtroom::on_prosecution_plus_clicked()
         new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
-void Courtroom::on_text_color_changed(int p_color)
-{
+void Courtroom::on_text_color_changed(int p_color) {
   m_text_color = p_color;
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_witness_testimony_clicked()
-{
+void Courtroom::on_witness_testimony_clicked() {
   if (is_client_muted)
     return;
 
@@ -2216,8 +1986,7 @@ void Courtroom::on_witness_testimony_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_cross_examination_clicked()
-{
+void Courtroom::on_cross_examination_clicked() {
   if (is_client_muted)
     return;
 
@@ -2237,8 +2006,7 @@ void Courtroom::reset_judge_wtce_buttons() // kind of an unnecessary function,
   }
 }
 
-void Courtroom::on_wtce_clicked()
-{
+void Courtroom::on_wtce_clicked() {
   //  qDebug() << "AA: wtce clicked!";
   if (is_client_muted)
     return;
@@ -2253,8 +2021,7 @@ void Courtroom::on_wtce_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_change_character_clicked()
-{
+void Courtroom::on_change_character_clicked() {
   set_audio_mute_enabled(true);
 
   set_char_select();
@@ -2263,8 +2030,7 @@ void Courtroom::on_change_character_clicked()
   ui_spectator->show();
 }
 
-void Courtroom::on_app_reload_theme_requested()
-{
+void Courtroom::on_app_reload_theme_requested() {
   load_shouts();
   load_effects();
   load_wtce();
@@ -2277,8 +2043,7 @@ void Courtroom::on_app_reload_theme_requested()
   text_state = 3;
 }
 
-void Courtroom::on_back_to_lobby_clicked()
-{
+void Courtroom::on_back_to_lobby_clicked() {
   // hide so we don't get the 'disconnected from server' prompt
   hide();
 
@@ -2288,20 +2053,17 @@ void Courtroom::on_back_to_lobby_clicked()
   ao_app->destruct_courtroom();
 }
 
-void Courtroom::on_char_select_left_clicked()
-{
+void Courtroom::on_char_select_left_clicked() {
   --current_char_page;
   set_char_select_page();
 }
 
-void Courtroom::on_char_select_right_clicked()
-{
+void Courtroom::on_char_select_right_clicked() {
   ++current_char_page;
   set_char_select_page();
 }
 
-void Courtroom::on_spectator_clicked()
-{
+void Courtroom::on_spectator_clicked() {
   QString content =
       "CC#" + QString::number(ao_app->s_pv) + "#-1#" + get_hdid() + "#%";
   ao_app->send_server_packet(new AOPacket(content));
@@ -2312,8 +2074,7 @@ void Courtroom::on_spectator_clicked()
   ui_char_select_background->hide();
 }
 
-void Courtroom::on_call_mod_clicked()
-{
+void Courtroom::on_call_mod_clicked() {
   QMessageBox::StandardButton reply;
   QString warning = "Are you sure you want to call a mod? They will get angry "
                     "at you if the reason is no good.";
@@ -2321,77 +2082,53 @@ void Courtroom::on_call_mod_clicked()
       QMessageBox::warning(this, "Warning", warning,
                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
-  if (reply == QMessageBox::Yes)
-  {
+  if (reply == QMessageBox::Yes) {
     ao_app->send_server_packet(new AOPacket("ZZ#%"));
     qDebug() << "Called mod";
-  }
-  else
+  } else
     qDebug() << "Did not call mod";
 
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_switch_area_music_clicked()
-{
-  if (ui_area_list->isHidden())
-  {
+void Courtroom::on_switch_area_music_clicked() {
+  if (ui_area_list->isHidden()) {
     ui_area_list->show();
     ui_music_list->hide();
-  }
-  else
-  {
+  } else {
     ui_area_list->hide();
     ui_music_list->show();
   }
 }
 
-void Courtroom::on_pre_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_pre_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_flip_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_flip_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_hidden_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_hidden_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_evidence_button_clicked()
-{
-  if (ui_evidence->isHidden())
-  {
+void Courtroom::on_evidence_button_clicked() {
+  if (ui_evidence->isHidden()) {
     ui_evidence->show();
     ui_evidence_overlay->hide();
-  }
-  else
-  {
+  } else {
     ui_evidence->hide();
   }
 }
 
-void Courtroom::on_config_panel_clicked()
-{
+void Courtroom::on_config_panel_clicked() {
   ao_app->toggle_config_panel();
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_note_button_clicked()
-{
-  if (!note_shown)
-  {
+void Courtroom::on_note_button_clicked() {
+  if (!note_shown) {
     load_note();
     ui_vp_notepad_image->show();
     ui_vp_notepad->show();
     ui_vp_notepad->setFocus();
     note_shown = true;
-  }
-  else
-  {
+  } else {
     save_note();
     ui_vp_notepad_image->hide();
     ui_vp_notepad->hide();
@@ -2400,70 +2137,58 @@ void Courtroom::on_note_button_clicked()
   }
 }
 
-void Courtroom::on_note_text_changed()
-{
+void Courtroom::on_note_text_changed() {
   ao_app->write_note(ui_vp_notepad->toPlainText(), current_file);
 }
 
-void Courtroom::ping_server()
-{
+void Courtroom::ping_server() {
   ao_app->send_server_packet(
       new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }
 
-void Courtroom::closeEvent(QCloseEvent *event)
-{
+void Courtroom::closeEvent(QCloseEvent *event) {
   emit closing();
   QMainWindow::closeEvent(event);
 }
 
-void Courtroom::on_sfx_list_clicked()
-{
-  ui_ic_chat_message->setFocus();
-}
+void Courtroom::on_sfx_list_clicked() { ui_ic_chat_message->setFocus(); }
 
-void Courtroom::on_set_notes_clicked()
-{
+void Courtroom::on_set_notes_clicked() {
   if (note_scroll_area->isHidden())
     note_scroll_area->show();
   else
     note_scroll_area->hide();
 }
 
-void Courtroom::resume_timer(int timer_id)
-{
+void Courtroom::resume_timer(int timer_id) {
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->resume();
 }
 
-void Courtroom::set_timer_time(int timer_id, int new_time)
-{
+void Courtroom::set_timer_time(int timer_id, int new_time) {
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_time(QTime(0, 0).addMSecs(new_time));
 }
 
-void Courtroom::set_timer_timestep(int timer_id, int timestep_length)
-{
+void Courtroom::set_timer_timestep(int timer_id, int timestep_length) {
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_timestep_length(timestep_length);
 }
 
-void Courtroom::set_timer_firing(int timer_id, int firing_interval)
-{
+void Courtroom::set_timer_firing(int timer_id, int firing_interval) {
   if (timer_id >= timer_number)
     return;
 
   ui_timers[timer_id]->set_firing_interval(firing_interval);
 }
 
-void Courtroom::pause_timer(int timer_id)
-{
+void Courtroom::pause_timer(int timer_id) {
   if (timer_id >= timer_number)
     return;
 

--- a/courtroom.h
+++ b/courtroom.h
@@ -10,6 +10,7 @@
 #include "aoconfigpanel.h"
 #include "aoemotebutton.h"
 #include "aoevidencebutton.h"
+#include "aoevidencedescription.h"
 #include "aoevidencedisplay.h"
 #include "aoimage.h"
 #include "aolabel.h"
@@ -23,7 +24,6 @@
 #include "aosfxplayer.h"
 #include "aoshoutplayer.h"
 #include "aotextarea.h"
-#include "aoevidencedescription.h"
 #include "aotimer.h"
 #include "datatypes.h"
 
@@ -48,732 +48,776 @@ class AOApplication;
 
 class Courtroom : public QMainWindow
 {
-    Q_OBJECT
+  Q_OBJECT
 public:
-    explicit Courtroom(AOApplication *p_ao_app);
+  explicit Courtroom(AOApplication *p_ao_app);
 
-    void append_char(char_type p_char) { char_list.append(p_char); }
-    void append_evidence(evi_type p_evi) { evidence_list.append(p_evi); }
-    void append_music(QString f_music) { music_list.append(f_music); }
-    void append_area(QString f_area) { area_list.append(f_area); }
-    void clear_music() { music_list.clear(); }
-    void clear_areas() { area_list.clear(); }
+  void append_char(char_type p_char)
+  {
+    char_list.append(p_char);
+  }
+  void append_evidence(evi_type p_evi)
+  {
+    evidence_list.append(p_evi);
+  }
+  void append_music(QString f_music)
+  {
+    music_list.append(f_music);
+  }
+  void append_area(QString f_area)
+  {
+    area_list.append(f_area);
+  }
+  void clear_music()
+  {
+    music_list.clear();
+  }
+  void clear_areas()
+  {
+    area_list.clear();
+  }
 
-    void fix_last_area()
+  void fix_last_area()
+  {
+    if (area_list.size() > 0)
     {
-        if (area_list.size() > 0)
-        {
-            QString malplaced = area_list.last();
-            area_list.removeLast();
-            append_music(malplaced);
-            //      qDebug() << "what" << malplaced;
-        }
+      QString malplaced = area_list.last();
+      area_list.removeLast();
+      append_music(malplaced);
+      //      qDebug() << "what" << malplaced;
     }
+  }
 
-    //sets position of widgets based on theme ini files
-    void set_widgets();
-    //sets font properties based on theme ini files
-    void set_font(QWidget *widget, QString p_identifier);
-    //same as above, but use override color as color if it is not an empty string, otherwise use
-    //normal logic for color of set_font
-    void set_font(QWidget *widget, QString p_identifier, QString override_color);
-    //sets font properties for QTextEdit (same as above but also text outline)
-    void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
-    //same as second set_font but for qtextedit
-    void set_qtextedit_font(QTextEdit *widget, QString p_identifier, QString override_color);
-    //helper function that calls above function on the relevant widgets
-    void set_fonts();
+  // sets position of widgets based on theme ini files
+  void set_widgets();
+  // sets font properties based on theme ini files
+  void set_font(QWidget *widget, QString p_identifier);
+  // same as above, but use override color as color if it is not an empty
+  // string, otherwise use normal logic for color of set_font
+  void set_font(QWidget *widget, QString p_identifier, QString override_color);
+  // sets font properties for QTextEdit (same as above but also text outline)
+  void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
+  // same as second set_font but for qtextedit
+  void set_qtextedit_font(QTextEdit *widget, QString p_identifier,
+                          QString override_color);
+  // helper function that calls above function on the relevant widgets
+  void set_fonts();
 
-    //sets dropdown menu stylesheet
-    void set_dropdown(QWidget *widget, QString target_tag);
+  // sets dropdown menu stylesheet
+  void set_dropdown(QWidget *widget, QString target_tag);
 
-    //helper funciton that call above function on the relevant widgets
-    void set_dropdowns();
+  // helper funciton that call above function on the relevant widgets
+  void set_dropdowns();
 
-    void set_window_title(QString p_title);
+  void set_window_title(QString p_title);
 
-    //reads theme inis and sets size and pos based on the identifier
-    void set_size_and_pos(QWidget *p_widget, QString p_identifier);
+  // reads theme inis and sets size and pos based on the identifier
+  void set_size_and_pos(QWidget *p_widget, QString p_identifier);
 
-    //sets status as taken on character with cid n_char and places proper shading on charselect
-    void set_taken(int n_char, bool p_taken);
+  // sets status as taken on character with cid n_char and places proper shading
+  // on charselect
+  void set_taken(int n_char, bool p_taken);
 
-    //sets the current background to argument. also does some checks to see if it's a legacy bg
-    void set_background(QString p_background);
+  // sets the current background to argument. also does some checks to see if
+  // it's a legacy bg
+  void set_background(QString p_background);
 
-    //sets the evidence list member variable to argument
-    void set_evidence_list(QVector<evi_type> &p_evi_list);
+  // sets the evidence list member variable to argument
+  void set_evidence_list(QVector<evi_type> &p_evi_list);
 
-    //sets the character position
-    void set_character_position(QString p_pos, bool refresh_dropdown);
+  // sets the character position
+  void set_character_position(QString p_pos, bool refresh_dropdown);
 
-    //called when a DONE#% from the server was received
-    void done_received();
+  // called when a DONE#% from the server was received
+  void done_received();
 
-    //sets the local mute list based on characters available on the server
-    void set_mute_list();
+  // sets the local mute list based on characters available on the server
+  void set_mute_list();
 
-    //sets desk and bg based on pos in chatmessage
-    void set_scene();
+  // sets desk and bg based on pos in chatmessage
+  void set_scene();
 
-    //sets text color based on text color in chatmessage
-    void set_text_color();
+  // sets text color based on text color in chatmessage
+  void set_text_color();
 
-    //takes in serverD-formatted IP list as prints a converted version to server OOC
-    //admittedly poorly named
-    void set_ip_list(QString p_list);
+  // takes in serverD-formatted IP list as prints a converted version to server
+  // OOC admittedly poorly named
+  void set_ip_list(QString p_list);
 
-    //disables chat if current cid matches second argument
-    //enables if p_muted is false
-    void set_mute(bool p_muted, int p_cid);
+  // disables chat if current cid matches second argument
+  // enables if p_muted is false
+  void set_mute(bool p_muted, int p_cid);
 
-    //send a message that the player is banned and quits the server
-    void set_ban(int p_cid);
+  // send a message that the player is banned and quits the server
+  void set_ban(int p_cid);
 
-    //implementations in path_functions.cpp
-    QString get_background_path();
-    QString get_default_background_path();
+  // implementations in path_functions.cpp
+  QString get_background_path();
+  QString get_default_background_path();
 
-    //cid = character id, returns the cid of the currently selected character
-    int get_cid() { return m_cid; }
-    QString get_current_char() { return current_char; }
+  // cid = character id, returns the cid of the currently selected character
+  int get_cid()
+  {
+    return m_cid;
+  }
+  QString get_current_char()
+  {
+    return current_char;
+  }
 
-    //properly sets up some varibles: resets user state
-    void enter_courtroom(int p_cid);
+  // properly sets up some varibles: resets user state
+  void enter_courtroom(int p_cid);
 
-    //helper function that populates ui_music_list with the contents of music_list
-    void list_music();
+  // helper function that populates ui_music_list with the contents of
+  // music_list
+  void list_music();
 
-    void list_areas();
+  void list_areas();
 
-    void list_sfx();
+  void list_sfx();
 
-    void list_note_files();
+  void list_note_files();
 
-    void set_note_files();
+  void set_note_files();
 
-    void move_widget(QWidget *p_widget, QString p_identifier);
+  void move_widget(QWidget *p_widget, QString p_identifier);
 
-    void set_shouts();
-    void set_effects();
-    void set_judge_enabled(bool p_enabled);
-    void set_judge_wtce();
-    void set_free_blocks();
+  void set_shouts();
+  void set_effects();
+  void set_judge_enabled(bool p_enabled);
+  void set_judge_wtce();
+  void set_free_blocks();
 
-    //these are for OOC chat
-    void append_server_chatmessage(QString p_name, QString p_message);
+  // these are for OOC chat
+  void append_server_chatmessage(QString p_name, QString p_message);
 
-    //these functions handle chatmessages sequentially.
-    //The process itself is very convoluted and merits separate documentation
-    //But the general idea is objection animation->pre animation->talking->idle
-    void handle_chatmessage(QStringList *p_contents);
-    void handle_chatmessage_2();
-    void handle_chatmessage_3();
+  // these functions handle chatmessages sequentially.
+  // The process itself is very convoluted and merits separate documentation
+  // But the general idea is objection animation->pre animation->talking->idle
+  void handle_chatmessage(QStringList *p_contents);
+  void handle_chatmessage_2();
+  void handle_chatmessage_3();
 
-    //adds text to the IC chatlog. p_name first as bold then p_text then a newlin
-    //this function keeps the chatlog scrolled to the top unless there's text selected
-    // or the user isn't already scrolled to the top
-    void update_ic_log(bool p_reset_log);
-    void append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music);
-    void append_system_text(QString p_line);
+  // adds text to the IC chatlog. p_name first as bold then p_text then a newlin
+  // this function keeps the chatlog scrolled to the top unless there's text
+  // selected
+  // or the user isn't already scrolled to the top
+  void update_ic_log(bool p_reset_log);
+  void append_ic_text(QString p_name, QString p_line, bool p_system,
+                      bool p_music);
+  void append_system_text(QString p_line);
 
-    //prints who played the song to IC chat and plays said song(if found on local filesystem)
-    //takes in a list where the first element is the song name and the second is the char id of who played it
-    void handle_song(QStringList *p_contents);
+  // prints who played the song to IC chat and plays said song(if found on local
+  // filesystem) takes in a list where the first element is the song name and
+  // the second is the char id of who played it
+  void handle_song(QStringList *p_contents);
 
-    //animates music text
-    void handle_music_anim();
+  // animates music text
+  void handle_music_anim();
 
-    //handle server-side clock animation and display
-    void handle_clock(QString time);
+  // handle server-side clock animation and display
+  void handle_clock(QString time);
 
-    //handle request to change theme variant
-    void handle_theme_variant(QString theme_variant);
+  // handle request to change theme variant
+  void handle_theme_variant(QString theme_variant);
 
-    void play_preanim();
+  void play_preanim();
 
-    //plays the witness testimony or cross examination animation based on argument
-    void handle_wtce(QString p_wtce);
+  // plays the witness testimony or cross examination animation based on
+  // argument
+  void handle_wtce(QString p_wtce);
 
-    //sets the hp bar of defense(p_bar 1) or pro(p_bar 2)
-    //state is an number between 0 and 10 inclusive
-    void set_hp_bar(int p_bar, int p_state);
+  // sets the hp bar of defense(p_bar 1) or pro(p_bar 2)
+  // state is an number between 0 and 10 inclusive
+  void set_hp_bar(int p_bar, int p_state);
 
-    void check_connection_received();
+  void check_connection_received();
 
-    //checks whether shout/effect/wtce/free block files are found
-    void check_shouts();
-    void check_effects();
-    void check_wtce();
-    void check_free_blocks();
+  // checks whether shout/effect/wtce/free block files are found
+  void check_shouts();
+  void check_effects();
+  void check_wtce();
+  void check_free_blocks();
 
-    void resume_timer(int timer_id);
-    void set_timer_time(int timer_id, int new_time);
-    void set_timer_timestep(int timer_id, int timestep_length);
-    void set_timer_firing(int timer_id, int firing_interval);
-    void pause_timer(int timer_id);
+  void resume_timer(int timer_id);
+  void set_timer_time(int timer_id, int new_time);
+  void set_timer_timestep(int timer_id, int timestep_length);
+  void set_timer_firing(int timer_id, int firing_interval);
+  void pause_timer(int timer_id);
 
-    template <typename T>
-    int adapt_numbered_items(QVector<T *> &item_vector, QString config_item_number, QString item_name);
+  template <typename T>
+  int adapt_numbered_items(QVector<T *> &item_vector,
+                           QString config_item_number, QString item_name);
 
 signals:
-    void closing();
+  void closing();
 
 private:
-    AOApplication *ao_app = nullptr;
-    AOConfig *ao_config   = nullptr;
+  AOApplication *ao_app = nullptr;
+  AOConfig *ao_config = nullptr;
 
-    int m_courtroom_width  = 714;
-    int m_courtroom_height = 668;
+  int m_courtroom_width = 714;
+  int m_courtroom_height = 668;
 
-    int m_viewport_x = 0;
-    int m_viewport_y = 0;
+  int m_viewport_x = 0;
+  int m_viewport_y = 0;
 
-    int m_viewport_width  = 256;
-    int m_viewport_height = 192;
+  int m_viewport_width = 256;
+  int m_viewport_height = 192;
 
-    QVector<char_type> char_list;
-    QVector<evi_type> evidence_list;
-    QVector<QString> music_list;
-    QVector<QString> area_list;
-    QVector<QString> sfx_names;
-    QVector<QString> area_names;
-    QVector<QString> note_list;
+  QVector<char_type> char_list;
+  QVector<evi_type> evidence_list;
+  QVector<QString> music_list;
+  QVector<QString> area_list;
+  QVector<QString> sfx_names;
+  QVector<QString> area_names;
+  QVector<QString> note_list;
 
-    QSignalMapper *char_button_mapper;
+  QSignalMapper *char_button_mapper;
 
-    //triggers ping_server() every 60 seconds
-    QTimer *keepalive_timer;
+  // triggers ping_server() every 60 seconds
+  QTimer *keepalive_timer;
 
-    //maintains a timer for how fast messages tick onto screen
-    QTimer *chat_tick_timer;
-    //which tick position(character in chat message) we are at
-    int tick_pos = 0;
-    //used to determine how often blips sound
-    int blip_pos             = 0;
-    int rainbow_counter      = 0;
-    bool rainbow_appended    = false;
-    bool note_shown          = false;
-    bool contains_add_button = false;
+  // maintains a timer for how fast messages tick onto screen
+  QTimer *chat_tick_timer;
+  // which tick position(character in chat message) we are at
+  int tick_pos = 0;
+  // used to determine how often blips sound
+  int blip_pos = 0;
+  int rainbow_counter = 0;
+  bool rainbow_appended = false;
+  bool note_shown = false;
+  bool contains_add_button = false;
 
-    //////////////
-    QScrollArea *note_scroll_area;
+  //////////////
+  QScrollArea *note_scroll_area;
 
-    //delay before chat messages starts ticking
-    QTimer *text_delay_timer;
+  // delay before chat messages starts ticking
+  QTimer *text_delay_timer;
 
-    //delay before sfx plays
-    QTimer *sfx_delay_timer;
+  // delay before sfx plays
+  QTimer *sfx_delay_timer;
 
-    //keeps track of how long realization is visible(it's just a white square and should be visible less than a second)
-    QTimer *realization_timer;
+  // keeps track of how long realization is visible(it's just a white square and
+  // should be visible less than a second)
+  QTimer *realization_timer;
 
-    //times how long the blinking testimony should be shown(green one in the corner)
-    QTimer *testimony_show_timer;
-    //times how long the blinking testimony should be hidden
-    QTimer *testimony_hide_timer;
+  // times how long the blinking testimony should be shown(green one in the
+  // corner)
+  QTimer *testimony_show_timer;
+  // times how long the blinking testimony should be hidden
+  QTimer *testimony_hide_timer;
 
-    //Generate a File Name based on the time you launched the client
-    QString icchatlogsfilename = QDateTime::currentDateTime().toString("'logs/'ddd MMMM dd yyyy hh.mm.ss.z'.txt'");
+  // Generate a File Name based on the time you launched the client
+  QString icchatlogsfilename = QDateTime::currentDateTime().toString(
+      "'logs/'ddd MMMM dd yyyy hh.mm.ss.z'.txt'");
 
-    //configuration files locations
-    QString rpc_ini         = "configs/rpccharlist.ini";
-    QString file_select_ini = "configs/filesabstract.ini";
-    QString shownames_ini   = "configs/shownames.ini";
+  // configuration files locations
+  QString rpc_ini = "configs/rpccharlist.ini";
+  QString file_select_ini = "configs/filesabstract.ini";
+  QString shownames_ini = "configs/shownames.ini";
 
-    //theme files locations
-    QString design_ini    = "courtroom_design.ini";
-    QString fonts_ini     = "courtroom_fonts.ini";
-    QString cc_config_ini = "courtroom_config.ini";
-    QString cc_sounds_ini = "courtroom_sounds.ini";
+  // theme files locations
+  QString design_ini = "courtroom_design.ini";
+  QString fonts_ini = "courtroom_fonts.ini";
+  QString cc_config_ini = "courtroom_config.ini";
+  QString cc_sounds_ini = "courtroom_sounds.ini";
 
-    //every time point in char.inis times this equals the final time
-    const int time_mod = 40;
+  // every time point in char.inis times this equals the final time
+  const int time_mod = 40;
 
-    static const int chatmessage_size = 16;
-    QString m_chatmessage[chatmessage_size];
-    bool chatmessage_is_empty = false;
+  static const int chatmessage_size = 16;
+  QString m_chatmessage[chatmessage_size];
+  bool chatmessage_is_empty = false;
 
-    QString previous_ic_message = "";
+  QString previous_ic_message = "";
 
-    QColor m_base_string_color;
-    QString m_string_color = "";
+  QColor m_base_string_color;
+  QString m_string_color = "";
 
-    QStack<QString> m_color_stack;
+  QStack<QString> m_color_stack;
 
-    bool testimony_in_progress = false;
+  bool testimony_in_progress = false;
 
-    //in milliseconds
-    const int testimony_show_time = 1500;
+  // in milliseconds
+  const int testimony_show_time = 1500;
 
-    //in milliseconds
-    const int testimony_hide_time = 500;
+  // in milliseconds
+  const int testimony_hide_time = 500;
 
-    //char id, muted or not
-    QMap<int, bool> mute_map;
+  // char id, muted or not
+  QMap<int, bool> mute_map;
 
-    //QVector<int> muted_cids;
+  // QVector<int> muted_cids;
 
-    bool is_client_muted = false;
+  bool is_client_muted = false;
 
-    // state of animation, 0 = objecting, 1 = preanim, 2 = talking, 3 = idle
-    int anim_state = 3;
+  // state of animation, 0 = objecting, 1 = preanim, 2 = talking, 3 = idle
+  int anim_state = 3;
 
-    // state of text ticking, 0 = not yet ticking, 1 = ticking in progress, 2 = ticking done
-    int text_state = 2;
+  // state of text ticking, 0 = not yet ticking, 1 = ticking in progress, 2 =
+  // ticking done
+  int text_state = 2;
 
-    // character id, which index of the char_list the player is
-    int m_cid = -1;
+  // character id, which index of the char_list the player is
+  int m_cid = -1;
 
-    // if enabled, disable showing our own sprites when we talk in ic
-    bool m_msg_is_first_person = false;
+  // if enabled, disable showing our own sprites when we talk in ic
+  bool m_msg_is_first_person = false;
 
-    //cid and this may differ in cases of ini-editing
-    QString current_char = "";
+  // cid and this may differ in cases of ini-editing
+  QString current_char = "";
 
-    QString current_file = "";
+  QString current_file = "";
 
-    int m_objection_state       = 0;
-    int m_effect_state          = 0;
-    int m_text_color            = 0;
-    int m_shout_state           = 0;
-    int m_effect_current        = 0;
-    int m_wtce_current          = 0;
-    bool is_presenting_evidence = false;
-    bool is_judge               = false;
-    bool is_system_speaking     = false;
+  int m_objection_state = 0;
+  int m_effect_state = 0;
+  int m_text_color = 0;
+  int m_shout_state = 0;
+  int m_effect_current = 0;
+  int m_wtce_current = 0;
+  bool is_presenting_evidence = false;
+  bool is_judge = false;
+  bool is_system_speaking = false;
 
-    int defense_bar_state     = 0;
-    int prosecution_bar_state = 0;
+  int defense_bar_state = 0;
+  int prosecution_bar_state = 0;
 
-    int current_char_page = 0;
-    int char_columns      = 10;
-    int char_rows         = 9;
-    int max_chars_on_page = 90;
+  int current_char_page = 0;
+  int char_columns = 10;
+  int char_rows = 9;
+  int max_chars_on_page = 90;
 
-    int current_emote_page = 0;
-    int current_emote      = 0;
-    int prev_emote         = 0;
-    int emote_columns      = 5;
-    int emote_rows         = 2;
-    int max_emotes_on_page = 10;
+  int current_emote_page = 0;
+  int current_emote = 0;
+  int prev_emote = 0;
+  int emote_columns = 5;
+  int emote_rows = 2;
+  int max_emotes_on_page = 10;
 
-    int m_chatlog_limit       = 200;
-    bool m_chatlog_newline    = false;
-    bool m_chatlog_scrolldown = false;
+  int m_chatlog_limit = 200;
+  bool m_chatlog_newline = false;
+  bool m_chatlog_scrolldown = false;
 
-    //  inmchatlog_changed;
+  //  inmchatlog_changed;
 
-    QVector<evi_type> local_evidence_list;
+  QVector<evi_type> local_evidence_list;
 
-    int current_evidence_page = 0;
-    int current_evidence      = 0;
-    int evidence_columns      = 6;
-    int evidence_rows         = 3;
-    int max_evidence_on_page  = 18;
+  int current_evidence_page = 0;
+  int current_evidence = 0;
+  int evidence_columns = 6;
+  int evidence_rows = 3;
+  int max_evidence_on_page = 18;
 
-    int current_clock = -1;
-    int timer_number  = 0;
+  int current_clock = -1;
+  int timer_number = 0;
 
-    QString current_background = "gs4";
+  QString current_background = "gs4";
 
-    AOImage *ui_background;
+  AOImage *ui_background;
 
-    QWidget *ui_viewport;
-    AOScene *ui_vp_background;
-    AOMovie *ui_vp_speedlines;
-    AOCharMovie *ui_vp_player_char;
-    AOScene *ui_vp_desk;
-    AOEvidenceDisplay *ui_vp_evidence_display;
+  QWidget *ui_viewport;
+  AOScene *ui_vp_background;
+  AOMovie *ui_vp_speedlines;
+  AOCharMovie *ui_vp_player_char;
+  AOScene *ui_vp_desk;
+  AOEvidenceDisplay *ui_vp_evidence_display;
 
-    AONoteArea *ui_note_area;
+  AONoteArea *ui_note_area;
 
-    //  AONotepad *ui_vp_notepad;
-    // list of characters that require a second application ID
-    // note that since it's hardcoded, it won't be of much use in other servers
-    QVector<QString> rpc_char_list;
+  //  AONotepad *ui_vp_notepad;
+  // list of characters that require a second application ID
+  // note that since it's hardcoded, it won't be of much use in other servers
+  QVector<QString> rpc_char_list;
 
-    AOImage *ui_vp_notepad_image;
-    QTextEdit *ui_vp_notepad;
+  AOImage *ui_vp_notepad_image;
+  QTextEdit *ui_vp_notepad;
+
+  AOImage *ui_vp_chatbox = nullptr;
+  QTextEdit *ui_vp_showname = nullptr;
+  QTextEdit *ui_vp_message = nullptr;
+  AOImage *ui_vp_testimony = nullptr;
+  AOMovie *ui_vp_effect = nullptr;
+  AOMovie *ui_vp_wtce = nullptr;
+  AOMovie *ui_vp_objection = nullptr;
+
+  AOImage *ui_vp_music_display_a = nullptr;
+  AOImage *ui_vp_music_display_b = nullptr;
+
+  AOImage *ui_vp_showname_image = nullptr;
+
+  QTextEdit *ui_vp_music_name = nullptr;
+  QPropertyAnimation *music_anim = nullptr;
 
-    AOImage *ui_vp_chatbox   = nullptr;
-    QTextEdit *ui_vp_showname   = nullptr;
-    QTextEdit *ui_vp_message = nullptr;
-    AOImage *ui_vp_testimony = nullptr;
-    AOMovie *ui_vp_effect    = nullptr;
-    AOMovie *ui_vp_wtce      = nullptr;
-    AOMovie *ui_vp_objection = nullptr;
-
-    AOImage *ui_vp_music_display_a = nullptr;
-    AOImage *ui_vp_music_display_b = nullptr;
+  QWidget *ui_vp_music_area;
+
+  AOMovie *ui_vp_clock;
+  QVector<AOTimer *> ui_timers;
 
-    AOImage *ui_vp_showname_image = nullptr;
+  QTextEdit *ui_ic_chatlog = nullptr;
+  record_type_array m_ic_records;
+
+  AOTextArea *ui_server_chatlog;
+
+  QListWidget *ui_mute_list;
+  QListWidget *ui_area_list;
+  QListWidget *ui_music_list;
+  QListWidget *ui_sfx_list;
 
-    QTextEdit *ui_vp_music_name    = nullptr;
-    QPropertyAnimation *music_anim = nullptr;
+  QLineEdit *ui_ic_chat_message;
 
-    QWidget *ui_vp_music_area;
+  QLineEdit *ui_ooc_chat_message;
+  QLineEdit *ui_ooc_chat_name;
 
-    AOMovie *ui_vp_clock;
-    QVector<AOTimer *> ui_timers;
+  QLineEdit *ui_music_search;
 
-    QTextEdit *ui_ic_chatlog = nullptr;
-    record_type_array m_ic_records;
+  QLineEdit *ui_sfx_search;
 
-    AOTextArea *ui_server_chatlog;
+  QWidget *ui_emotes = nullptr;
+  QVector<AOEmoteButton *> ui_emote_list;
+  AOButton *ui_emote_left;
+  AOButton *ui_emote_right;
 
-    QListWidget *ui_mute_list;
-    QListWidget *ui_area_list;
-    QListWidget *ui_music_list;
-    QListWidget *ui_sfx_list;
+  QComboBox *ui_emote_dropdown;
+  QComboBox *ui_pos_dropdown;
 
-    QLineEdit *ui_ic_chat_message;
+  AOImage *ui_defense_bar;
+  AOImage *ui_prosecution_bar;
 
-    QLineEdit *ui_ooc_chat_message;
-    QLineEdit *ui_ooc_chat_name;
+  // buttons to cycle through shouts
+  AOButton *ui_shout_up = nullptr;
+  AOButton *ui_shout_down = nullptr;
+  // buttons to cycle through effects
+  AOButton *ui_effect_up = nullptr;
+  AOButton *ui_effect_down = nullptr;
+  // buttons to cycle through wtce
+  AOButton *ui_wtce_up = nullptr;
+  AOButton *ui_wtce_down = nullptr;
 
-    QLineEdit *ui_music_search;
+  // holds all the shout button objects
+  QVector<AOButton *> ui_shouts;
+  // holds all the effect button objects
+  QVector<AOButton *> ui_effects;
+  // holds all the shout buttons objects
+  QVector<AOButton *> ui_wtce;
+  // holds all the free block objects
+  QVector<AOMovie *> ui_free_blocks;
 
-    QLineEdit *ui_sfx_search;
+  // holds all the names for sound files for the shouts
+  //  QVector<QString> shout_names = {"holdit", "objection", "takethat",
+  //  "custom", "gotit", "crossswords", "counteralt"};
+  QVector<QString> shout_names;
 
-    QWidget *ui_emotes = nullptr;
-    QVector<AOEmoteButton *> ui_emote_list;
-    AOButton *ui_emote_left;
-    AOButton *ui_emote_right;
+  // holds all the names for sound/anim files for the effects
+  // QVector<QString> effect_names = {"effect_flash", "effect_gloom",
+  // "effect_question", "effect_pow"};
+  QVector<QString> effect_names;
 
-    QComboBox *ui_emote_dropdown;
-    QComboBox *ui_pos_dropdown;
-
-    AOImage *ui_defense_bar;
-    AOImage *ui_prosecution_bar;
-
-    //buttons to cycle through shouts
-    AOButton *ui_shout_up   = nullptr;
-    AOButton *ui_shout_down = nullptr;
-    //buttons to cycle through effects
-    AOButton *ui_effect_up   = nullptr;
-    AOButton *ui_effect_down = nullptr;
-    //buttons to cycle through wtce
-    AOButton *ui_wtce_up   = nullptr;
-    AOButton *ui_wtce_down = nullptr;
-
-    //holds all the shout button objects
-    QVector<AOButton *> ui_shouts;
-    //holds all the effect button objects
-    QVector<AOButton *> ui_effects;
-    //holds all the shout buttons objects
-    QVector<AOButton *> ui_wtce;
-    //holds all the free block objects
-    QVector<AOMovie *> ui_free_blocks;
-
-    //holds all the names for sound files for the shouts
-    //  QVector<QString> shout_names = {"holdit", "objection", "takethat", "custom", "gotit", "crossswords", "counteralt"};
-    QVector<QString> shout_names;
-
-    //holds all the names for sound/anim files for the effects
-    //QVector<QString> effect_names = {"effect_flash", "effect_gloom", "effect_question", "effect_pow"};
-    QVector<QString> effect_names;
-
-    //holds all the names for sound/anim files for the shouts
-    //QVector<QString> shout_names = {"witnesstestimony", "crossexamination", "investigation", "nonstop"};
-    QVector<QString> wtce_names;
-
-    //holds all the names for free blocks
-    QVector<QString> free_block_names;
-
-    //holds whether the animation file exists for a determined shout/effect
-    QVector<bool> shouts_enabled;
-    QVector<bool> effects_enabled;
-    QVector<bool> wtce_enabled;
-    QVector<bool> free_blocks_enabled;
-
-    //  AOButton* ui_shout_hold_it      = nullptr; // 1
-    //  AOButton* ui_shout_objection    = nullptr; // 2
-    //  AOButton* ui_shout_take_that    = nullptr; // 3
-    //  AOButton* ui_shout_custom       = nullptr; // 4
-    //  AOButton* ui_shout_got_it       = nullptr; // 5
-    //  AOButton* ui_shout_cross_swords = nullptr; // 6
-    //  AOButton* ui_shout_counter_alt  = nullptr; // 7
-
-    AOButton *ui_witness_testimony;
-    AOButton *ui_cross_examination;
-    AOButton *ui_investigation;
-    AOButton *ui_nonstop;
-
-    AOButton *ui_change_character;
-    AOButton *ui_call_mod;
-    AOButton *ui_switch_area_music;
-
-    AOButton *ui_config_panel;
-
-    AOButton *ui_set_notes;
-
-    QCheckBox *ui_pre;
-    QCheckBox *ui_flip;
-    QCheckBox *ui_hidden;
-
-    QVector<QCheckBox *> ui_checks; // 0 = pre, 1 = flip, 2 = hidden
-    QVector<AOLabel *> ui_labels;   // 0 = music, 1 = sfx, 2 = blip
-    QVector<AOImage *> ui_label_images;
-    QVector<QString> label_images = {"Pre", "Flip", "Hidden", "Music", "SFX", "Blip"};
-
-    AOButton *ui_effect_flash = nullptr;
-    AOButton *ui_effect_gloom = nullptr;
-
-    AOButton *ui_mute = nullptr;
-
-    AOButton *ui_defense_plus;
-    AOButton *ui_defense_minus;
-
-    AOButton *ui_prosecution_plus;
-    AOButton *ui_prosecution_minus;
-
-    QComboBox *ui_text_color;
-
-    AOImage *ui_muted;
-
-    AOButton *ui_note_button;
-
-    AOButton *ui_evidence_button;
-    AOImage *ui_evidence;
-    AOLineEdit *ui_evidence_name;
-    QWidget *ui_evidence_buttons;
-    QVector<AOEvidenceButton *> ui_evidence_list;
-    AOButton *ui_evidence_left;
-    AOButton *ui_evidence_right;
-    AOButton *ui_evidence_present;
-    AOImage *ui_evidence_overlay;
-    AOButton *ui_evidence_delete;
-    AOLineEdit *ui_evidence_image_name;
-    AOButton *ui_evidence_image_button;
-    AOButton *ui_evidence_x;
-    AOEvidenceDescription *ui_evidence_description;
-
-    AOImage *ui_char_select_background;
-
-    //abstract widget to hold char buttons
-    QWidget *ui_char_buttons         = nullptr;
-    AOImage *ui_char_button_selector = nullptr;
-    QVector<AOCharButton *> ui_char_button_list;
-
-    AOButton *ui_back_to_lobby;
-
-    AOButton *ui_char_select_left;
-    AOButton *ui_char_select_right;
-
-    AOButton *ui_spectator;
-
-    QHash<QString, QWidget *> widget_names;
-
-    void create_widgets();
-    void connect_widgets();
-    void set_widget_names();
-    void reset_widget_names();
-    void insert_widget_name(QString p_widget_name, QWidget *p_widget);
-    void insert_widget_names(QVector<QString> &p_widget_names, QVector<QWidget *> &p_widgets);
-    template <typename T>
-    void insert_widget_names(QVector<QString> &p_widget_names, QVector<T *> &p_widgets);
-    void set_widget_layers();
-
-    void construct_char_select();
-    void reconstruct_char_select();
-    void reset_char_select();
-    void set_char_select();
-    void set_char_select_page();
-
-    void construct_emotes();
-    void reconstruct_emotes();
-    void reset_emote_page();
-    void set_emote_page();
-    void set_emote_dropdown();
-
-    void construct_evidence();
-    void set_evidence_page();
-
-    void load_note();
-    void save_note();
-    void save_textlog(QString p_text);
-
-    void set_char_rpc();
+  // holds all the names for sound/anim files for the shouts
+  // QVector<QString> shout_names = {"witnesstestimony", "crossexamination",
+  // "investigation", "nonstop"};
+  QVector<QString> wtce_names;
+
+  // holds all the names for free blocks
+  QVector<QString> free_block_names;
+
+  // holds whether the animation file exists for a determined shout/effect
+  QVector<bool> shouts_enabled;
+  QVector<bool> effects_enabled;
+  QVector<bool> wtce_enabled;
+  QVector<bool> free_blocks_enabled;
+
+  //  AOButton* ui_shout_hold_it      = nullptr; // 1
+  //  AOButton* ui_shout_objection    = nullptr; // 2
+  //  AOButton* ui_shout_take_that    = nullptr; // 3
+  //  AOButton* ui_shout_custom       = nullptr; // 4
+  //  AOButton* ui_shout_got_it       = nullptr; // 5
+  //  AOButton* ui_shout_cross_swords = nullptr; // 6
+  //  AOButton* ui_shout_counter_alt  = nullptr; // 7
+
+  AOButton *ui_witness_testimony;
+  AOButton *ui_cross_examination;
+  AOButton *ui_investigation;
+  AOButton *ui_nonstop;
+
+  AOButton *ui_change_character;
+  AOButton *ui_call_mod;
+  AOButton *ui_switch_area_music;
+
+  AOButton *ui_config_panel;
+
+  AOButton *ui_set_notes;
+
+  QCheckBox *ui_pre;
+  QCheckBox *ui_flip;
+  QCheckBox *ui_hidden;
+
+  QVector<QCheckBox *> ui_checks; // 0 = pre, 1 = flip, 2 = hidden
+  QVector<AOLabel *> ui_labels;   // 0 = music, 1 = sfx, 2 = blip
+  QVector<AOImage *> ui_label_images;
+  QVector<QString> label_images = {"Pre",   "Flip", "Hidden",
+                                   "Music", "SFX",  "Blip"};
+
+  AOButton *ui_effect_flash = nullptr;
+  AOButton *ui_effect_gloom = nullptr;
+
+  AOButton *ui_mute = nullptr;
+
+  AOButton *ui_defense_plus;
+  AOButton *ui_defense_minus;
+
+  AOButton *ui_prosecution_plus;
+  AOButton *ui_prosecution_minus;
+
+  QComboBox *ui_text_color;
+
+  AOImage *ui_muted;
+
+  AOButton *ui_note_button;
+
+  AOButton *ui_evidence_button;
+  AOImage *ui_evidence;
+  AOLineEdit *ui_evidence_name;
+  QWidget *ui_evidence_buttons;
+  QVector<AOEvidenceButton *> ui_evidence_list;
+  AOButton *ui_evidence_left;
+  AOButton *ui_evidence_right;
+  AOButton *ui_evidence_present;
+  AOImage *ui_evidence_overlay;
+  AOButton *ui_evidence_delete;
+  AOLineEdit *ui_evidence_image_name;
+  AOButton *ui_evidence_image_button;
+  AOButton *ui_evidence_x;
+  AOEvidenceDescription *ui_evidence_description;
+
+  AOImage *ui_char_select_background;
+
+  // abstract widget to hold char buttons
+  QWidget *ui_char_buttons = nullptr;
+  AOImage *ui_char_button_selector = nullptr;
+  QVector<AOCharButton *> ui_char_button_list;
+
+  AOButton *ui_back_to_lobby;
+
+  AOButton *ui_char_select_left;
+  AOButton *ui_char_select_right;
+
+  AOButton *ui_spectator;
+
+  QHash<QString, QWidget *> widget_names;
+
+  void create_widgets();
+  void connect_widgets();
+  void set_widget_names();
+  void reset_widget_names();
+  void insert_widget_name(QString p_widget_name, QWidget *p_widget);
+  void insert_widget_names(QVector<QString> &p_widget_names,
+                           QVector<QWidget *> &p_widgets);
+  template <typename T>
+  void insert_widget_names(QVector<QString> &p_widget_names,
+                           QVector<T *> &p_widgets);
+  void set_widget_layers();
+
+  void construct_char_select();
+  void reconstruct_char_select();
+  void reset_char_select();
+  void set_char_select();
+  void set_char_select_page();
+
+  void construct_emotes();
+  void reconstruct_emotes();
+  void reset_emote_page();
+  void set_emote_page();
+  void set_emote_dropdown();
+
+  void construct_evidence();
+  void set_evidence_page();
+
+  void load_note();
+  void save_note();
+  void save_textlog(QString p_text);
+
+  void set_char_rpc();
 
 public slots:
-    void objection_done();
-    void preanim_done();
+  void objection_done();
+  void preanim_done();
 
-    void realization_done();
+  void realization_done();
 
-    void show_testimony();
-    void hide_testimony();
+  void show_testimony();
+  void hide_testimony();
 
-    void mod_called(QString p_ip);
+  void mod_called(QString p_ip);
 
 private slots:
-    void start_chat_ticking();
-    void play_sfx();
+  void start_chat_ticking();
+  void play_sfx();
 
-    void chat_tick();
+  void chat_tick();
 
-    void on_mute_list_clicked(QModelIndex p_index);
+  void on_mute_list_clicked(QModelIndex p_index);
 
-    void on_chat_return_pressed();
-    void on_chat_config_changed();
+  void on_chat_return_pressed();
+  void on_chat_config_changed();
 
-    void on_ooc_return_pressed();
+  void on_ooc_return_pressed();
 
-    void on_music_search_edited(QString p_text);
-    void on_music_list_clicked();
-    void on_area_list_clicked();
-    void on_music_list_double_clicked(QModelIndex p_model);
-    void on_area_list_double_clicked(QModelIndex p_model);
+  void on_music_search_edited(QString p_text);
+  void on_music_list_clicked();
+  void on_area_list_clicked();
+  void on_music_list_double_clicked(QModelIndex p_model);
+  void on_area_list_double_clicked(QModelIndex p_model);
 
-    void on_sfx_search_edited(QString p_text);
+  void on_sfx_search_edited(QString p_text);
 
-    void select_emote(int p_id);
+  void select_emote(int p_id);
 
-    void on_emote_clicked(int p_id);
+  void on_emote_clicked(int p_id);
 
-    void on_emote_left_clicked();
-    void on_emote_right_clicked();
+  void on_emote_left_clicked();
+  void on_emote_right_clicked();
 
-    void on_emote_dropdown_changed(int p_index);
-    void on_pos_dropdown_changed(int p_index);
+  void on_emote_dropdown_changed(int p_index);
+  void on_pos_dropdown_changed(int p_index);
 
-    void on_evidence_name_edited();
-    void on_evidence_image_name_edited();
-    void on_evidence_image_button_clicked();
-    void on_evidence_clicked(int p_id);
-    void on_evidence_double_clicked(int p_id);
+  void on_evidence_name_edited();
+  void on_evidence_image_name_edited();
+  void on_evidence_image_button_clicked();
+  void on_evidence_clicked(int p_id);
+  void on_evidence_double_clicked(int p_id);
 
-    void on_evidence_hover(int p_id, bool p_state);
+  void on_evidence_hover(int p_id, bool p_state);
 
-    void on_evidence_left_clicked();
-    void on_evidence_right_clicked();
-    void on_evidence_present_clicked();
+  void on_evidence_left_clicked();
+  void on_evidence_right_clicked();
+  void on_evidence_present_clicked();
 
-    void on_cycle_clicked();
+  void on_cycle_clicked();
 
-    void cycle_shout(int p_index);
-    void cycle_effect(int p_index);
-    void cycle_wtce(int p_index);
+  void cycle_shout(int p_index);
+  void cycle_effect(int p_index);
+  void cycle_wtce(int p_index);
 
-    void on_add_button_clicked();
-    void on_delete_button_clicked();
+  void on_add_button_clicked();
+  void on_delete_button_clicked();
 
-    void on_set_file_button_clicked();
-    void on_file_selected();
+  void on_set_file_button_clicked();
+  void on_file_selected();
 
-    void delete_widget(QWidget *p_widget);
-    void load_shouts();
-    void load_effects();
-    void load_wtce();
-    void load_free_blocks();
-    /**
+  void delete_widget(QWidget *p_widget);
+  void load_shouts();
+  void load_effects();
+  void load_wtce();
+  void load_free_blocks();
+  /**
    * @brief reset the shout button's texture to default
    * DOES NOT MODIFY OBJECTION_STATE
    */
-    void reset_shout_buttons();
+  void reset_shout_buttons();
 
-    /**
+  /**
    * @brief a general purpose function to toggle button selection
    */
-    void on_shout_clicked();
+  void on_shout_clicked();
 
-    void reset_effect_buttons();
-    void on_effect_button_clicked();
+  void reset_effect_buttons();
+  void on_effect_button_clicked();
 
-    void on_mute_clicked();
+  void on_mute_clicked();
 
-    void on_defense_minus_clicked();
-    void on_defense_plus_clicked();
-    void on_prosecution_minus_clicked();
-    void on_prosecution_plus_clicked();
+  void on_defense_minus_clicked();
+  void on_defense_plus_clicked();
+  void on_prosecution_minus_clicked();
+  void on_prosecution_plus_clicked();
 
-    void on_text_color_changed(int p_color);
+  void on_text_color_changed(int p_color);
 
-    void on_witness_testimony_clicked();
-    void on_cross_examination_clicked();
-    void reset_judge_wtce_buttons();
-    void on_wtce_clicked();
+  void on_witness_testimony_clicked();
+  void on_cross_examination_clicked();
+  void reset_judge_wtce_buttons();
+  void on_wtce_clicked();
 
-    void on_change_character_clicked();
-    void on_app_reload_theme_requested();
-    void on_call_mod_clicked();
+  void on_change_character_clicked();
+  void on_app_reload_theme_requested();
+  void on_call_mod_clicked();
 
-    void on_switch_area_music_clicked();
+  void on_switch_area_music_clicked();
 
-    void on_config_panel_clicked();
-    void on_note_button_clicked();
+  void on_config_panel_clicked();
+  void on_note_button_clicked();
 
-    void on_set_notes_clicked();
+  void on_set_notes_clicked();
 
-    void on_note_text_changed();
+  void on_note_text_changed();
 
-    void on_pre_clicked();
-    void on_flip_clicked();
-    void on_hidden_clicked();
+  void on_pre_clicked();
+  void on_flip_clicked();
+  void on_hidden_clicked();
 
-    void on_sfx_list_clicked();
+  void on_sfx_list_clicked();
 
-    void on_evidence_button_clicked();
+  void on_evidence_button_clicked();
 
-    void on_evidence_delete_clicked();
-    void on_evidence_x_clicked();
+  void on_evidence_delete_clicked();
+  void on_evidence_x_clicked();
 
-    void on_back_to_lobby_clicked();
+  void on_back_to_lobby_clicked();
 
-    void on_char_select_left_clicked();
-    void on_char_select_right_clicked();
-    void char_clicked(int n_char);
-    void char_mouse_entered(AOCharButton *p_caller);
-    void char_mouse_left();
+  void on_char_select_left_clicked();
+  void on_char_select_right_clicked();
+  void char_clicked(int n_char);
+  void char_mouse_entered(AOCharButton *p_caller);
+  void char_mouse_left();
 
-    void on_spectator_clicked();
+  void on_spectator_clicked();
 
-    void ping_server();
+  void ping_server();
 
-/*!
- * =============================================================================
- * AUDIO SYSTEM
- */
+  /*!
+   * =============================================================================
+   * AUDIO SYSTEM
+   */
 
 public:
-    bool is_audio_muted();
+  bool is_audio_muted();
 
 public slots:
-    void set_audio_mute_enabled(bool p_enabled);
-    void set_effects_volume(int p_volume);
-    void set_system_volume(int p_volume);
-    void set_music_volume(int p_volume);
-    void set_blips_volume(int p_volume);
+  void set_audio_mute_enabled(bool p_enabled);
+  void set_effects_volume(int p_volume);
+  void set_system_volume(int p_volume);
+  void set_music_volume(int p_volume);
+  void set_blips_volume(int p_volume);
 
 private:
-    bool m_audio_mute              = false;
-    AOSfxPlayer *m_effects_player  = nullptr;
-    AOShoutPlayer *m_shouts_player = nullptr;
-    AOSfxPlayer *m_system_player   = nullptr;
-    AOMusicPlayer *m_music_player  = nullptr;
-    AOBlipPlayer *m_blips_player   = nullptr;
+  bool m_audio_mute = false;
+  AOSfxPlayer *m_effects_player = nullptr;
+  AOShoutPlayer *m_shouts_player = nullptr;
+  AOSfxPlayer *m_system_player = nullptr;
+  AOMusicPlayer *m_music_player = nullptr;
+  AOBlipPlayer *m_blips_player = nullptr;
 
 private slots:
-    void on_config_effects_volume_changed(int p_volume);
-    void on_config_system_volume_changed(int p_volume);
-    void on_config_music_volume_changed(int p_volume);
-    void on_config_blips_volume_changed(int p_volume);
+  void on_config_effects_volume_changed(int p_volume);
+  void on_config_system_volume_changed(int p_volume);
+  void on_config_music_volume_changed(int p_volume);
+  void on_config_blips_volume_changed(int p_volume);
 
-    // QWidget interface
+  // QWidget interface
 protected:
-    void closeEvent(QCloseEvent *event) override;
+  void closeEvent(QCloseEvent *event) override;
 };
 
 template <typename T>
-void Courtroom::insert_widget_names(QVector<QString> &p_widget_names, QVector<T *> &p_widgets)
+void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
+                                    QVector<T *> &p_widgets)
 {
-    QVector<QWidget *> widgets;
+  QVector<QWidget *> widgets;
 
-    for (QWidget *widget : p_widgets)
-        widgets.append(widget);
+  for (QWidget *widget : p_widgets)
+    widgets.append(widget);
 
-    insert_widget_names(p_widget_names, widgets);
+  insert_widget_names(p_widget_names, widgets);
 }
 
 #endif // COURTROOM_H

--- a/courtroom.h
+++ b/courtroom.h
@@ -52,12 +52,30 @@ class Courtroom : public QMainWindow
 public:
   explicit Courtroom(AOApplication *p_ao_app);
 
-  void append_char(char_type p_char) { char_list.append(p_char); }
-  void append_evidence(evi_type p_evi) { evidence_list.append(p_evi); }
-  void append_music(QString f_music) { music_list.append(f_music); }
-  void append_area(QString f_area) { area_list.append(f_area); }
-  void clear_music() { music_list.clear(); }
-  void clear_areas() { area_list.clear(); }
+  void append_char(char_type p_char)
+  {
+    char_list.append(p_char);
+  }
+  void append_evidence(evi_type p_evi)
+  {
+    evidence_list.append(p_evi);
+  }
+  void append_music(QString f_music)
+  {
+    music_list.append(f_music);
+  }
+  void append_area(QString f_area)
+  {
+    area_list.append(f_area);
+  }
+  void clear_music()
+  {
+    music_list.clear();
+  }
+  void clear_areas()
+  {
+    area_list.clear();
+  }
 
   void fix_last_area()
   {
@@ -137,8 +155,14 @@ public:
   QString get_background_path(QString p_file);
 
   // cid = character id, returns the cid of the currently selected character
-  int get_cid() { return m_cid; }
-  QString get_current_char() { return current_char; }
+  int get_cid()
+  {
+    return m_cid;
+  }
+  QString get_current_char()
+  {
+    return current_char;
+  }
 
   // properly sets up some varibles: resets user state
   void enter_courtroom(int p_cid);

--- a/courtroom.h
+++ b/courtroom.h
@@ -611,6 +611,11 @@ private:
 
   void set_char_rpc();
 
+  /**
+   * @brief Loads the OS specific bass opus plugin.
+   */
+  void load_bass_opus_plugin();
+
 public slots:
   void objection_done();
   void preanim_done();

--- a/courtroom.h
+++ b/courtroom.h
@@ -46,41 +46,20 @@
 
 class AOApplication;
 
-class Courtroom : public QMainWindow
-{
+class Courtroom : public QMainWindow {
   Q_OBJECT
 public:
   explicit Courtroom(AOApplication *p_ao_app);
 
-  void append_char(char_type p_char)
-  {
-    char_list.append(p_char);
-  }
-  void append_evidence(evi_type p_evi)
-  {
-    evidence_list.append(p_evi);
-  }
-  void append_music(QString f_music)
-  {
-    music_list.append(f_music);
-  }
-  void append_area(QString f_area)
-  {
-    area_list.append(f_area);
-  }
-  void clear_music()
-  {
-    music_list.clear();
-  }
-  void clear_areas()
-  {
-    area_list.clear();
-  }
+  void append_char(char_type p_char) { char_list.append(p_char); }
+  void append_evidence(evi_type p_evi) { evidence_list.append(p_evi); }
+  void append_music(QString f_music) { music_list.append(f_music); }
+  void append_area(QString f_area) { area_list.append(f_area); }
+  void clear_music() { music_list.clear(); }
+  void clear_areas() { area_list.clear(); }
 
-  void fix_last_area()
-  {
-    if (area_list.size() > 0)
-    {
+  void fix_last_area() {
+    if (area_list.size() > 0) {
       QString malplaced = area_list.last();
       area_list.removeLast();
       append_music(malplaced);
@@ -152,18 +131,11 @@ public:
   void set_ban(int p_cid);
 
   // implementations in path_functions.cpp
-  QString get_background_path();
-  QString get_default_background_path();
+  QString get_background_path(QString p_file);
 
   // cid = character id, returns the cid of the currently selected character
-  int get_cid()
-  {
-    return m_cid;
-  }
-  QString get_current_char()
-  {
-    return current_char;
-  }
+  int get_cid() { return m_cid; }
+  QString get_current_char() { return current_char; }
 
   // properly sets up some varibles: resets user state
   void enter_courtroom(int p_cid);
@@ -810,8 +782,7 @@ protected:
 
 template <typename T>
 void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
-                                    QVector<T *> &p_widgets)
-{
+                                    QVector<T *> &p_widgets) {
   QVector<QWidget *> widgets;
 
   for (QWidget *widget : p_widgets)

--- a/courtroom.h
+++ b/courtroom.h
@@ -46,7 +46,8 @@
 
 class AOApplication;
 
-class Courtroom : public QMainWindow {
+class Courtroom : public QMainWindow
+{
   Q_OBJECT
 public:
   explicit Courtroom(AOApplication *p_ao_app);
@@ -58,8 +59,10 @@ public:
   void clear_music() { music_list.clear(); }
   void clear_areas() { area_list.clear(); }
 
-  void fix_last_area() {
-    if (area_list.size() > 0) {
+  void fix_last_area()
+  {
+    if (area_list.size() > 0)
+    {
       QString malplaced = area_list.last();
       area_list.removeLast();
       append_music(malplaced);
@@ -787,7 +790,8 @@ protected:
 
 template <typename T>
 void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
-                                    QVector<T *> &p_widgets) {
+                                    QVector<T *> &p_widgets)
+{
   QVector<QWidget *> widgets;
 
   for (QWidget *widget : p_widgets)

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -1,24 +1,24 @@
 #include "courtroom.h"
 
 #include "aoapplication.h"
-#include "lobby.h"
-#include "hardware_functions.h"
-#include "file_functions.h"
 #include "datatypes.h"
 #include "debug_functions.h"
+#include "file_functions.h"
+#include "hardware_functions.h"
+#include "lobby.h"
 
-#include <QDebug>
-#include <QScrollBar>
-#include <QRegExp>
 #include <QBrush>
-#include <QTextCharFormat>
-#include <QFont>
-#include <QTime>
-#include <QPropertyAnimation>
-#include <QGraphicsOpacityEffect>
+#include <QDebug>
 #include <QDir>
-#include <QMessageBox>
 #include <QFileDialog>
+#include <QFont>
+#include <QGraphicsOpacityEffect>
+#include <QMessageBox>
+#include <QPropertyAnimation>
+#include <QRegExp>
+#include <QScrollBar>
+#include <QTextCharFormat>
+#include <QTime>
 
 void Courtroom::create_widgets()
 {
@@ -48,16 +48,20 @@ void Courtroom::create_widgets()
   m_effects_player->set_volume(ao_config->effects_volume());
   m_shouts_player = new AOShoutPlayer(this, ao_app);
   m_shouts_player->set_volume(ao_config->effects_volume());
-  connect(ao_config, SIGNAL(effects_volume_changed(int)), this, SLOT(on_config_effects_volume_changed(int)));
+  connect(ao_config, SIGNAL(effects_volume_changed(int)), this,
+          SLOT(on_config_effects_volume_changed(int)));
   m_system_player = new AOSfxPlayer(this, ao_app);
   m_system_player->set_volume(ao_config->system_volume());
-  connect(ao_config, SIGNAL(system_volume_changed(int)), this, SLOT(on_config_system_volume_changed(int)));
+  connect(ao_config, SIGNAL(system_volume_changed(int)), this,
+          SLOT(on_config_system_volume_changed(int)));
   m_music_player = new AOMusicPlayer(this, ao_app);
   m_music_player->set_volume(ao_config->music_volume());
-  connect(ao_config, SIGNAL(music_volume_changed(int)), this, SLOT(on_config_music_volume_changed(int)));
+  connect(ao_config, SIGNAL(music_volume_changed(int)), this,
+          SLOT(on_config_music_volume_changed(int)));
   m_blips_player = new AOBlipPlayer(this, ao_app);
   m_blips_player->set_volume(ao_config->blips_volume());
-  connect(ao_config, SIGNAL(blips_volume_changed(int)), this, SLOT(on_config_blips_volume_changed(int)));
+  connect(ao_config, SIGNAL(blips_volume_changed(int)), this,
+          SLOT(on_config_blips_volume_changed(int)));
 
   ui_background = new AOImage(this, ao_app);
 
@@ -149,9 +153,10 @@ void Courtroom::create_widgets()
   construct_emotes();
 
   ui_defense_bar = new AOImage(this, ao_app);
-  ui_prosecution_bar = new  AOImage(this, ao_app);
+  ui_prosecution_bar = new AOImage(this, ao_app);
 
-  load_shouts(); // Readds from theme, deletes old shouts if needed and creates new ones
+  load_shouts(); // Readds from theme, deletes old shouts if needed and creates
+                 // new ones
 
   ui_shout_up = new AOButton(this, ao_app);
   ui_shout_up->setProperty("cycle_id", 1);
@@ -180,7 +185,7 @@ void Courtroom::create_widgets()
   ui_note_button = new AOButton(this, ao_app);
 
   ui_label_images.resize(label_images.size());
-  for(int i = 0; i < ui_label_images.size(); ++i)
+  for (int i = 0; i < ui_label_images.size(); ++i)
   {
     ui_label_images[i] = new AOImage(this, ao_app);
   }
@@ -239,311 +244,350 @@ void Courtroom::connect_widgets()
 {
   connect(keepalive_timer, SIGNAL(timeout()), this, SLOT(ping_server()));
 
-  connect(ao_app, SIGNAL(reload_theme()), this, SLOT(on_app_reload_theme_requested()));
+  connect(ao_app, SIGNAL(reload_theme()), this,
+          SLOT(on_app_reload_theme_requested()));
 
   connect(ui_vp_objection, SIGNAL(done()), this, SLOT(objection_done()));
   connect(ui_vp_player_char, SIGNAL(done()), this, SLOT(preanim_done()));
 
-  connect(text_delay_timer, SIGNAL(timeout()), this, SLOT(start_chat_ticking()));
+  connect(text_delay_timer, SIGNAL(timeout()), this,
+          SLOT(start_chat_ticking()));
   connect(sfx_delay_timer, SIGNAL(timeout()), this, SLOT(play_sfx()));
 
   connect(chat_tick_timer, SIGNAL(timeout()), this, SLOT(chat_tick()));
 
   connect(realization_timer, SIGNAL(timeout()), this, SLOT(realization_done()));
 
-  connect(testimony_show_timer, SIGNAL(timeout()), this, SLOT(hide_testimony()));
-  connect(testimony_hide_timer, SIGNAL(timeout()), this, SLOT(show_testimony()));
+  connect(testimony_show_timer, SIGNAL(timeout()), this,
+          SLOT(hide_testimony()));
+  connect(testimony_hide_timer, SIGNAL(timeout()), this,
+          SLOT(show_testimony()));
 
-  connect(ui_emote_left, SIGNAL(clicked()), this, SLOT(on_emote_left_clicked()));
-  connect(ui_emote_right, SIGNAL(clicked()), this, SLOT(on_emote_right_clicked()));
+  connect(ui_emote_left, SIGNAL(clicked()), this,
+          SLOT(on_emote_left_clicked()));
+  connect(ui_emote_right, SIGNAL(clicked()), this,
+          SLOT(on_emote_right_clicked()));
 
-  connect(ui_emote_dropdown, SIGNAL(activated(int)), this, SLOT(on_emote_dropdown_changed(int)));
-  connect(ui_pos_dropdown, SIGNAL(activated(int)), this, SLOT(on_pos_dropdown_changed(int)));
+  connect(ui_emote_dropdown, SIGNAL(activated(int)), this,
+          SLOT(on_emote_dropdown_changed(int)));
+  connect(ui_pos_dropdown, SIGNAL(activated(int)), this,
+          SLOT(on_pos_dropdown_changed(int)));
 
-  connect(ui_mute_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_mute_list_clicked(QModelIndex)));
+  connect(ui_mute_list, SIGNAL(clicked(QModelIndex)), this,
+          SLOT(on_mute_list_clicked(QModelIndex)));
 
-  connect(ui_ic_chat_message, SIGNAL(returnPressed()), this, SLOT(on_chat_return_pressed()));
+  connect(ui_ic_chat_message, SIGNAL(returnPressed()), this,
+          SLOT(on_chat_return_pressed()));
 
-  connect(ui_ooc_chat_name, SIGNAL(textEdited(QString)), ao_config, SLOT(set_username(QString)));
-  connect(ao_config, SIGNAL(username_changed(QString)), ui_ooc_chat_name, SLOT(setText(QString)));
-  connect(ui_ooc_chat_message, SIGNAL(returnPressed()), this, SLOT(on_ooc_return_pressed()));
+  connect(ui_ooc_chat_name, SIGNAL(textEdited(QString)), ao_config,
+          SLOT(set_username(QString)));
+  connect(ao_config, SIGNAL(username_changed(QString)), ui_ooc_chat_name,
+          SLOT(setText(QString)));
+  connect(ui_ooc_chat_message, SIGNAL(returnPressed()), this,
+          SLOT(on_ooc_return_pressed()));
 
-  connect(ui_music_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_music_list_clicked()));
-  connect(ui_area_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_area_list_clicked()));
-  connect(ui_music_list, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(on_music_list_double_clicked(QModelIndex)));
-  connect(ui_area_list, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(on_area_list_double_clicked(QModelIndex)));
+  connect(ui_music_list, SIGNAL(clicked(QModelIndex)), this,
+          SLOT(on_music_list_clicked()));
+  connect(ui_area_list, SIGNAL(clicked(QModelIndex)), this,
+          SLOT(on_area_list_clicked()));
+  connect(ui_music_list, SIGNAL(doubleClicked(QModelIndex)), this,
+          SLOT(on_music_list_double_clicked(QModelIndex)));
+  connect(ui_area_list, SIGNAL(doubleClicked(QModelIndex)), this,
+          SLOT(on_area_list_double_clicked(QModelIndex)));
 
-  // connect events for shout/effect/wtce buttons happen in load_shouts(), load_effects(), load_wtce()
+  // connect events for shout/effect/wtce buttons happen in load_shouts(),
+  // load_effects(), load_wtce()
   connect(ui_shout_up, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
   connect(ui_shout_down, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
 
   connect(ui_effect_up, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
-  connect(ui_effect_down, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
+  connect(ui_effect_down, SIGNAL(clicked(bool)), this,
+          SLOT(on_cycle_clicked()));
 
   connect(ui_wtce_up, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
   connect(ui_wtce_down, SIGNAL(clicked(bool)), this, SLOT(on_cycle_clicked()));
 
   connect(ui_mute, SIGNAL(clicked()), this, SLOT(on_mute_clicked()));
 
-  connect(ui_defense_minus, SIGNAL(clicked()), this, SLOT(on_defense_minus_clicked()));
-  connect(ui_defense_plus, SIGNAL(clicked()), this, SLOT(on_defense_plus_clicked()));
-  connect(ui_prosecution_minus, SIGNAL(clicked()), this, SLOT(on_prosecution_minus_clicked()));
-  connect(ui_prosecution_plus, SIGNAL(clicked()), this, SLOT(on_prosecution_plus_clicked()));
+  connect(ui_defense_minus, SIGNAL(clicked()), this,
+          SLOT(on_defense_minus_clicked()));
+  connect(ui_defense_plus, SIGNAL(clicked()), this,
+          SLOT(on_defense_plus_clicked()));
+  connect(ui_prosecution_minus, SIGNAL(clicked()), this,
+          SLOT(on_prosecution_minus_clicked()));
+  connect(ui_prosecution_plus, SIGNAL(clicked()), this,
+          SLOT(on_prosecution_plus_clicked()));
 
-  connect(ui_text_color, SIGNAL(currentIndexChanged(int)), this, SLOT(on_text_color_changed(int)));
+  connect(ui_text_color, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(on_text_color_changed(int)));
 
-  connect(ao_config, SIGNAL(log_max_lines_changed(int)), this, SLOT(on_chat_config_changed()));
-  connect(ao_config, SIGNAL(log_goes_downward_changed(bool)), this, SLOT(on_chat_config_changed()));
-  connect(ao_config, SIGNAL(log_uses_newline_changed(bool)), this, SLOT(on_chat_config_changed()));
+  connect(ao_config, SIGNAL(log_max_lines_changed(int)), this,
+          SLOT(on_chat_config_changed()));
+  connect(ao_config, SIGNAL(log_goes_downward_changed(bool)), this,
+          SLOT(on_chat_config_changed()));
+  connect(ao_config, SIGNAL(log_uses_newline_changed(bool)), this,
+          SLOT(on_chat_config_changed()));
 
-  connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited(QString)));
+  connect(ui_music_search, SIGNAL(textChanged(QString)), this,
+          SLOT(on_music_search_edited(QString)));
+  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this,
+          SLOT(on_sfx_search_edited(QString)));
 
-  connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
+  connect(ui_change_character, SIGNAL(clicked()), this,
+          SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));
 
-  connect(ui_switch_area_music, SIGNAL(clicked()), this, SLOT(on_switch_area_music_clicked()));
+  connect(ui_switch_area_music, SIGNAL(clicked()), this,
+          SLOT(on_switch_area_music_clicked()));
 
-  connect(ui_config_panel, SIGNAL(clicked()), this, SLOT(on_config_panel_clicked()));
-  connect(ui_note_button, SIGNAL(clicked()), this, SLOT(on_note_button_clicked()));
+  connect(ui_config_panel, SIGNAL(clicked()), this,
+          SLOT(on_config_panel_clicked()));
+  connect(ui_note_button, SIGNAL(clicked()), this,
+          SLOT(on_note_button_clicked()));
 
-  connect(ui_vp_notepad, SIGNAL(textChanged()), this, SLOT(on_note_text_changed()));
+  connect(ui_vp_notepad, SIGNAL(textChanged()), this,
+          SLOT(on_note_text_changed()));
 
   connect(ui_pre, SIGNAL(clicked()), this, SLOT(on_pre_clicked()));
   connect(ui_flip, SIGNAL(clicked()), this, SLOT(on_flip_clicked()));
   connect(ui_hidden, SIGNAL(clicked()), this, SLOT(on_hidden_clicked()));
 
-  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_sfx_list_clicked()));
+  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this,
+          SLOT(on_sfx_list_clicked()));
 
-  connect(ui_evidence_button, SIGNAL(clicked()), this, SLOT(on_evidence_button_clicked()));
+  connect(ui_evidence_button, SIGNAL(clicked()), this,
+          SLOT(on_evidence_button_clicked()));
 
-  connect(ui_note_area->add_button, SIGNAL(clicked(bool)), this, SLOT(on_add_button_clicked()));
-  connect(ui_set_notes, SIGNAL(clicked(bool)), this, SLOT(on_set_notes_clicked()));
+  connect(ui_note_area->add_button, SIGNAL(clicked(bool)), this,
+          SLOT(on_add_button_clicked()));
+  connect(ui_set_notes, SIGNAL(clicked(bool)), this,
+          SLOT(on_set_notes_clicked()));
 }
 
 void Courtroom::reset_widget_names()
 {
-    // Assign names to the default widgets
-    widget_names = {
-        {"courtroom", this},
-            {"viewport", ui_viewport},
-                {"background", ui_vp_background}, //*
-                {"speedlines", ui_vp_speedlines}, //*
-                {"player_char", ui_vp_player_char}, //*
-                {"desk", ui_vp_desk}, //*
-            {"music_display_a", ui_vp_music_display_a},
-            {"music_display_b", ui_vp_music_display_b},
-            {"music_area", ui_vp_music_area},
-            {"music_name", ui_vp_music_name},
-            // music_anim
-            {"clock", ui_vp_clock},
-            // ui_vp_evidence_display
-            {"ao2_chatbox", ui_vp_chatbox},
-                {"showname", ui_vp_showname},
-                {"message", ui_vp_message},
-            {"showname_image", ui_vp_showname_image},
-            {"vp_testimony", ui_vp_testimony},
-            {"vp_effect", ui_vp_effect},
-            {"vp_wtce", ui_vp_wtce},
-            {"vp_objection", ui_vp_objection},
-            {"ic_chatlog", ui_ic_chatlog},
-            {"server_chatlog", ui_server_chatlog},
-            {"mute_list", ui_mute_list},
-            {"area_list", ui_area_list},
-            {"music_list", ui_music_list},
-            {"sfx_list", ui_sfx_list},
-            {"ao2_ic_chat_message", ui_ic_chat_message},
-            // ui_muted
-            {"ooc_chat_message", ui_ooc_chat_message},
-            {"ooc_chat_name", ui_ooc_chat_name},
-            {"music_search", ui_music_search},
-            {"sfx_search", ui_sfx_search},
-            {"note_scroll_area", note_scroll_area},
-                {"note_area", ui_note_area},
-            // add_button
-            // m_layout
-            {"set_notes_button", ui_set_notes},
-            {"emotes", ui_emotes},
-            {"emote_left", ui_emote_left},
-            {"emote_right", ui_emote_right},
-            {"emote_dropdown", ui_emote_dropdown},
-            {"pos_dropdown", ui_pos_dropdown},
-            {"defense_bar", ui_defense_bar},
-            {"prosecution_bar", ui_prosecution_bar},
-            // Each ui_shouts[i]
-            {"shout_up", ui_shout_up},
-            {"shout_down", ui_shout_down},
-            // Each ui_effects[i]
-            {"effect_down", ui_effect_down},
-            {"effect_up", ui_effect_up},
-            // Each ui_wtce[i]
-            {"wtce_up", ui_wtce_up},
-            {"wtce_down", ui_wtce_down},
-            {"change_character", ui_change_character},
-            {"call_mod", ui_call_mod},
-            {"switch_area_music", ui_switch_area_music},
-            {"config_panel", ui_config_panel},
-            {"note_button", ui_note_button},
-            // Each ui_label_images[i]
-            {"pre", ui_pre},
-            {"flip", ui_flip},
-            {"hidden", ui_hidden},
-            {"mute_button", ui_mute},
-            {"defense_plus", ui_defense_plus},
-            {"defense_minus", ui_defense_minus},
-            {"prosecution_plus", ui_prosecution_plus},
-            {"prosecution_minus", ui_prosecution_minus},
-            {"text_color", ui_text_color},
-            {"evidence_button", ui_evidence_button},
-            {"notepad_image", ui_vp_notepad_image},
-            {"notepad", ui_vp_notepad},
-            // Each ui_timers[i]
-            {"evidence_background", ui_evidence},
-                {"evidence_buttons", ui_evidence_buttons},
-            {"char_select", ui_char_select_background},
-                {"back_to_lobby", ui_back_to_lobby},
-                {"char_buttons", ui_char_buttons},
-                {"char_select_left", ui_char_select_left},
-                {"char_select_right", ui_char_select_right},
-                {"spectator", ui_spectator},
-    };
+  // Assign names to the default widgets
+  widget_names = {
+      {"courtroom", this},
+      {"viewport", ui_viewport},
+      {"background", ui_vp_background},   //*
+      {"speedlines", ui_vp_speedlines},   //*
+      {"player_char", ui_vp_player_char}, //*
+      {"desk", ui_vp_desk},               //*
+      {"music_display_a", ui_vp_music_display_a},
+      {"music_display_b", ui_vp_music_display_b},
+      {"music_area", ui_vp_music_area},
+      {"music_name", ui_vp_music_name},
+      // music_anim
+      {"clock", ui_vp_clock},
+      // ui_vp_evidence_display
+      {"ao2_chatbox", ui_vp_chatbox},
+      {"showname", ui_vp_showname},
+      {"message", ui_vp_message},
+      {"showname_image", ui_vp_showname_image},
+      {"vp_testimony", ui_vp_testimony},
+      {"vp_effect", ui_vp_effect},
+      {"vp_wtce", ui_vp_wtce},
+      {"vp_objection", ui_vp_objection},
+      {"ic_chatlog", ui_ic_chatlog},
+      {"server_chatlog", ui_server_chatlog},
+      {"mute_list", ui_mute_list},
+      {"area_list", ui_area_list},
+      {"music_list", ui_music_list},
+      {"sfx_list", ui_sfx_list},
+      {"ao2_ic_chat_message", ui_ic_chat_message},
+      // ui_muted
+      {"ooc_chat_message", ui_ooc_chat_message},
+      {"ooc_chat_name", ui_ooc_chat_name},
+      {"music_search", ui_music_search},
+      {"sfx_search", ui_sfx_search},
+      {"note_scroll_area", note_scroll_area},
+      {"note_area", ui_note_area},
+      // add_button
+      // m_layout
+      {"set_notes_button", ui_set_notes},
+      {"emotes", ui_emotes},
+      {"emote_left", ui_emote_left},
+      {"emote_right", ui_emote_right},
+      {"emote_dropdown", ui_emote_dropdown},
+      {"pos_dropdown", ui_pos_dropdown},
+      {"defense_bar", ui_defense_bar},
+      {"prosecution_bar", ui_prosecution_bar},
+      // Each ui_shouts[i]
+      {"shout_up", ui_shout_up},
+      {"shout_down", ui_shout_down},
+      // Each ui_effects[i]
+      {"effect_down", ui_effect_down},
+      {"effect_up", ui_effect_up},
+      // Each ui_wtce[i]
+      {"wtce_up", ui_wtce_up},
+      {"wtce_down", ui_wtce_down},
+      {"change_character", ui_change_character},
+      {"call_mod", ui_call_mod},
+      {"switch_area_music", ui_switch_area_music},
+      {"config_panel", ui_config_panel},
+      {"note_button", ui_note_button},
+      // Each ui_label_images[i]
+      {"pre", ui_pre},
+      {"flip", ui_flip},
+      {"hidden", ui_hidden},
+      {"mute_button", ui_mute},
+      {"defense_plus", ui_defense_plus},
+      {"defense_minus", ui_defense_minus},
+      {"prosecution_plus", ui_prosecution_plus},
+      {"prosecution_minus", ui_prosecution_minus},
+      {"text_color", ui_text_color},
+      {"evidence_button", ui_evidence_button},
+      {"notepad_image", ui_vp_notepad_image},
+      {"notepad", ui_vp_notepad},
+      // Each ui_timers[i]
+      {"evidence_background", ui_evidence},
+      {"evidence_buttons", ui_evidence_buttons},
+      {"char_select", ui_char_select_background},
+      {"back_to_lobby", ui_back_to_lobby},
+      {"char_buttons", ui_char_buttons},
+      {"char_select_left", ui_char_select_left},
+      {"char_select_right", ui_char_select_right},
+      {"spectator", ui_spectator},
+  };
 }
 
 void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget)
 {
-    // insert entry
-    widget_names[p_widget_name] = p_widget;
-    // set name
-    p_widget->setObjectName(p_widget_name);
+  // insert entry
+  widget_names[p_widget_name] = p_widget;
+  // set name
+  p_widget->setObjectName(p_widget_name);
 }
 
-
-void Courtroom::insert_widget_names(QVector<QString> &p_widget_names, QVector<QWidget*> &p_widgets)
+void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
+                                    QVector<QWidget *> &p_widgets)
 {
-    for (int i = 0; i < p_widgets.length(); ++i)
-        insert_widget_name(p_widget_names[i], p_widgets[i]);
+  for (int i = 0; i < p_widgets.length(); ++i)
+    insert_widget_name(p_widget_names[i], p_widgets[i]);
 }
 
 void Courtroom::set_widget_names()
 {
-    // Assign names to the default widgets
-    reset_widget_names();
+  // Assign names to the default widgets
+  reset_widget_names();
 
-    // set existing widget names
-    for (QString widget_name : widget_names.keys())
-        widget_names[widget_name]->setObjectName(widget_name);
+  // set existing widget names
+  for (QString widget_name : widget_names.keys())
+    widget_names[widget_name]->setObjectName(widget_name);
 
-    // setup table of widgets and names
-    insert_widget_names(effect_names, ui_effects);
-    insert_widget_names(free_block_names, ui_free_blocks);
-    insert_widget_names(shout_names, ui_shouts);
-    insert_widget_names(wtce_names, ui_wtce);
+  // setup table of widgets and names
+  insert_widget_names(effect_names, ui_effects);
+  insert_widget_names(free_block_names, ui_free_blocks);
+  insert_widget_names(shout_names, ui_shouts);
+  insert_widget_names(wtce_names, ui_wtce);
 
-    // timers are special children
-    QVector<QString> timer_names;
-    for (int i = 0; i < ui_timers.length(); ++i)
-        timer_names.append("timer_" + QString::number(i));
-    insert_widget_names(timer_names, ui_timers);
+  // timers are special children
+  QVector<QString> timer_names;
+  for (int i = 0; i < ui_timers.length(); ++i)
+    timer_names.append("timer_" + QString::number(i));
+  insert_widget_names(timer_names, ui_timers);
 }
 
 void Courtroom::set_widget_layers()
 {
-    QStringList paths{
-        ao_app->get_theme_variant_path() + "courtroom_layers.ini",
-        ao_app->get_theme_path() + "courtroom_layers.ini",
-        ao_app->get_default_theme_path() + "courtroom_layers.ini",
-    };
+  QStringList paths{
+      ao_app->get_theme_variant_path() + "courtroom_layers.ini",
+      ao_app->get_theme_path() + "courtroom_layers.ini",
+      ao_app->get_default_theme_path() + "courtroom_layers.ini",
+  };
 
-    // needed to avoid cyclic parenting
-    QStringList recorded_widgets;
+  // needed to avoid cyclic parenting
+  QStringList recorded_widgets;
 
-    // read the entire thing
-    for (QString path : paths)
+  // read the entire thing
+  for (QString path : paths)
+  {
+    QFile layer_ini(path);
+
+    if (layer_ini.open(QFile::ReadOnly))
     {
-        QFile layer_ini(path);
+      QTextStream in(&layer_ini);
 
-        if (layer_ini.open(QFile::ReadOnly))
+      // current parent's name
+      QString parent_name = "courtroom";
+      // the courtroom is ALWAYS going to be recorded
+      recorded_widgets.append(parent_name);
+
+      while (!in.atEnd())
+      {
+        QString line = in.readLine().trimmed();
+
+        // skip if line is empty
+        if (line.isEmpty())
+          continue;
+
+        // revert to default parent if we encounter an end scope
+        if (line.startsWith("[\\"))
         {
-            QTextStream in(&layer_ini);
-
-            // current parent's name
-            QString parent_name = "courtroom";
-            // the courtroom is ALWAYS going to be recorded
-            recorded_widgets.append(parent_name);
-
-            while (!in.atEnd())
-            {
-                QString line = in.readLine().trimmed();
-
-                // skip if line is empty
-                if (line.isEmpty())
-                    continue;
-
-                // revert to default parent if we encounter an end scope
-                if (line.startsWith("[\\"))
-                {
-                    parent_name = "courtroom";
-                }
-                // is this a parent?
-                else if (line.startsWith("["))
-                {
-                    // update the current parent
-                    parent_name = line.remove(0, 1).chopped(1).trimmed();
-                }
-                // if this is not a parent, it's a child
-                else
-                {
-                    // if the child is already known, skip
-                    if (recorded_widgets.contains(line))
-                        continue;
-                    // make the child known
-                    recorded_widgets.append(line);
-
-                    // attach the children to the parents'
-                    QWidget *child = widget_names[line];
-                    // if child is null, then it does not exist
-                    if (!child)
-                        continue;
-
-                    QWidget *parent = widget_names[parent_name];
-                    // if parent is null, attach main parent
-                    if (!parent)
-                        parent = widget_names["courtroom"];
-
-                    // set child to parent
-                    bool was_visible = child->isVisible();
-                    child->setParent(parent);
-                    child->raise();
-
-                    // Readjust visibility in case this changed after the widget changed parent
-                    // I don't know why, I don't want to know why, I shouldn't
-                    // have to wonder why, but for whatever reason these stupid
-                    // panels aren't laying out correctly unless we do this terribleness
-                    if (child->isVisible() != was_visible)
-                        child->setVisible(was_visible);
-                }
-            }
-
-            // break the loop, we have found a proper file
-            break;
+          parent_name = "courtroom";
         }
+        // is this a parent?
+        else if (line.startsWith("["))
+        {
+          // update the current parent
+          parent_name = line.remove(0, 1).chopped(1).trimmed();
+        }
+        // if this is not a parent, it's a child
+        else
+        {
+          // if the child is already known, skip
+          if (recorded_widgets.contains(line))
+            continue;
+          // make the child known
+          recorded_widgets.append(line);
+
+          // attach the children to the parents'
+          QWidget *child = widget_names[line];
+          // if child is null, then it does not exist
+          if (!child)
+            continue;
+
+          QWidget *parent = widget_names[parent_name];
+          // if parent is null, attach main parent
+          if (!parent)
+            parent = widget_names["courtroom"];
+
+          // set child to parent
+          bool was_visible = child->isVisible();
+          child->setParent(parent);
+          child->raise();
+
+          // Readjust visibility in case this changed after the widget changed
+          // parent I don't know why, I don't want to know why, I shouldn't have
+          // to wonder why, but for whatever reason these stupid panels aren't
+          // laying out correctly unless we do this terribleness
+          if (child->isVisible() != was_visible)
+            child->setVisible(was_visible);
+        }
+      }
+
+      // break the loop, we have found a proper file
+      break;
     }
-    // do special logic if config panel was not found in courtroom_layers. In particular, make it
-    // visible and raise it in front of all assets. This can help assist a theme designer who
-    // accidentally missed config_panel and would have become unable to reload themes had they
-    // closed the config panel
-    if (!recorded_widgets.contains("config_panel"))
-    {
-      ui_config_panel->setParent(this);
-      ui_config_panel->raise();
-      ui_config_panel->setVisible(true);
-    }
+  }
+  // do special logic if config panel was not found in courtroom_layers. In
+  // particular, make it visible and raise it in front of all assets. This can
+  // help assist a theme designer who accidentally missed config_panel and would
+  // have become unable to reload themes had they closed the config panel
+  if (!recorded_widgets.contains("config_panel"))
+  {
+    ui_config_panel->setParent(this);
+    ui_config_panel->raise();
+    ui_config_panel->setVisible(true);
+  }
 }
 
 void Courtroom::set_widgets()
 {
   QString filename = design_ini;
-  pos_size_type f_courtroom = ao_app->get_element_dimensions("courtroom", filename);
+  pos_size_type f_courtroom =
+      ao_app->get_element_dimensions("courtroom", filename);
 
   if (f_courtroom.width < 0 || f_courtroom.height < 0)
   {
@@ -574,7 +618,7 @@ void Courtroom::set_widgets()
   ui_vp_player_char->move(0, 0);
   ui_vp_player_char->combo_resize(ui_viewport->size());
 
-  //the AO2 desk element
+  // the AO2 desk element
   ui_vp_desk->move(0, 0);
   ui_vp_desk->combo_resize(ui_viewport->size());
 
@@ -622,7 +666,7 @@ void Courtroom::set_widgets()
 
   set_size_and_pos(ui_area_list, "area_list");
   ui_area_list->hide();
-//  ui_area_list->setStyleSheet("background-color: rgba(0, 0, 0, 0);");
+  //  ui_area_list->setStyleSheet("background-color: rgba(0, 0, 0, 0);");
 
   set_size_and_pos(ui_music_list, "music_list");
 
@@ -646,7 +690,8 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_vp_clock, "clock");
   ui_vp_clock->show();
 
-  ui_ic_chat_message->setStyleSheet("QLineEdit{background-color: rgba(100, 100, 100, 255);}");
+  ui_ic_chat_message->setStyleSheet(
+      "QLineEdit{background-color: rgba(100, 100, 100, 255);}");
 
   ui_vp_chatbox->set_image("chatmed.png");
   ui_vp_chatbox->hide();
@@ -682,28 +727,30 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_pos_dropdown, "pos_dropdown");
 
   set_size_and_pos(ui_defense_bar, "defense_bar");
-  ui_defense_bar->set_image("defensebar" + QString::number(defense_bar_state) + ".png");
+  ui_defense_bar->set_image("defensebar" + QString::number(defense_bar_state) +
+                            ".png");
 
   set_size_and_pos(ui_prosecution_bar, "prosecution_bar");
-  ui_prosecution_bar->set_image("prosecutionbar" + QString::number(prosecution_bar_state) + ".png");
+  ui_prosecution_bar->set_image(
+      "prosecutionbar" + QString::number(prosecution_bar_state) + ".png");
 
-//  set_size_and_pos(ui_shouts[0], "hold_it");
-//  ui_shouts[0]->show();
-//  set_size_and_pos(ui_shouts[1], "objection");
-//  ui_shouts[1]->show();
-//  set_size_and_pos(ui_shouts[2], "take_that");
-//  ui_shouts[2]->show();
-//  set_size_and_pos(ui_shouts[3], "custom_objection");
-//  set_size_and_pos(ui_shouts[4], "got_it");
-//  set_size_and_pos(ui_shouts[5], "cross_swords");
-//  set_size_and_pos(ui_shouts[6], "counter_alt");
-  for(int i = 0; i < shout_names.size(); ++i)
+  //  set_size_and_pos(ui_shouts[0], "hold_it");
+  //  ui_shouts[0]->show();
+  //  set_size_and_pos(ui_shouts[1], "objection");
+  //  ui_shouts[1]->show();
+  //  set_size_and_pos(ui_shouts[2], "take_that");
+  //  ui_shouts[2]->show();
+  //  set_size_and_pos(ui_shouts[3], "custom_objection");
+  //  set_size_and_pos(ui_shouts[4], "got_it");
+  //  set_size_and_pos(ui_shouts[5], "cross_swords");
+  //  set_size_and_pos(ui_shouts[6], "counter_alt");
+  for (int i = 0; i < shout_names.size(); ++i)
   {
     set_size_and_pos(ui_shouts[i], shout_names[i]);
   }
-//  ui_shouts[0]->show();
-//  ui_shouts[1]->show();
-//  ui_shouts[2]->show();
+  //  ui_shouts[0]->show();
+  //  ui_shouts[1]->show();
+  //  ui_shouts[2]->show();
   reset_shout_buttons();
 
   set_size_and_pos(ui_shout_up, "shout_up");
@@ -714,9 +761,11 @@ void Courtroom::set_widgets()
   ui_shout_down->hide();
 
   // courtroom_config.ini necessary + check for crash
-  if (ao_app->read_theme_ini("enable_single_shout", cc_config_ini) == "true" && ui_shouts.size() > 0)
+  if (ao_app->read_theme_ini("enable_single_shout", cc_config_ini) == "true" &&
+      ui_shouts.size() > 0)
   {
-    for(auto & shout : ui_shouts) move_widget(shout, "bullet");
+    for (auto &shout : ui_shouts)
+      move_widget(shout, "bullet");
 
     set_shouts();
 
@@ -724,11 +773,11 @@ void Courtroom::set_widgets()
     ui_shout_down->show();
   }
 
-//  set_size_and_pos(ui_effects[0], "effect_flash");
-//  set_size_and_pos(ui_effects[1], "effect_gloom");
-//  set_size_and_pos(ui_effects[2], "effect_question");
-//  set_size_and_pos(ui_effects[3], "effect_pow");
-  for(int i = 0; i < effect_names.size(); ++i)
+  //  set_size_and_pos(ui_effects[0], "effect_flash");
+  //  set_size_and_pos(ui_effects[1], "effect_gloom");
+  //  set_size_and_pos(ui_effects[2], "effect_question");
+  //  set_size_and_pos(ui_effects[3], "effect_pow");
+  for (int i = 0; i < effect_names.size(); ++i)
   {
     set_size_and_pos(ui_effects[i], effect_names[i]);
   }
@@ -741,9 +790,11 @@ void Courtroom::set_widgets()
   ui_effect_down->set_image("effectdown.png");
   ui_effect_down->hide();
 
-  if (ao_app->read_theme_ini("enable_single_effect", cc_config_ini) == "true" && ui_effects.size() > 0) // check to prevent crashing
+  if (ao_app->read_theme_ini("enable_single_effect", cc_config_ini) == "true" &&
+      ui_effects.size() > 0) // check to prevent crashing
   {
-    for(auto & effect  : ui_effects) move_widget(effect, "effect");
+    for (auto &effect : ui_effects)
+      move_widget(effect, "effect");
 
     set_effects();
 
@@ -758,15 +809,16 @@ void Courtroom::set_widgets()
   ui_wtce_down->set_image("wtcedown.png");
   ui_wtce_down->hide();
 
-  for(int i = 0; i < wtce_names.size(); ++i)
+  for (int i = 0; i < wtce_names.size(); ++i)
   {
-      set_size_and_pos(ui_wtce[i], wtce_names[i]);
+    set_size_and_pos(ui_wtce[i], wtce_names[i]);
   }
 
-  if (ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) == "true" ) // courtroom_config.ini necessary
+  if (ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) ==
+      "true") // courtroom_config.ini necessary
   {
-    for(auto & wtce : ui_wtce)
-        move_widget(wtce, "wtce");
+    for (auto &wtce : ui_wtce)
+      move_widget(wtce, "wtce");
     qDebug() << "AA: single wtce";
   }
   set_judge_wtce();
@@ -774,13 +826,14 @@ void Courtroom::set_widgets()
   // this will reset the image
   reset_judge_wtce_buttons();
 
-  for(int i = 0; i < free_block_names.size(); ++i)
+  for (int i = 0; i < free_block_names.size(); ++i)
   {
     set_size_and_pos(ui_free_blocks[i], free_block_names[i]);
   }
   set_free_blocks();
 
-  // Set the default values for the buttons, then determine if they should be replaced by images
+  // Set the default values for the buttons, then determine if they should be
+  // replaced by images
   set_size_and_pos(ui_change_character, "change_character");
   set_size_and_pos(ui_call_mod, "call_mod");
   set_size_and_pos(ui_note_button, "note_button");
@@ -802,8 +855,8 @@ void Courtroom::set_widgets()
   if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true")
   {
     // Set files, ask questions later
-    // set_image first tries the theme variant folder, then the theme folder, then falls back to
-    // the default theme
+    // set_image first tries the theme variant folder, then the theme folder,
+    // then falls back to the default theme
     ui_change_character->set_image("changecharacter.png");
     if (ui_change_character->image_path.isEmpty())
       ui_change_character->setText("Change Character");
@@ -818,25 +871,25 @@ void Courtroom::set_widgets()
 
     ui_config_panel->set_image("config_panel.png");
     if (ui_config_panel->image_path.isEmpty())
-        ui_config_panel->setText("Config");
+      ui_config_panel->setText("Config");
 
     ui_note_button->set_image("notebutton.png");
     if (ui_note_button->image_path.isEmpty())
-        ui_note_button->setText("Notes");
+      ui_note_button->setText("Notes");
   }
 
-  // The config panel has a special property. If it is displayed beyond the right or lower limit
-  // of the window, it will be moved to 0, 0
-  // A similar behavior will occur if the button is hidden due to 'config_panel' not being found
-  // in courtroom_design.ini
-  // This is to assist with people who switch to incompatible and/or smaller themes and have the
-  // button disappear
+  // The config panel has a special property. If it is displayed beyond the
+  // right or lower limit of the window, it will be moved to 0, 0 A similar
+  // behavior will occur if the button is hidden due to 'config_panel' not being
+  // found in courtroom_design.ini This is to assist with people who switch to
+  // incompatible and/or smaller themes and have the button disappear
   if (ui_config_panel->x() > width() || ui_config_panel->y() > height() ||
       !ui_config_panel->isVisible())
   {
     ui_config_panel->setVisible(true);
     ui_config_panel->move(0, 0);
-    // Moreover, if the width or height is invalid, change it to some fixed values
+    // Moreover, if the width or height is invalid, change it to some fixed
+    // values
     if (ui_config_panel->width() <= 0 || ui_config_panel->height() <= 0)
       ui_config_panel->resize(64, 64);
   }
@@ -848,14 +901,14 @@ void Courtroom::set_widgets()
 
   set_size_and_pos(ui_hidden, "hidden");
 
-  for(int i = 0; i < ui_label_images.size(); ++i)
+  for (int i = 0; i < ui_label_images.size(); ++i)
   {
     set_size_and_pos(ui_label_images[i], label_images[i].toLower() + "_image");
   }
 
   if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true")
   {
-    for (int i = 0 ; i < ui_checks.size(); ++i) // loop through checks
+    for (int i = 0; i < ui_checks.size(); ++i) // loop through checks
     {
       QString image = label_images[i].toLower() + ".png";
       ui_label_images[i]->set_image(image);
@@ -866,7 +919,7 @@ void Courtroom::set_widgets()
         ui_checks[i]->setText(label_images[i]);
     }
 
-    for(int i = 0 ; i < ui_labels.size(); ++i) // now through labels..........
+    for (int i = 0; i < ui_labels.size(); ++i) // now through labels..........
     {
       int j = i + ui_checks.size();
       QString image = label_images[j].toLower() + ".png";
@@ -880,13 +933,13 @@ void Courtroom::set_widgets()
   }
   else
   {
-    for(int i = 0; i < ui_checks.size(); ++i) //same thing
+    for (int i = 0; i < ui_checks.size(); ++i) // same thing
     {
       ui_checks[i]->setText(label_images[i]);
       ui_label_images[i]->set_image("");
     }
 
-    for(int i = 0; i < ui_labels.size(); ++i) //same thing
+    for (int i = 0; i < ui_labels.size(); ++i) // same thing
     {
       int j = i + ui_checks.size();
       ui_labels[i]->setText(label_images[j]);
@@ -971,14 +1024,15 @@ void Courtroom::set_widgets()
   note_scroll_area->setWidget(ui_note_area);
   ui_note_area->set_image("note_area.png");
   ui_note_area->add_button->set_image("add_button.png");
-  ui_note_area->add_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  ui_note_area->add_button->setSizePolicy(QSizePolicy::Fixed,
+                                          QSizePolicy::Fixed);
   ui_note_area->setLayout(ui_note_area->m_layout);
   ui_note_area->show();
   note_scroll_area->hide();
 
   list_note_files();
 
-  if(!contains_add_button)
+  if (!contains_add_button)
   {
     ui_note_area->m_layout->addWidget(ui_note_area->add_button);
     contains_add_button = true;
@@ -993,8 +1047,8 @@ void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
   QString filename = design_ini;
 
-
-  pos_size_type design_ini_result = ao_app->get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result =
+      ao_app->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -1012,7 +1066,8 @@ void Courtroom::move_widget(QWidget *p_widget, QString p_identifier)
 {
   QString filename = design_ini;
 
-  pos_size_type design_ini_result = ao_app->get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result =
+      ao_app->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -1025,23 +1080,27 @@ void Courtroom::move_widget(QWidget *p_widget, QString p_identifier)
   }
 }
 
-template<typename T>
-int Courtroom::adapt_numbered_items(QVector<T*> &item_vector, QString config_item_number,
+template <typename T>
+int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
+                                    QString config_item_number,
                                     QString item_name)
 {
   // &item_vector must be a vector of size at least 1!
 
   // Redraw the new correct number of items.
-  int new_item_number = ao_app->read_theme_ini(config_item_number, cc_config_ini).toInt();
+  int new_item_number =
+      ao_app->read_theme_ini(config_item_number, cc_config_ini).toInt();
   int current_item_number = item_vector.size();
-  // Note we use the fact that, if config_item_number is not there, read_theme_ini returns an
-  // empty string, which .toInt() would fail to convert and by documentation transform to 0.
+  // Note we use the fact that, if config_item_number is not there,
+  // read_theme_ini returns an empty string, which .toInt() would fail to
+  // convert and by documentation transform to 0.
 
-  // Decide what to do if the new theme has a different amount of items than the old one
+  // Decide what to do if the new theme has a different amount of items than the
+  // old one
   if (new_item_number < current_item_number)
   {
     // Hide old items if there are any.
-    for (int i=new_item_number; i<current_item_number; i++)
+    for (int i = new_item_number; i < current_item_number; i++)
     {
       item_vector[i]->hide();
     }
@@ -1050,25 +1109,25 @@ int Courtroom::adapt_numbered_items(QVector<T*> &item_vector, QString config_ite
   {
     // Create new items
     item_vector.resize(new_item_number);
-    for (int i=current_item_number; i<new_item_number; i++)
+    for (int i = current_item_number; i < new_item_number; i++)
     {
       item_vector[i] = new T(this);
-      item_vector[i]->stackUnder(item_vector[i-1]);
+      item_vector[i]->stackUnder(item_vector[i - 1]);
       // index i-1 exists as i >= current_item_number == item_vector.size() >= 1
     }
   }
-  // Note that by design we do *not* destroy items (or similarly, the size of item_vector
-  // is non-decreasing. This is because we want to allow for items to, say, run in the
-  // background as invisible.
-  // With that said, we can now properly format our new items
-  for (int i=0; i<new_item_number; i++)
+  // Note that by design we do *not* destroy items (or similarly, the size of
+  // item_vector is non-decreasing. This is because we want to allow for items
+  // to, say, run in the background as invisible. With that said, we can now
+  // properly format our new items
+  for (int i = 0; i < new_item_number; i++)
   {
     item_vector[i]->show();
-    set_size_and_pos(item_vector[i], item_name+"_"+QString::number(i));
+    set_size_and_pos(item_vector[i], item_name + "_" + QString::number(i));
     // Note that show is deliberately placed before set_size_and_pos
-    // That is because we want to retain the functionality set_size_and_pos includes where
-    // hides a widget if it is unable to find a position for it, and does not change its
-    // visibility otherwise.
+    // That is because we want to retain the functionality set_size_and_pos
+    // includes where hides a widget if it is unable to find a position for it,
+    // and does not change its visibility otherwise.
   }
   return new_item_number;
 }
@@ -1078,18 +1137,16 @@ void Courtroom::check_effects()
   QString char_path = ao_app->get_character_path(current_char);
   QString theme_variant_path = ao_app->get_theme_variant_path();
   QString theme_path = ao_app->get_theme_path();
-  for(int i = 0; i < ui_effects.size(); ++i)
+  for (int i = 0; i < ui_effects.size(); ++i)
   {
-    QStringList paths{
-      char_path + effect_names.at(i) + ".webp",
-      char_path + effect_names.at(i) + ".gif",
-      theme_variant_path + effect_names.at(i) + ".webp",
-      theme_variant_path + effect_names.at(i) + ".gif",
-      theme_variant_path + effect_names.at(i) + ".apng",
-      theme_path + effect_names.at(i) + ".webp",
-      theme_path + effect_names.at(i) + ".gif",
-      theme_path + effect_names.at(i) + ".apng"
-    };
+    QStringList paths{char_path + effect_names.at(i) + ".webp",
+                      char_path + effect_names.at(i) + ".gif",
+                      theme_variant_path + effect_names.at(i) + ".webp",
+                      theme_variant_path + effect_names.at(i) + ".gif",
+                      theme_variant_path + effect_names.at(i) + ".apng",
+                      theme_path + effect_names.at(i) + ".webp",
+                      theme_path + effect_names.at(i) + ".gif",
+                      theme_path + effect_names.at(i) + ".apng"};
 
     // Assume the effect does not exist until a matching file is found
     effects_enabled[i] = false;
@@ -1109,18 +1166,16 @@ void Courtroom::check_free_blocks()
   QString char_path = ao_app->get_character_path(current_char);
   QString theme_variant_path = ao_app->get_theme_variant_path();
   QString theme_path = ao_app->get_theme_path();
-  for(int i = 0; i < ui_free_blocks.size(); ++i)
+  for (int i = 0; i < ui_free_blocks.size(); ++i)
   {
-    QStringList paths{
-      char_path + free_block_names.at(i) + ".webp",
-      char_path + free_block_names.at(i) + ".gif",
-      theme_variant_path + free_block_names.at(i) + ".webp",
-      theme_variant_path + free_block_names.at(i) + ".gif",
-      theme_variant_path + free_block_names.at(i) + ".apng",
-      theme_path + free_block_names.at(i) + ".webp",
-      theme_path + free_block_names.at(i) + ".gif",
-      theme_path + free_block_names.at(i) + ".apng"
-    };
+    QStringList paths{char_path + free_block_names.at(i) + ".webp",
+                      char_path + free_block_names.at(i) + ".gif",
+                      theme_variant_path + free_block_names.at(i) + ".webp",
+                      theme_variant_path + free_block_names.at(i) + ".gif",
+                      theme_variant_path + free_block_names.at(i) + ".apng",
+                      theme_path + free_block_names.at(i) + ".webp",
+                      theme_path + free_block_names.at(i) + ".gif",
+                      theme_path + free_block_names.at(i) + ".apng"};
 
     // Assume the free block does not exist until a matching file is found
     free_blocks_enabled[i] = false;
@@ -1140,18 +1195,16 @@ void Courtroom::check_shouts()
   QString char_path = ao_app->get_character_path(current_char);
   QString theme_variant_path = ao_app->get_theme_variant_path();
   QString theme_path = ao_app->get_theme_path();
-  for(int i = 0; i < ui_shouts.size(); ++i)
+  for (int i = 0; i < ui_shouts.size(); ++i)
   {
-    QStringList paths{
-      char_path + shout_names.at(i) + ".webp",
-      char_path + shout_names.at(i) + ".gif",
-      theme_variant_path + shout_names.at(i) + ".webp",
-      theme_variant_path + shout_names.at(i) + ".gif",
-      theme_variant_path + shout_names.at(i) + ".apng",
-      theme_path + shout_names.at(i) + ".webp",
-      theme_path + shout_names.at(i) + ".gif",
-      theme_path + shout_names.at(i) + ".apng"
-    };
+    QStringList paths{char_path + shout_names.at(i) + ".webp",
+                      char_path + shout_names.at(i) + ".gif",
+                      theme_variant_path + shout_names.at(i) + ".webp",
+                      theme_variant_path + shout_names.at(i) + ".gif",
+                      theme_variant_path + shout_names.at(i) + ".apng",
+                      theme_path + shout_names.at(i) + ".webp",
+                      theme_path + shout_names.at(i) + ".gif",
+                      theme_path + shout_names.at(i) + ".apng"};
 
     // Assume the shout does not exist until a matching file is found
     shouts_enabled[i] = false;
@@ -1171,18 +1224,16 @@ void Courtroom::check_wtce()
   QString char_path = ao_app->get_character_path(current_char);
   QString theme_variant_path = ao_app->get_theme_variant_path();
   QString theme_path = ao_app->get_theme_path();
-  for(int i = 0; i < ui_wtce.size(); ++i)
+  for (int i = 0; i < ui_wtce.size(); ++i)
   {
-    QStringList paths{
-      char_path + wtce_names.at(i) + ".webp",
-      char_path + wtce_names.at(i) + ".gif",
-      theme_variant_path + wtce_names.at(i) + ".webp",
-      theme_variant_path + wtce_names.at(i) + ".gif",
-      theme_variant_path + wtce_names.at(i) + ".apng",
-      theme_path + wtce_names.at(i) + ".webp",
-      theme_path + wtce_names.at(i) + ".gif",
-      theme_path + wtce_names.at(i) + ".apng"
-    };
+    QStringList paths{char_path + wtce_names.at(i) + ".webp",
+                      char_path + wtce_names.at(i) + ".gif",
+                      theme_variant_path + wtce_names.at(i) + ".webp",
+                      theme_variant_path + wtce_names.at(i) + ".gif",
+                      theme_variant_path + wtce_names.at(i) + ".apng",
+                      theme_path + wtce_names.at(i) + ".webp",
+                      theme_path + wtce_names.at(i) + ".gif",
+                      theme_path + wtce_names.at(i) + ".apng"};
 
     // Assume the judge button does not exist until a matching file is found
     wtce_enabled[i] = false;
@@ -1199,50 +1250,53 @@ void Courtroom::check_wtce()
 
 void Courtroom::delete_widget(QWidget *p_widget)
 {
-    // remove the widget from recorded names
-    widget_names.remove(p_widget->objectName());
+  // remove the widget from recorded names
+  widget_names.remove(p_widget->objectName());
 
-    // transfer the children to our grandparent since our parent is
-    // about to commit suicide
-    QWidget *grand_parent = p_widget->parentWidget();
-    // if we don't have a grand parent, attach ourselves to courtroom
-    if (!grand_parent)
-        grand_parent = this;
+  // transfer the children to our grandparent since our parent is
+  // about to commit suicide
+  QWidget *grand_parent = p_widget->parentWidget();
+  // if we don't have a grand parent, attach ourselves to courtroom
+  if (!grand_parent)
+    grand_parent = this;
 
-    // set new parent
-    for (QWidget *child : p_widget->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly))
-        child->setParent(grand_parent);
+  // set new parent
+  for (QWidget *child :
+       p_widget->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly))
+    child->setParent(grand_parent);
 
-    // delete widget
-    delete p_widget;
+  // delete widget
+  delete p_widget;
 }
 
 void Courtroom::load_effects()
 {
   // Close any existing effects to prevent memory leaks
   for (QWidget *widget : ui_effects)
-      delete_widget(widget);
+    delete_widget(widget);
 
   // And create new effects
-  int effect_number = ao_app->get_design_ini_value("effect_number", cc_config_ini);
+  int effect_number =
+      ao_app->get_design_ini_value("effect_number", cc_config_ini);
   effects_enabled.resize(effect_number);
   ui_effects.resize(effect_number);
 
-  for (int i=0; i<ui_effects.size(); ++i)
+  for (int i = 0; i < ui_effects.size(); ++i)
   {
     ui_effects[i] = new AOButton(this, ao_app);
-    ui_effects[i]->setProperty("effect_id", i+1);
+    ui_effects[i]->setProperty("effect_id", i + 1);
     ui_effects[i]->stackUnder(ui_effect_up);
     ui_effects[i]->stackUnder(ui_effect_down);
   }
 
   // And connect their actions
-  for (auto & effect : ui_effects)
-    connect(effect, SIGNAL(clicked(bool)), this, SLOT(on_effect_button_clicked()));
+  for (auto &effect : ui_effects)
+    connect(effect, SIGNAL(clicked(bool)), this,
+            SLOT(on_effect_button_clicked()));
 
   // And add names
   effect_names.clear();
-  for (int i=1; i<=ui_effects.size(); ++i)
+  for (int i = 1; i <= ui_effects.size(); ++i)
   {
     QStringList names = ao_app->get_effect(i);
     if (!names.isEmpty())
@@ -1255,32 +1309,34 @@ void Courtroom::load_effects()
 
 void Courtroom::load_free_blocks()
 {
-    for (QWidget *widget : ui_free_blocks)
-        delete_widget(widget);
+  for (QWidget *widget : ui_free_blocks)
+    delete_widget(widget);
 
   // And create new free block buttons
-  int free_block_number = ao_app->get_design_ini_value("free_block_number", cc_config_ini);
+  int free_block_number =
+      ao_app->get_design_ini_value("free_block_number", cc_config_ini);
   free_blocks_enabled.resize(free_block_number);
   ui_free_blocks.resize(free_block_number);
 
-  for (int i=0; i<ui_free_blocks.size(); ++i)
+  for (int i = 0; i < ui_free_blocks.size(); ++i)
   {
     ui_free_blocks[i] = new AOMovie(this, ao_app);
-    //ui_free_blocks[i]->setProperty("free_block_id", i+1);
+    // ui_free_blocks[i]->setProperty("free_block_id", i+1);
     ui_free_blocks[i]->set_play_once(false);
     ui_free_blocks[i]->stackUnder(ui_vp_player_char);
   }
 
   // And add names
   free_block_names.clear();
-  for (int i=1; i<=ui_free_blocks.size(); ++i)
+  for (int i = 1; i <= ui_free_blocks.size(); ++i)
   {
-    QString name = "free_block_" + ao_app->get_spbutton("[FREE BLOCKS]", i).trimmed();
+    QString name =
+        "free_block_" + ao_app->get_spbutton("[FREE BLOCKS]", i).trimmed();
     if (!name.isEmpty())
     {
       free_block_names.append(name);
-      widget_names[name] = ui_free_blocks[i-1];
-      ui_free_blocks[i-1]->setObjectName(name);
+      widget_names[name] = ui_free_blocks[i - 1];
+      ui_free_blocks[i - 1]->setObjectName(name);
     }
   }
   qDebug() << "FREE BLOCKS HERE " << free_block_names;
@@ -1288,37 +1344,38 @@ void Courtroom::load_free_blocks()
 
 void Courtroom::load_shouts()
 {
-    for (QWidget *widget : ui_shouts)
-        delete_widget(widget);
+  for (QWidget *widget : ui_shouts)
+    delete_widget(widget);
 
   // And create new shouts
-  int shout_number = ao_app->get_design_ini_value("shout_number", cc_config_ini);
+  int shout_number =
+      ao_app->get_design_ini_value("shout_number", cc_config_ini);
   shouts_enabled.resize(shout_number);
   ui_shouts.resize(shout_number);
 
-  for (int i=0; i<ui_shouts.size(); ++i)
+  for (int i = 0; i < ui_shouts.size(); ++i)
   {
     ui_shouts[i] = new AOButton(this, ao_app);
-    ui_shouts[i]->setProperty("shout_id", i+1);
+    ui_shouts[i]->setProperty("shout_id", i + 1);
     ui_shouts[i]->stackUnder(ui_shout_up);
     ui_shouts[i]->stackUnder(ui_shout_down);
   }
 
   // And connect their actions
-  for (auto & shout : ui_shouts)
+  for (auto &shout : ui_shouts)
     connect(shout, SIGNAL(clicked(bool)), this, SLOT(on_shout_clicked()));
 
   // And add names
   shout_names.clear();
-  for (int i=1; i<=ui_shouts.size(); ++i)
+  for (int i = 1; i <= ui_shouts.size(); ++i)
   {
     QString name = ao_app->get_spbutton("[SHOUTS]", i).trimmed();
     if (!name.isEmpty())
     {
-      qDebug() << "SHOUT " << name << " " << ui_shouts[i-1];
+      qDebug() << "SHOUT " << name << " " << ui_shouts[i - 1];
       shout_names.append(name);
-      widget_names[name] = ui_shouts[i-1];
-      ui_shouts[i-1]->setObjectName(name);
+      widget_names[name] = ui_shouts[i - 1];
+      ui_shouts[i - 1]->setObjectName(name);
     }
   }
   qDebug() << widget_names;
@@ -1326,104 +1383,106 @@ void Courtroom::load_shouts()
 
 void Courtroom::load_wtce()
 {
-    for (QWidget *widget : ui_wtce)
-        delete_widget(widget);
+  for (QWidget *widget : ui_wtce)
+    delete_widget(widget);
 
   // And create new wtce buttons
   int wtce_number = ao_app->get_design_ini_value("wtce_number", cc_config_ini);
   wtce_enabled.resize(wtce_number);
   ui_wtce.resize(wtce_number);
 
-  for (int i=0; i<ui_wtce.size(); ++i)
+  for (int i = 0; i < ui_wtce.size(); ++i)
   {
     ui_wtce[i] = new AOButton(this, ao_app);
-    ui_wtce[i]->setProperty("wtce_id", i+1);
+    ui_wtce[i]->setProperty("wtce_id", i + 1);
     ui_wtce[i]->stackUnder(ui_wtce_up);
     ui_wtce[i]->stackUnder(ui_wtce_down);
   }
 
   // And connect their actions
-  for (auto & wtce : ui_wtce)
+  for (auto &wtce : ui_wtce)
     connect(wtce, SIGNAL(clicked(bool)), this, SLOT(on_wtce_clicked()));
 
   // And add names
   wtce_names.clear();
-  for (int i=1; i<=ui_wtce.size(); ++i)
+  for (int i = 1; i <= ui_wtce.size(); ++i)
   {
     QString name = ao_app->get_spbutton("[WTCE]", i).trimmed();
     if (!name.isEmpty())
     {
       wtce_names.append(name);
-      widget_names[name] = ui_wtce[i-1];
-      ui_wtce[i-1]->setObjectName(name);
+      widget_names[name] = ui_wtce[i - 1];
+      ui_wtce[i - 1]->setObjectName(name);
     }
   }
 }
 
 void Courtroom::set_shouts()
 {
-  for(auto & shout : ui_shouts) shout->hide();
-  if (ui_shouts.size() > 0) ui_shouts[m_shout_state]->show(); // check to prevent crashing
+  for (auto &shout : ui_shouts)
+    shout->hide();
+  if (ui_shouts.size() > 0)
+    ui_shouts[m_shout_state]->show(); // check to prevent crashing
 }
 
 void Courtroom::set_effects()
 {
-  for(auto & effect : ui_effects)
-      effect->hide();
+  for (auto &effect : ui_effects)
+    effect->hide();
 
   // check to prevent crashing
   if (ui_effects.size() > 0)
-      ui_effects[m_effect_current]->show();
+    ui_effects[m_effect_current]->show();
 }
 
 void Courtroom::set_judge_enabled(bool p_enabled)
 {
-    is_judge = p_enabled;
+  is_judge = p_enabled;
 
-    // set judge button visibility
-    ui_defense_plus->setVisible(is_judge);
-    ui_defense_minus->setVisible(is_judge);
-    ui_prosecution_plus->setVisible(is_judge);
-    ui_prosecution_minus->setVisible(is_judge);
+  // set judge button visibility
+  ui_defense_plus->setVisible(is_judge);
+  ui_defense_minus->setVisible(is_judge);
+  ui_prosecution_plus->setVisible(is_judge);
+  ui_prosecution_minus->setVisible(is_judge);
 
-    set_judge_wtce();
+  set_judge_wtce();
 }
 
 void Courtroom::set_judge_wtce()
 {
-    // hide all wtce before enabling visibility
-    for(auto & wtce : ui_wtce)
-        wtce->hide();
+  // hide all wtce before enabling visibility
+  for (auto &wtce : ui_wtce)
+    wtce->hide();
 
-    // check if we use a single wtce or multiple
-    const bool is_single_wtce = ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) == "true";
+  // check if we use a single wtce or multiple
+  const bool is_single_wtce =
+      ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) == "true";
 
-    // update visibility for next/previous
-    ui_wtce_up->setVisible(is_judge && is_single_wtce);
-    ui_wtce_down->setVisible(is_judge && is_single_wtce);
+  // update visibility for next/previous
+  ui_wtce_up->setVisible(is_judge && is_single_wtce);
+  ui_wtce_down->setVisible(is_judge && is_single_wtce);
 
-    // prevent going ahead if we have no wtce
-    if (!is_judge || ui_wtce.length() == 0)
-        return;
+  // prevent going ahead if we have no wtce
+  if (!is_judge || ui_wtce.length() == 0)
+    return;
 
-
-    // set visibility based off parameter
-    if (is_single_wtce == true)
-    {
-        ui_wtce[m_wtce_current]->show();
-    }
-    else
-    {
-        for (AOButton *i_wtce : ui_wtce)
-            i_wtce->show();
-    }
+  // set visibility based off parameter
+  if (is_single_wtce == true)
+  {
+    ui_wtce[m_wtce_current]->show();
+  }
+  else
+  {
+    for (AOButton *i_wtce : ui_wtce)
+      i_wtce->show();
+  }
 }
 
 void Courtroom::set_free_blocks()
 {
-  for (int i=0; i<ui_free_blocks.size(); i++)
+  for (int i = 0; i < ui_free_blocks.size(); i++)
   {
-    AOMovie* free_block = ui_free_blocks[i];
+    AOMovie *free_block = ui_free_blocks[i];
     free_block->play(free_block_names[i]);
   }
 }
@@ -1446,44 +1505,50 @@ void Courtroom::set_dropdowns()
   set_dropdown(ui_ooc_chat_message, "[OOC LINE]");
 }
 
-
 void Courtroom::set_font(QWidget *widget, QString p_identifier)
 {
-    set_font(widget, p_identifier, "");
+  set_font(widget, p_identifier, "");
 }
 
-void Courtroom::set_font(QWidget *widget, QString p_identifier, QString override_color)
+void Courtroom::set_font(QWidget *widget, QString p_identifier,
+                         QString override_color)
 {
-    QString design_file = fonts_ini;
-    QString class_name = widget->metaObject()->className();
+  QString design_file = fonts_ini;
+  QString class_name = widget->metaObject()->className();
 
-    int f_weight = ao_app->get_font_property(p_identifier, design_file);
-    QString font_name = ao_app->get_font_name("font_" + p_identifier, design_file);
-    widget->setFont(QFont(font_name, f_weight));
+  int f_weight = ao_app->get_font_property(p_identifier, design_file);
+  QString font_name =
+      ao_app->get_font_name("font_" + p_identifier, design_file);
+  widget->setFont(QFont(font_name, f_weight));
 
-    if (override_color.isEmpty())
-    {
-      QString color = ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
-      if (color.isEmpty())
-          color = "255, 255, 255";
-      override_color = "rgba(" + color + ", 255)";
-    }
+  if (override_color.isEmpty())
+  {
+    QString color =
+        ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
+    if (color.isEmpty())
+      color = "255, 255, 255";
+    override_color = "rgba(" + color + ", 255)";
+  }
 
-    int bold = ao_app->get_font_property(p_identifier + "_bold", design_file);
-    QString is_bold = (bold == 1 ? "bold" : "");
+  int bold = ao_app->get_font_property(p_identifier + "_bold", design_file);
+  QString is_bold = (bold == 1 ? "bold" : "");
 
-    QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" +
-                                 "color: " + override_color + ";\n"
-                                 "font: " + is_bold + "; }";
-    widget->setStyleSheet(style_sheet_string);
+  QString style_sheet_string = class_name +
+                               " { background-color: rgba(0, 0, 0, 0);\n" +
+                               "color: " + override_color +
+                               ";\n"
+                               "font: " +
+                               is_bold + "; }";
+  widget->setStyleSheet(style_sheet_string);
 }
 
 void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier)
 {
-    set_qtextedit_font(widget, p_identifier, "");
+  set_qtextedit_font(widget, p_identifier, "");
 }
 
-void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier, QString override_color)
+void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier,
+                                   QString override_color)
 {
   set_font(widget, p_identifier, override_color);
 
@@ -1501,25 +1566,25 @@ void Courtroom::set_fonts()
   set_qtextedit_font(ui_vp_showname, "showname");
   set_qtextedit_font(ui_vp_message, "message");
   set_qtextedit_font(ui_ic_chatlog, "ic_chatlog");
-  set_font(ui_server_chatlog, "server_chatlog"); // Chatlog does not support qtextedit because html
+  set_font(ui_server_chatlog,
+           "server_chatlog"); // Chatlog does not support qtextedit because html
   set_font(ui_music_list, "music_list");
   set_font(ui_area_list, "area_list");
   set_font(ui_sfx_list, "sfx_list");
   set_qtextedit_font(ui_vp_music_name, "music_name");
   set_qtextedit_font(ui_vp_notepad, "notepad");
-  for (int i=0; i<timer_number; i++)
+  for (int i = 0; i < timer_number; i++)
   {
-    set_qtextedit_font(ui_timers[i], "timer_"+QString::number(i));
+    set_qtextedit_font(ui_timers[i], "timer_" + QString::number(i));
   }
 }
-
 
 void Courtroom::set_mute_list()
 {
   mute_map.clear();
 
-  //maps which characters are muted based on cid, none are muted by default
-  for (int n_cid = 0 ; n_cid < char_list.size() ; n_cid++)
+  // maps which characters are muted based on cid, none are muted by default
+  for (int n_cid = 0; n_cid < char_list.size(); n_cid++)
   {
     mute_map.insert(n_cid, false);
   }
@@ -1533,7 +1598,7 @@ void Courtroom::set_mute_list()
 
   for (QString i_name : sorted_mute_list)
   {
-    //mute_map.insert(i_name, false);
+    // mute_map.insert(i_name, false);
     ui_mute_list->addItem(i_name);
   }
 }

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -20,7 +20,8 @@
 #include <QTextCharFormat>
 #include <QTime>
 
-void Courtroom::create_widgets() {
+void Courtroom::create_widgets()
+{
   keepalive_timer = new QTimer(this);
   keepalive_timer->start(60000);
 
@@ -184,7 +185,8 @@ void Courtroom::create_widgets() {
   ui_note_button = new AOButton(this, ao_app);
 
   ui_label_images.resize(label_images.size());
-  for (int i = 0; i < ui_label_images.size(); ++i) {
+  for (int i = 0; i < ui_label_images.size(); ++i)
+  {
     ui_label_images[i] = new AOImage(this, ao_app);
   }
 
@@ -215,7 +217,8 @@ void Courtroom::create_widgets() {
   ui_text_color->addItem("Red");
   ui_text_color->addItem("Orange");
   ui_text_color->addItem("Blue");
-  if (ao_app->yellow_text_enabled) {
+  if (ao_app->yellow_text_enabled)
+  {
     ui_text_color->addItem("Yellow");
     ui_text_color->addItem("Purple");
     ui_text_color->addItem("Pink");
@@ -237,7 +240,8 @@ void Courtroom::create_widgets() {
   construct_char_select();
 }
 
-void Courtroom::connect_widgets() {
+void Courtroom::connect_widgets()
+{
   connect(keepalive_timer, SIGNAL(timeout()), this, SLOT(ping_server()));
 
   connect(ao_app, SIGNAL(reload_theme()), this,
@@ -360,7 +364,8 @@ void Courtroom::connect_widgets() {
           SLOT(on_set_notes_clicked()));
 }
 
-void Courtroom::reset_widget_names() {
+void Courtroom::reset_widget_names()
+{
   // Assign names to the default widgets
   widget_names = {
       {"courtroom", this},
@@ -447,7 +452,8 @@ void Courtroom::reset_widget_names() {
   };
 }
 
-void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget) {
+void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget)
+{
   // insert entry
   widget_names[p_widget_name] = p_widget;
   // set name
@@ -455,12 +461,14 @@ void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget) {
 }
 
 void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
-                                    QVector<QWidget *> &p_widgets) {
+                                    QVector<QWidget *> &p_widgets)
+{
   for (int i = 0; i < p_widgets.length(); ++i)
     insert_widget_name(p_widget_names[i], p_widgets[i]);
 }
 
-void Courtroom::set_widget_names() {
+void Courtroom::set_widget_names()
+{
   // Assign names to the default widgets
   reset_widget_names();
 
@@ -481,7 +489,8 @@ void Courtroom::set_widget_names() {
   insert_widget_names(timer_names, ui_timers);
 }
 
-void Courtroom::set_widget_layers() {
+void Courtroom::set_widget_layers()
+{
   QStringList paths{
       ao_app->get_theme_variant_path("courtroom_layers.ini"),
       ao_app->get_theme_path("courtroom_layers.ini"),
@@ -492,10 +501,12 @@ void Courtroom::set_widget_layers() {
   QStringList recorded_widgets;
 
   // read the entire thing
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QFile layer_ini(path);
 
-    if (layer_ini.open(QFile::ReadOnly)) {
+    if (layer_ini.open(QFile::ReadOnly))
+    {
       QTextStream in(&layer_ini);
 
       // current parent's name
@@ -503,7 +514,8 @@ void Courtroom::set_widget_layers() {
       // the courtroom is ALWAYS going to be recorded
       recorded_widgets.append(parent_name);
 
-      while (!in.atEnd()) {
+      while (!in.atEnd())
+      {
         QString line = in.readLine().trimmed();
 
         // skip if line is empty
@@ -511,16 +523,19 @@ void Courtroom::set_widget_layers() {
           continue;
 
         // revert to default parent if we encounter an end scope
-        if (line.startsWith("[\\")) {
+        if (line.startsWith("[\\"))
+        {
           parent_name = "courtroom";
         }
         // is this a parent?
-        else if (line.startsWith("[")) {
+        else if (line.startsWith("["))
+        {
           // update the current parent
           parent_name = line.remove(0, 1).chopped(1).trimmed();
         }
         // if this is not a parent, it's a child
-        else {
+        else
+        {
           // if the child is already known, skip
           if (recorded_widgets.contains(line))
             continue;
@@ -560,23 +575,28 @@ void Courtroom::set_widget_layers() {
   // particular, make it visible and raise it in front of all assets. This can
   // help assist a theme designer who accidentally missed config_panel and would
   // have become unable to reload themes had they closed the config panel
-  if (!recorded_widgets.contains("config_panel")) {
+  if (!recorded_widgets.contains("config_panel"))
+  {
     ui_config_panel->setParent(this);
     ui_config_panel->raise();
     ui_config_panel->setVisible(true);
   }
 }
 
-void Courtroom::set_widgets() {
+void Courtroom::set_widgets()
+{
   QString filename = design_ini;
   pos_size_type f_courtroom =
       ao_app->get_element_dimensions("courtroom", filename);
 
-  if (f_courtroom.width < 0 || f_courtroom.height < 0) {
+  if (f_courtroom.width < 0 || f_courtroom.height < 0)
+  {
     qDebug() << "W: did not find courtroom width or height in " << filename;
 
     this->resize(714, 668);
-  } else {
+  }
+  else
+  {
     m_courtroom_width = f_courtroom.width;
     m_courtroom_height = f_courtroom.height;
 
@@ -724,7 +744,8 @@ void Courtroom::set_widgets() {
   //  set_size_and_pos(ui_shouts[4], "got_it");
   //  set_size_and_pos(ui_shouts[5], "cross_swords");
   //  set_size_and_pos(ui_shouts[6], "counter_alt");
-  for (int i = 0; i < shout_names.size(); ++i) {
+  for (int i = 0; i < shout_names.size(); ++i)
+  {
     set_size_and_pos(ui_shouts[i], shout_names[i]);
   }
   //  ui_shouts[0]->show();
@@ -741,7 +762,8 @@ void Courtroom::set_widgets() {
 
   // courtroom_config.ini necessary + check for crash
   if (ao_app->read_theme_ini("enable_single_shout", cc_config_ini) == "true" &&
-      ui_shouts.size() > 0) {
+      ui_shouts.size() > 0)
+  {
     for (auto &shout : ui_shouts)
       move_widget(shout, "bullet");
 
@@ -755,7 +777,8 @@ void Courtroom::set_widgets() {
   //  set_size_and_pos(ui_effects[1], "effect_gloom");
   //  set_size_and_pos(ui_effects[2], "effect_question");
   //  set_size_and_pos(ui_effects[3], "effect_pow");
-  for (int i = 0; i < effect_names.size(); ++i) {
+  for (int i = 0; i < effect_names.size(); ++i)
+  {
     set_size_and_pos(ui_effects[i], effect_names[i]);
   }
   reset_effect_buttons();
@@ -786,7 +809,8 @@ void Courtroom::set_widgets() {
   ui_wtce_down->set_image("wtcedown.png");
   ui_wtce_down->hide();
 
-  for (int i = 0; i < wtce_names.size(); ++i) {
+  for (int i = 0; i < wtce_names.size(); ++i)
+  {
     set_size_and_pos(ui_wtce[i], wtce_names[i]);
   }
 
@@ -802,7 +826,8 @@ void Courtroom::set_widgets() {
   // this will reset the image
   reset_judge_wtce_buttons();
 
-  for (int i = 0; i < free_block_names.size(); ++i) {
+  for (int i = 0; i < free_block_names.size(); ++i)
+  {
     set_size_and_pos(ui_free_blocks[i], free_block_names[i]);
   }
   set_free_blocks();
@@ -827,7 +852,8 @@ void Courtroom::set_widgets() {
   ui_config_panel->setStyleSheet("");
   ui_note_button->setStyleSheet("");
 
-  if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true") {
+  if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true")
+  {
     // Set files, ask questions later
     // set_image first tries the theme variant folder, then the theme folder,
     // then falls back to the default theme
@@ -858,7 +884,8 @@ void Courtroom::set_widgets() {
   // found in courtroom_design.ini This is to assist with people who switch to
   // incompatible and/or smaller themes and have the button disappear
   if (ui_config_panel->x() > width() || ui_config_panel->y() > height() ||
-      !ui_config_panel->isVisible()) {
+      !ui_config_panel->isVisible())
+  {
     ui_config_panel->setVisible(true);
     ui_config_panel->move(0, 0);
     // Moreover, if the width or height is invalid, change it to some fixed
@@ -874,11 +901,13 @@ void Courtroom::set_widgets() {
 
   set_size_and_pos(ui_hidden, "hidden");
 
-  for (int i = 0; i < ui_label_images.size(); ++i) {
+  for (int i = 0; i < ui_label_images.size(); ++i)
+  {
     set_size_and_pos(ui_label_images[i], label_images[i].toLower() + "_image");
   }
 
-  if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true") {
+  if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true")
+  {
     for (int i = 0; i < ui_checks.size(); ++i) // loop through checks
     {
       QString image = label_images[i].toLower() + ".png";
@@ -901,7 +930,9 @@ void Courtroom::set_widgets() {
       else
         ui_labels[i]->setText(label_images[j]);
     }
-  } else {
+  }
+  else
+  {
     for (int i = 0; i < ui_checks.size(); ++i) // same thing
     {
       ui_checks[i]->setText(label_images[i]);
@@ -1001,7 +1032,8 @@ void Courtroom::set_widgets() {
 
   list_note_files();
 
-  if (!contains_add_button) {
+  if (!contains_add_button)
+  {
     ui_note_area->m_layout->addWidget(ui_note_area->add_button);
     contains_add_button = true;
   }
@@ -1011,31 +1043,39 @@ void Courtroom::set_widgets() {
   set_fonts();
 }
 
-void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier) {
+void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier)
+{
   QString filename = design_ini;
 
   pos_size_type design_ini_result =
       ao_app->get_element_dimensions(p_identifier, filename);
 
-  if (design_ini_result.width < 0 || design_ini_result.height < 0) {
+  if (design_ini_result.width < 0 || design_ini_result.height < 0)
+  {
     qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
     p_widget->hide();
-  } else {
+  }
+  else
+  {
     p_widget->move(design_ini_result.x, design_ini_result.y);
     p_widget->resize(design_ini_result.width, design_ini_result.height);
   }
 }
 
-void Courtroom::move_widget(QWidget *p_widget, QString p_identifier) {
+void Courtroom::move_widget(QWidget *p_widget, QString p_identifier)
+{
   QString filename = design_ini;
 
   pos_size_type design_ini_result =
       ao_app->get_element_dimensions(p_identifier, filename);
 
-  if (design_ini_result.width < 0 || design_ini_result.height < 0) {
+  if (design_ini_result.width < 0 || design_ini_result.height < 0)
+  {
     qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
     p_widget->hide();
-  } else {
+  }
+  else
+  {
     p_widget->move(design_ini_result.x, design_ini_result.y);
   }
 }
@@ -1043,7 +1083,8 @@ void Courtroom::move_widget(QWidget *p_widget, QString p_identifier) {
 template <typename T>
 int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
                                     QString config_item_number,
-                                    QString item_name) {
+                                    QString item_name)
+{
   // &item_vector must be a vector of size at least 1!
 
   // Redraw the new correct number of items.
@@ -1056,15 +1097,20 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
 
   // Decide what to do if the new theme has a different amount of items than the
   // old one
-  if (new_item_number < current_item_number) {
+  if (new_item_number < current_item_number)
+  {
     // Hide old items if there are any.
-    for (int i = new_item_number; i < current_item_number; i++) {
+    for (int i = new_item_number; i < current_item_number; i++)
+    {
       item_vector[i]->hide();
     }
-  } else if (current_item_number < new_item_number) {
+  }
+  else if (current_item_number < new_item_number)
+  {
     // Create new items
     item_vector.resize(new_item_number);
-    for (int i = current_item_number; i < new_item_number; i++) {
+    for (int i = current_item_number; i < new_item_number; i++)
+    {
       item_vector[i] = new T(this);
       item_vector[i]->stackUnder(item_vector[i - 1]);
       // index i-1 exists as i >= current_item_number == item_vector.size() >= 1
@@ -1074,7 +1120,8 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
   // item_vector is non-decreasing. This is because we want to allow for items
   // to, say, run in the background as invisible. With that said, we can now
   // properly format our new items
-  for (int i = 0; i < new_item_number; i++) {
+  for (int i = 0; i < new_item_number; i++)
+  {
     item_vector[i]->show();
     set_size_and_pos(item_vector[i], item_name + "_" + QString::number(i));
     // Note that show is deliberately placed before set_size_and_pos
@@ -1085,8 +1132,10 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
   return new_item_number;
 }
 
-void Courtroom::check_effects() {
-  for (int i = 0; i < ui_effects.size(); ++i) {
+void Courtroom::check_effects()
+{
+  for (int i = 0; i < ui_effects.size(); ++i)
+  {
     QStringList paths{
         ao_app->get_character_path(current_char, effect_names.at(i) + ".webp"),
         ao_app->get_character_path(current_char, effect_names.at(i) + ".gif"),
@@ -1099,8 +1148,10 @@ void Courtroom::check_effects() {
 
     // Assume the effect does not exist until a matching file is found
     effects_enabled[i] = false;
-    for (QString path : paths) {
-      if (file_exists(path)) {
+    for (QString path : paths)
+    {
+      if (file_exists(path))
+      {
         effects_enabled[i] = true;
         break;
       }
@@ -1108,8 +1159,10 @@ void Courtroom::check_effects() {
   }
 }
 
-void Courtroom::check_free_blocks() {
-  for (int i = 0; i < ui_free_blocks.size(); ++i) {
+void Courtroom::check_free_blocks()
+{
+  for (int i = 0; i < ui_free_blocks.size(); ++i)
+  {
     QStringList paths{
         ao_app->get_character_path(current_char,
                                    free_block_names.at(i) + ".webp"),
@@ -1124,8 +1177,10 @@ void Courtroom::check_free_blocks() {
 
     // Assume the free block does not exist until a matching file is found
     free_blocks_enabled[i] = false;
-    for (QString path : paths) {
-      if (file_exists(path)) {
+    for (QString path : paths)
+    {
+      if (file_exists(path))
+      {
         free_blocks_enabled[i] = true;
         break;
       }
@@ -1133,8 +1188,10 @@ void Courtroom::check_free_blocks() {
   }
 }
 
-void Courtroom::check_shouts() {
-  for (int i = 0; i < ui_shouts.size(); ++i) {
+void Courtroom::check_shouts()
+{
+  for (int i = 0; i < ui_shouts.size(); ++i)
+  {
     QStringList paths{
         ao_app->get_character_path(current_char, shout_names.at(i) + ".webp"),
         ao_app->get_character_path(current_char, shout_names.at(i) + ".gif"),
@@ -1147,8 +1204,10 @@ void Courtroom::check_shouts() {
 
     // Assume the shout does not exist until a matching file is found
     shouts_enabled[i] = false;
-    for (QString path : paths) {
-      if (file_exists(path)) {
+    for (QString path : paths)
+    {
+      if (file_exists(path))
+      {
         shouts_enabled[i] = true;
         break;
       }
@@ -1156,8 +1215,10 @@ void Courtroom::check_shouts() {
   }
 }
 
-void Courtroom::check_wtce() {
-  for (int i = 0; i < ui_wtce.size(); ++i) {
+void Courtroom::check_wtce()
+{
+  for (int i = 0; i < ui_wtce.size(); ++i)
+  {
     QStringList paths{
         ao_app->get_character_path(current_char, wtce_names.at(i) + ".webp"),
         ao_app->get_character_path(current_char, wtce_names.at(i) + ".gif"),
@@ -1170,8 +1231,10 @@ void Courtroom::check_wtce() {
 
     // Assume the judge button does not exist until a matching file is found
     wtce_enabled[i] = false;
-    for (QString path : paths) {
-      if (file_exists(path)) {
+    for (QString path : paths)
+    {
+      if (file_exists(path))
+      {
         wtce_enabled[i] = true;
         break;
       }
@@ -1179,7 +1242,8 @@ void Courtroom::check_wtce() {
   }
 }
 
-void Courtroom::delete_widget(QWidget *p_widget) {
+void Courtroom::delete_widget(QWidget *p_widget)
+{
   // remove the widget from recorded names
   widget_names.remove(p_widget->objectName());
 
@@ -1199,7 +1263,8 @@ void Courtroom::delete_widget(QWidget *p_widget) {
   delete p_widget;
 }
 
-void Courtroom::load_effects() {
+void Courtroom::load_effects()
+{
   // Close any existing effects to prevent memory leaks
   for (QWidget *widget : ui_effects)
     delete_widget(widget);
@@ -1210,7 +1275,8 @@ void Courtroom::load_effects() {
   effects_enabled.resize(effect_number);
   ui_effects.resize(effect_number);
 
-  for (int i = 0; i < ui_effects.size(); ++i) {
+  for (int i = 0; i < ui_effects.size(); ++i)
+  {
     ui_effects[i] = new AOButton(this, ao_app);
     ui_effects[i]->setProperty("effect_id", i + 1);
     ui_effects[i]->stackUnder(ui_effect_up);
@@ -1224,16 +1290,19 @@ void Courtroom::load_effects() {
 
   // And add names
   effect_names.clear();
-  for (int i = 1; i <= ui_effects.size(); ++i) {
+  for (int i = 1; i <= ui_effects.size(); ++i)
+  {
     QStringList names = ao_app->get_effect(i);
-    if (!names.isEmpty()) {
+    if (!names.isEmpty())
+    {
       QString name = names.at(0).trimmed();
       effect_names.append(name);
     }
   }
 }
 
-void Courtroom::load_free_blocks() {
+void Courtroom::load_free_blocks()
+{
   for (QWidget *widget : ui_free_blocks)
     delete_widget(widget);
 
@@ -1243,7 +1312,8 @@ void Courtroom::load_free_blocks() {
   free_blocks_enabled.resize(free_block_number);
   ui_free_blocks.resize(free_block_number);
 
-  for (int i = 0; i < ui_free_blocks.size(); ++i) {
+  for (int i = 0; i < ui_free_blocks.size(); ++i)
+  {
     ui_free_blocks[i] = new AOMovie(this, ao_app);
     // ui_free_blocks[i]->setProperty("free_block_id", i+1);
     ui_free_blocks[i]->set_play_once(false);
@@ -1252,10 +1322,12 @@ void Courtroom::load_free_blocks() {
 
   // And add names
   free_block_names.clear();
-  for (int i = 1; i <= ui_free_blocks.size(); ++i) {
+  for (int i = 1; i <= ui_free_blocks.size(); ++i)
+  {
     QString name =
         "free_block_" + ao_app->get_spbutton("[FREE BLOCKS]", i).trimmed();
-    if (!name.isEmpty()) {
+    if (!name.isEmpty())
+    {
       free_block_names.append(name);
       widget_names[name] = ui_free_blocks[i - 1];
       ui_free_blocks[i - 1]->setObjectName(name);
@@ -1264,7 +1336,8 @@ void Courtroom::load_free_blocks() {
   qDebug() << "FREE BLOCKS HERE " << free_block_names;
 }
 
-void Courtroom::load_shouts() {
+void Courtroom::load_shouts()
+{
   for (QWidget *widget : ui_shouts)
     delete_widget(widget);
 
@@ -1274,7 +1347,8 @@ void Courtroom::load_shouts() {
   shouts_enabled.resize(shout_number);
   ui_shouts.resize(shout_number);
 
-  for (int i = 0; i < ui_shouts.size(); ++i) {
+  for (int i = 0; i < ui_shouts.size(); ++i)
+  {
     ui_shouts[i] = new AOButton(this, ao_app);
     ui_shouts[i]->setProperty("shout_id", i + 1);
     ui_shouts[i]->stackUnder(ui_shout_up);
@@ -1287,9 +1361,11 @@ void Courtroom::load_shouts() {
 
   // And add names
   shout_names.clear();
-  for (int i = 1; i <= ui_shouts.size(); ++i) {
+  for (int i = 1; i <= ui_shouts.size(); ++i)
+  {
     QString name = ao_app->get_spbutton("[SHOUTS]", i).trimmed();
-    if (!name.isEmpty()) {
+    if (!name.isEmpty())
+    {
       qDebug() << "SHOUT " << name << " " << ui_shouts[i - 1];
       shout_names.append(name);
       widget_names[name] = ui_shouts[i - 1];
@@ -1299,7 +1375,8 @@ void Courtroom::load_shouts() {
   qDebug() << widget_names;
 }
 
-void Courtroom::load_wtce() {
+void Courtroom::load_wtce()
+{
   for (QWidget *widget : ui_wtce)
     delete_widget(widget);
 
@@ -1308,7 +1385,8 @@ void Courtroom::load_wtce() {
   wtce_enabled.resize(wtce_number);
   ui_wtce.resize(wtce_number);
 
-  for (int i = 0; i < ui_wtce.size(); ++i) {
+  for (int i = 0; i < ui_wtce.size(); ++i)
+  {
     ui_wtce[i] = new AOButton(this, ao_app);
     ui_wtce[i]->setProperty("wtce_id", i + 1);
     ui_wtce[i]->stackUnder(ui_wtce_up);
@@ -1321,9 +1399,11 @@ void Courtroom::load_wtce() {
 
   // And add names
   wtce_names.clear();
-  for (int i = 1; i <= ui_wtce.size(); ++i) {
+  for (int i = 1; i <= ui_wtce.size(); ++i)
+  {
     QString name = ao_app->get_spbutton("[WTCE]", i).trimmed();
-    if (!name.isEmpty()) {
+    if (!name.isEmpty())
+    {
       wtce_names.append(name);
       widget_names[name] = ui_wtce[i - 1];
       ui_wtce[i - 1]->setObjectName(name);
@@ -1331,14 +1411,16 @@ void Courtroom::load_wtce() {
   }
 }
 
-void Courtroom::set_shouts() {
+void Courtroom::set_shouts()
+{
   for (auto &shout : ui_shouts)
     shout->hide();
   if (ui_shouts.size() > 0)
     ui_shouts[m_shout_state]->show(); // check to prevent crashing
 }
 
-void Courtroom::set_effects() {
+void Courtroom::set_effects()
+{
   for (auto &effect : ui_effects)
     effect->hide();
 
@@ -1347,7 +1429,8 @@ void Courtroom::set_effects() {
     ui_effects[m_effect_current]->show();
 }
 
-void Courtroom::set_judge_enabled(bool p_enabled) {
+void Courtroom::set_judge_enabled(bool p_enabled)
+{
   is_judge = p_enabled;
 
   // set judge button visibility
@@ -1359,7 +1442,8 @@ void Courtroom::set_judge_enabled(bool p_enabled) {
   set_judge_wtce();
 }
 
-void Courtroom::set_judge_wtce() {
+void Courtroom::set_judge_wtce()
+{
   // hide all wtce before enabling visibility
   for (auto &wtce : ui_wtce)
     wtce->hide();
@@ -1377,29 +1461,36 @@ void Courtroom::set_judge_wtce() {
     return;
 
   // set visibility based off parameter
-  if (is_single_wtce == true) {
+  if (is_single_wtce == true)
+  {
     ui_wtce[m_wtce_current]->show();
-  } else {
+  }
+  else
+  {
     for (AOButton *i_wtce : ui_wtce)
       i_wtce->show();
   }
 }
 
-void Courtroom::set_free_blocks() {
-  for (int i = 0; i < ui_free_blocks.size(); i++) {
+void Courtroom::set_free_blocks()
+{
+  for (int i = 0; i < ui_free_blocks.size(); i++)
+  {
     AOMovie *free_block = ui_free_blocks[i];
     free_block->play(free_block_names[i]);
   }
 }
 
-void Courtroom::set_dropdown(QWidget *widget, QString target_tag) {
+void Courtroom::set_dropdown(QWidget *widget, QString target_tag)
+{
   QString f_file = "courtroom_stylesheets.css";
   QString style_sheet_string = ao_app->get_stylesheet(target_tag, f_file);
   if (style_sheet_string != "")
     widget->setStyleSheet(style_sheet_string);
 }
 
-void Courtroom::set_dropdowns() {
+void Courtroom::set_dropdowns()
+{
   set_dropdown(ui_text_color, "[TEXT COLOR]");
   set_dropdown(ui_pos_dropdown, "[POS DROPDOWN]");
   set_dropdown(ui_emote_dropdown, "[EMOTE DROPDOWN]");
@@ -1408,12 +1499,14 @@ void Courtroom::set_dropdowns() {
   set_dropdown(ui_ooc_chat_message, "[OOC LINE]");
 }
 
-void Courtroom::set_font(QWidget *widget, QString p_identifier) {
+void Courtroom::set_font(QWidget *widget, QString p_identifier)
+{
   set_font(widget, p_identifier, "");
 }
 
 void Courtroom::set_font(QWidget *widget, QString p_identifier,
-                         QString override_color) {
+                         QString override_color)
+{
   QString design_file = fonts_ini;
   QString class_name = widget->metaObject()->className();
 
@@ -1422,7 +1515,8 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier,
       ao_app->get_font_name("font_" + p_identifier, design_file);
   widget->setFont(QFont(font_name, f_weight));
 
-  if (override_color.isEmpty()) {
+  if (override_color.isEmpty())
+  {
     QString color =
         ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
     if (color.isEmpty())
@@ -1442,12 +1536,14 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier,
   widget->setStyleSheet(style_sheet_string);
 }
 
-void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier) {
+void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier)
+{
   set_qtextedit_font(widget, p_identifier, "");
 }
 
 void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier,
-                                   QString override_color) {
+                                   QString override_color)
+{
   set_font(widget, p_identifier, override_color);
 
   QString design_file = fonts_ini;
@@ -1459,7 +1555,8 @@ void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier,
   widget->setCurrentCharFormat(widget_format);
 }
 
-void Courtroom::set_fonts() {
+void Courtroom::set_fonts()
+{
   set_qtextedit_font(ui_vp_showname, "showname");
   set_qtextedit_font(ui_vp_message, "message");
   set_qtextedit_font(ui_ic_chatlog, "ic_chatlog");
@@ -1470,16 +1567,19 @@ void Courtroom::set_fonts() {
   set_font(ui_sfx_list, "sfx_list");
   set_qtextedit_font(ui_vp_music_name, "music_name");
   set_qtextedit_font(ui_vp_notepad, "notepad");
-  for (int i = 0; i < timer_number; i++) {
+  for (int i = 0; i < timer_number; i++)
+  {
     set_qtextedit_font(ui_timers[i], "timer_" + QString::number(i));
   }
 }
 
-void Courtroom::set_mute_list() {
+void Courtroom::set_mute_list()
+{
   mute_map.clear();
 
   // maps which characters are muted based on cid, none are muted by default
-  for (int n_cid = 0; n_cid < char_list.size(); n_cid++) {
+  for (int n_cid = 0; n_cid < char_list.size(); n_cid++)
+  {
     mute_map.insert(n_cid, false);
   }
 
@@ -1490,7 +1590,8 @@ void Courtroom::set_mute_list() {
 
   sorted_mute_list.sort();
 
-  for (QString i_name : sorted_mute_list) {
+  for (QString i_name : sorted_mute_list)
+  {
     // mute_map.insert(i_name, false);
     ui_mute_list->addItem(i_name);
   }

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -20,8 +20,7 @@
 #include <QTextCharFormat>
 #include <QTime>
 
-void Courtroom::create_widgets()
-{
+void Courtroom::create_widgets() {
   keepalive_timer = new QTimer(this);
   keepalive_timer->start(60000);
 
@@ -185,8 +184,7 @@ void Courtroom::create_widgets()
   ui_note_button = new AOButton(this, ao_app);
 
   ui_label_images.resize(label_images.size());
-  for (int i = 0; i < ui_label_images.size(); ++i)
-  {
+  for (int i = 0; i < ui_label_images.size(); ++i) {
     ui_label_images[i] = new AOImage(this, ao_app);
   }
 
@@ -217,8 +215,7 @@ void Courtroom::create_widgets()
   ui_text_color->addItem("Red");
   ui_text_color->addItem("Orange");
   ui_text_color->addItem("Blue");
-  if (ao_app->yellow_text_enabled)
-  {
+  if (ao_app->yellow_text_enabled) {
     ui_text_color->addItem("Yellow");
     ui_text_color->addItem("Purple");
     ui_text_color->addItem("Pink");
@@ -240,8 +237,7 @@ void Courtroom::create_widgets()
   construct_char_select();
 }
 
-void Courtroom::connect_widgets()
-{
+void Courtroom::connect_widgets() {
   connect(keepalive_timer, SIGNAL(timeout()), this, SLOT(ping_server()));
 
   connect(ao_app, SIGNAL(reload_theme()), this,
@@ -364,8 +360,7 @@ void Courtroom::connect_widgets()
           SLOT(on_set_notes_clicked()));
 }
 
-void Courtroom::reset_widget_names()
-{
+void Courtroom::reset_widget_names() {
   // Assign names to the default widgets
   widget_names = {
       {"courtroom", this},
@@ -452,8 +447,7 @@ void Courtroom::reset_widget_names()
   };
 }
 
-void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget)
-{
+void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget) {
   // insert entry
   widget_names[p_widget_name] = p_widget;
   // set name
@@ -461,14 +455,12 @@ void Courtroom::insert_widget_name(QString p_widget_name, QWidget *p_widget)
 }
 
 void Courtroom::insert_widget_names(QVector<QString> &p_widget_names,
-                                    QVector<QWidget *> &p_widgets)
-{
+                                    QVector<QWidget *> &p_widgets) {
   for (int i = 0; i < p_widgets.length(); ++i)
     insert_widget_name(p_widget_names[i], p_widgets[i]);
 }
 
-void Courtroom::set_widget_names()
-{
+void Courtroom::set_widget_names() {
   // Assign names to the default widgets
   reset_widget_names();
 
@@ -489,24 +481,21 @@ void Courtroom::set_widget_names()
   insert_widget_names(timer_names, ui_timers);
 }
 
-void Courtroom::set_widget_layers()
-{
+void Courtroom::set_widget_layers() {
   QStringList paths{
-      ao_app->get_theme_variant_path() + "courtroom_layers.ini",
-      ao_app->get_theme_path() + "courtroom_layers.ini",
-      ao_app->get_default_theme_path() + "courtroom_layers.ini",
+      ao_app->get_theme_variant_path("courtroom_layers.ini"),
+      ao_app->get_theme_path("courtroom_layers.ini"),
+      ao_app->get_default_theme_path("courtroom_layers.ini"),
   };
 
   // needed to avoid cyclic parenting
   QStringList recorded_widgets;
 
   // read the entire thing
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QFile layer_ini(path);
 
-    if (layer_ini.open(QFile::ReadOnly))
-    {
+    if (layer_ini.open(QFile::ReadOnly)) {
       QTextStream in(&layer_ini);
 
       // current parent's name
@@ -514,8 +503,7 @@ void Courtroom::set_widget_layers()
       // the courtroom is ALWAYS going to be recorded
       recorded_widgets.append(parent_name);
 
-      while (!in.atEnd())
-      {
+      while (!in.atEnd()) {
         QString line = in.readLine().trimmed();
 
         // skip if line is empty
@@ -523,19 +511,16 @@ void Courtroom::set_widget_layers()
           continue;
 
         // revert to default parent if we encounter an end scope
-        if (line.startsWith("[\\"))
-        {
+        if (line.startsWith("[\\")) {
           parent_name = "courtroom";
         }
         // is this a parent?
-        else if (line.startsWith("["))
-        {
+        else if (line.startsWith("[")) {
           // update the current parent
           parent_name = line.remove(0, 1).chopped(1).trimmed();
         }
         // if this is not a parent, it's a child
-        else
-        {
+        else {
           // if the child is already known, skip
           if (recorded_widgets.contains(line))
             continue;
@@ -575,28 +560,23 @@ void Courtroom::set_widget_layers()
   // particular, make it visible and raise it in front of all assets. This can
   // help assist a theme designer who accidentally missed config_panel and would
   // have become unable to reload themes had they closed the config panel
-  if (!recorded_widgets.contains("config_panel"))
-  {
+  if (!recorded_widgets.contains("config_panel")) {
     ui_config_panel->setParent(this);
     ui_config_panel->raise();
     ui_config_panel->setVisible(true);
   }
 }
 
-void Courtroom::set_widgets()
-{
+void Courtroom::set_widgets() {
   QString filename = design_ini;
   pos_size_type f_courtroom =
       ao_app->get_element_dimensions("courtroom", filename);
 
-  if (f_courtroom.width < 0 || f_courtroom.height < 0)
-  {
+  if (f_courtroom.width < 0 || f_courtroom.height < 0) {
     qDebug() << "W: did not find courtroom width or height in " << filename;
 
     this->resize(714, 668);
-  }
-  else
-  {
+  } else {
     m_courtroom_width = f_courtroom.width;
     m_courtroom_height = f_courtroom.height;
 
@@ -744,8 +724,7 @@ void Courtroom::set_widgets()
   //  set_size_and_pos(ui_shouts[4], "got_it");
   //  set_size_and_pos(ui_shouts[5], "cross_swords");
   //  set_size_and_pos(ui_shouts[6], "counter_alt");
-  for (int i = 0; i < shout_names.size(); ++i)
-  {
+  for (int i = 0; i < shout_names.size(); ++i) {
     set_size_and_pos(ui_shouts[i], shout_names[i]);
   }
   //  ui_shouts[0]->show();
@@ -762,8 +741,7 @@ void Courtroom::set_widgets()
 
   // courtroom_config.ini necessary + check for crash
   if (ao_app->read_theme_ini("enable_single_shout", cc_config_ini) == "true" &&
-      ui_shouts.size() > 0)
-  {
+      ui_shouts.size() > 0) {
     for (auto &shout : ui_shouts)
       move_widget(shout, "bullet");
 
@@ -777,8 +755,7 @@ void Courtroom::set_widgets()
   //  set_size_and_pos(ui_effects[1], "effect_gloom");
   //  set_size_and_pos(ui_effects[2], "effect_question");
   //  set_size_and_pos(ui_effects[3], "effect_pow");
-  for (int i = 0; i < effect_names.size(); ++i)
-  {
+  for (int i = 0; i < effect_names.size(); ++i) {
     set_size_and_pos(ui_effects[i], effect_names[i]);
   }
   reset_effect_buttons();
@@ -809,8 +786,7 @@ void Courtroom::set_widgets()
   ui_wtce_down->set_image("wtcedown.png");
   ui_wtce_down->hide();
 
-  for (int i = 0; i < wtce_names.size(); ++i)
-  {
+  for (int i = 0; i < wtce_names.size(); ++i) {
     set_size_and_pos(ui_wtce[i], wtce_names[i]);
   }
 
@@ -826,8 +802,7 @@ void Courtroom::set_widgets()
   // this will reset the image
   reset_judge_wtce_buttons();
 
-  for (int i = 0; i < free_block_names.size(); ++i)
-  {
+  for (int i = 0; i < free_block_names.size(); ++i) {
     set_size_and_pos(ui_free_blocks[i], free_block_names[i]);
   }
   set_free_blocks();
@@ -852,8 +827,7 @@ void Courtroom::set_widgets()
   ui_config_panel->setStyleSheet("");
   ui_note_button->setStyleSheet("");
 
-  if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true")
-  {
+  if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true") {
     // Set files, ask questions later
     // set_image first tries the theme variant folder, then the theme folder,
     // then falls back to the default theme
@@ -884,8 +858,7 @@ void Courtroom::set_widgets()
   // found in courtroom_design.ini This is to assist with people who switch to
   // incompatible and/or smaller themes and have the button disappear
   if (ui_config_panel->x() > width() || ui_config_panel->y() > height() ||
-      !ui_config_panel->isVisible())
-  {
+      !ui_config_panel->isVisible()) {
     ui_config_panel->setVisible(true);
     ui_config_panel->move(0, 0);
     // Moreover, if the width or height is invalid, change it to some fixed
@@ -901,13 +874,11 @@ void Courtroom::set_widgets()
 
   set_size_and_pos(ui_hidden, "hidden");
 
-  for (int i = 0; i < ui_label_images.size(); ++i)
-  {
+  for (int i = 0; i < ui_label_images.size(); ++i) {
     set_size_and_pos(ui_label_images[i], label_images[i].toLower() + "_image");
   }
 
-  if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true")
-  {
+  if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true") {
     for (int i = 0; i < ui_checks.size(); ++i) // loop through checks
     {
       QString image = label_images[i].toLower() + ".png";
@@ -930,9 +901,7 @@ void Courtroom::set_widgets()
       else
         ui_labels[i]->setText(label_images[j]);
     }
-  }
-  else
-  {
+  } else {
     for (int i = 0; i < ui_checks.size(); ++i) // same thing
     {
       ui_checks[i]->setText(label_images[i]);
@@ -1032,8 +1001,7 @@ void Courtroom::set_widgets()
 
   list_note_files();
 
-  if (!contains_add_button)
-  {
+  if (!contains_add_button) {
     ui_note_area->m_layout->addWidget(ui_note_area->add_button);
     contains_add_button = true;
   }
@@ -1043,39 +1011,31 @@ void Courtroom::set_widgets()
   set_fonts();
 }
 
-void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier)
-{
+void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier) {
   QString filename = design_ini;
 
   pos_size_type design_ini_result =
       ao_app->get_element_dimensions(p_identifier, filename);
 
-  if (design_ini_result.width < 0 || design_ini_result.height < 0)
-  {
+  if (design_ini_result.width < 0 || design_ini_result.height < 0) {
     qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
     p_widget->hide();
-  }
-  else
-  {
+  } else {
     p_widget->move(design_ini_result.x, design_ini_result.y);
     p_widget->resize(design_ini_result.width, design_ini_result.height);
   }
 }
 
-void Courtroom::move_widget(QWidget *p_widget, QString p_identifier)
-{
+void Courtroom::move_widget(QWidget *p_widget, QString p_identifier) {
   QString filename = design_ini;
 
   pos_size_type design_ini_result =
       ao_app->get_element_dimensions(p_identifier, filename);
 
-  if (design_ini_result.width < 0 || design_ini_result.height < 0)
-  {
+  if (design_ini_result.width < 0 || design_ini_result.height < 0) {
     qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
     p_widget->hide();
-  }
-  else
-  {
+  } else {
     p_widget->move(design_ini_result.x, design_ini_result.y);
   }
 }
@@ -1083,8 +1043,7 @@ void Courtroom::move_widget(QWidget *p_widget, QString p_identifier)
 template <typename T>
 int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
                                     QString config_item_number,
-                                    QString item_name)
-{
+                                    QString item_name) {
   // &item_vector must be a vector of size at least 1!
 
   // Redraw the new correct number of items.
@@ -1097,20 +1056,15 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
 
   // Decide what to do if the new theme has a different amount of items than the
   // old one
-  if (new_item_number < current_item_number)
-  {
+  if (new_item_number < current_item_number) {
     // Hide old items if there are any.
-    for (int i = new_item_number; i < current_item_number; i++)
-    {
+    for (int i = new_item_number; i < current_item_number; i++) {
       item_vector[i]->hide();
     }
-  }
-  else if (current_item_number < new_item_number)
-  {
+  } else if (current_item_number < new_item_number) {
     // Create new items
     item_vector.resize(new_item_number);
-    for (int i = current_item_number; i < new_item_number; i++)
-    {
+    for (int i = current_item_number; i < new_item_number; i++) {
       item_vector[i] = new T(this);
       item_vector[i]->stackUnder(item_vector[i - 1]);
       // index i-1 exists as i >= current_item_number == item_vector.size() >= 1
@@ -1120,8 +1074,7 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
   // item_vector is non-decreasing. This is because we want to allow for items
   // to, say, run in the background as invisible. With that said, we can now
   // properly format our new items
-  for (int i = 0; i < new_item_number; i++)
-  {
+  for (int i = 0; i < new_item_number; i++) {
     item_vector[i]->show();
     set_size_and_pos(item_vector[i], item_name + "_" + QString::number(i));
     // Note that show is deliberately placed before set_size_and_pos
@@ -1132,28 +1085,22 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector,
   return new_item_number;
 }
 
-void Courtroom::check_effects()
-{
-  QString char_path = ao_app->get_character_path(current_char);
-  QString theme_variant_path = ao_app->get_theme_variant_path();
-  QString theme_path = ao_app->get_theme_path();
-  for (int i = 0; i < ui_effects.size(); ++i)
-  {
-    QStringList paths{char_path + effect_names.at(i) + ".webp",
-                      char_path + effect_names.at(i) + ".gif",
-                      theme_variant_path + effect_names.at(i) + ".webp",
-                      theme_variant_path + effect_names.at(i) + ".gif",
-                      theme_variant_path + effect_names.at(i) + ".apng",
-                      theme_path + effect_names.at(i) + ".webp",
-                      theme_path + effect_names.at(i) + ".gif",
-                      theme_path + effect_names.at(i) + ".apng"};
+void Courtroom::check_effects() {
+  for (int i = 0; i < ui_effects.size(); ++i) {
+    QStringList paths{
+        ao_app->get_character_path(current_char, effect_names.at(i) + ".webp"),
+        ao_app->get_character_path(current_char, effect_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(effect_names.at(i) + ".webp"),
+        ao_app->get_theme_variant_path(effect_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(effect_names.at(i) + ".apng"),
+        ao_app->get_theme_path(effect_names.at(i) + ".webp"),
+        ao_app->get_theme_path(effect_names.at(i) + ".gif"),
+        ao_app->get_theme_path(effect_names.at(i) + ".apng")};
 
     // Assume the effect does not exist until a matching file is found
     effects_enabled[i] = false;
-    for (QString path : paths)
-    {
-      if (file_exists(path))
-      {
+    for (QString path : paths) {
+      if (file_exists(path)) {
         effects_enabled[i] = true;
         break;
       }
@@ -1161,28 +1108,24 @@ void Courtroom::check_effects()
   }
 }
 
-void Courtroom::check_free_blocks()
-{
-  QString char_path = ao_app->get_character_path(current_char);
-  QString theme_variant_path = ao_app->get_theme_variant_path();
-  QString theme_path = ao_app->get_theme_path();
-  for (int i = 0; i < ui_free_blocks.size(); ++i)
-  {
-    QStringList paths{char_path + free_block_names.at(i) + ".webp",
-                      char_path + free_block_names.at(i) + ".gif",
-                      theme_variant_path + free_block_names.at(i) + ".webp",
-                      theme_variant_path + free_block_names.at(i) + ".gif",
-                      theme_variant_path + free_block_names.at(i) + ".apng",
-                      theme_path + free_block_names.at(i) + ".webp",
-                      theme_path + free_block_names.at(i) + ".gif",
-                      theme_path + free_block_names.at(i) + ".apng"};
+void Courtroom::check_free_blocks() {
+  for (int i = 0; i < ui_free_blocks.size(); ++i) {
+    QStringList paths{
+        ao_app->get_character_path(current_char,
+                                   free_block_names.at(i) + ".webp"),
+        ao_app->get_character_path(current_char,
+                                   free_block_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(free_block_names.at(i) + ".webp"),
+        ao_app->get_theme_variant_path(free_block_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(free_block_names.at(i) + ".apng"),
+        ao_app->get_theme_path(free_block_names.at(i) + ".webp"),
+        ao_app->get_theme_path(free_block_names.at(i) + ".gif"),
+        ao_app->get_theme_path(free_block_names.at(i) + ".apng")};
 
     // Assume the free block does not exist until a matching file is found
     free_blocks_enabled[i] = false;
-    for (QString path : paths)
-    {
-      if (file_exists(path))
-      {
+    for (QString path : paths) {
+      if (file_exists(path)) {
         free_blocks_enabled[i] = true;
         break;
       }
@@ -1190,28 +1133,22 @@ void Courtroom::check_free_blocks()
   }
 }
 
-void Courtroom::check_shouts()
-{
-  QString char_path = ao_app->get_character_path(current_char);
-  QString theme_variant_path = ao_app->get_theme_variant_path();
-  QString theme_path = ao_app->get_theme_path();
-  for (int i = 0; i < ui_shouts.size(); ++i)
-  {
-    QStringList paths{char_path + shout_names.at(i) + ".webp",
-                      char_path + shout_names.at(i) + ".gif",
-                      theme_variant_path + shout_names.at(i) + ".webp",
-                      theme_variant_path + shout_names.at(i) + ".gif",
-                      theme_variant_path + shout_names.at(i) + ".apng",
-                      theme_path + shout_names.at(i) + ".webp",
-                      theme_path + shout_names.at(i) + ".gif",
-                      theme_path + shout_names.at(i) + ".apng"};
+void Courtroom::check_shouts() {
+  for (int i = 0; i < ui_shouts.size(); ++i) {
+    QStringList paths{
+        ao_app->get_character_path(current_char, shout_names.at(i) + ".webp"),
+        ao_app->get_character_path(current_char, shout_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(shout_names.at(i) + ".webp"),
+        ao_app->get_theme_variant_path(shout_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(shout_names.at(i) + ".apng"),
+        ao_app->get_theme_path(shout_names.at(i) + ".webp"),
+        ao_app->get_theme_path(shout_names.at(i) + ".gif"),
+        ao_app->get_theme_path(shout_names.at(i) + ".apng")};
 
     // Assume the shout does not exist until a matching file is found
     shouts_enabled[i] = false;
-    for (QString path : paths)
-    {
-      if (file_exists(path))
-      {
+    for (QString path : paths) {
+      if (file_exists(path)) {
         shouts_enabled[i] = true;
         break;
       }
@@ -1219,28 +1156,22 @@ void Courtroom::check_shouts()
   }
 }
 
-void Courtroom::check_wtce()
-{
-  QString char_path = ao_app->get_character_path(current_char);
-  QString theme_variant_path = ao_app->get_theme_variant_path();
-  QString theme_path = ao_app->get_theme_path();
-  for (int i = 0; i < ui_wtce.size(); ++i)
-  {
-    QStringList paths{char_path + wtce_names.at(i) + ".webp",
-                      char_path + wtce_names.at(i) + ".gif",
-                      theme_variant_path + wtce_names.at(i) + ".webp",
-                      theme_variant_path + wtce_names.at(i) + ".gif",
-                      theme_variant_path + wtce_names.at(i) + ".apng",
-                      theme_path + wtce_names.at(i) + ".webp",
-                      theme_path + wtce_names.at(i) + ".gif",
-                      theme_path + wtce_names.at(i) + ".apng"};
+void Courtroom::check_wtce() {
+  for (int i = 0; i < ui_wtce.size(); ++i) {
+    QStringList paths{
+        ao_app->get_character_path(current_char, wtce_names.at(i) + ".webp"),
+        ao_app->get_character_path(current_char, wtce_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(wtce_names.at(i) + ".webp"),
+        ao_app->get_theme_variant_path(wtce_names.at(i) + ".gif"),
+        ao_app->get_theme_variant_path(wtce_names.at(i) + ".apng"),
+        ao_app->get_theme_path(wtce_names.at(i) + ".webp"),
+        ao_app->get_theme_path(wtce_names.at(i) + ".gif"),
+        ao_app->get_theme_path(wtce_names.at(i) + ".apng")};
 
     // Assume the judge button does not exist until a matching file is found
     wtce_enabled[i] = false;
-    for (QString path : paths)
-    {
-      if (file_exists(path))
-      {
+    for (QString path : paths) {
+      if (file_exists(path)) {
         wtce_enabled[i] = true;
         break;
       }
@@ -1248,8 +1179,7 @@ void Courtroom::check_wtce()
   }
 }
 
-void Courtroom::delete_widget(QWidget *p_widget)
-{
+void Courtroom::delete_widget(QWidget *p_widget) {
   // remove the widget from recorded names
   widget_names.remove(p_widget->objectName());
 
@@ -1269,8 +1199,7 @@ void Courtroom::delete_widget(QWidget *p_widget)
   delete p_widget;
 }
 
-void Courtroom::load_effects()
-{
+void Courtroom::load_effects() {
   // Close any existing effects to prevent memory leaks
   for (QWidget *widget : ui_effects)
     delete_widget(widget);
@@ -1281,8 +1210,7 @@ void Courtroom::load_effects()
   effects_enabled.resize(effect_number);
   ui_effects.resize(effect_number);
 
-  for (int i = 0; i < ui_effects.size(); ++i)
-  {
+  for (int i = 0; i < ui_effects.size(); ++i) {
     ui_effects[i] = new AOButton(this, ao_app);
     ui_effects[i]->setProperty("effect_id", i + 1);
     ui_effects[i]->stackUnder(ui_effect_up);
@@ -1296,19 +1224,16 @@ void Courtroom::load_effects()
 
   // And add names
   effect_names.clear();
-  for (int i = 1; i <= ui_effects.size(); ++i)
-  {
+  for (int i = 1; i <= ui_effects.size(); ++i) {
     QStringList names = ao_app->get_effect(i);
-    if (!names.isEmpty())
-    {
+    if (!names.isEmpty()) {
       QString name = names.at(0).trimmed();
       effect_names.append(name);
     }
   }
 }
 
-void Courtroom::load_free_blocks()
-{
+void Courtroom::load_free_blocks() {
   for (QWidget *widget : ui_free_blocks)
     delete_widget(widget);
 
@@ -1318,8 +1243,7 @@ void Courtroom::load_free_blocks()
   free_blocks_enabled.resize(free_block_number);
   ui_free_blocks.resize(free_block_number);
 
-  for (int i = 0; i < ui_free_blocks.size(); ++i)
-  {
+  for (int i = 0; i < ui_free_blocks.size(); ++i) {
     ui_free_blocks[i] = new AOMovie(this, ao_app);
     // ui_free_blocks[i]->setProperty("free_block_id", i+1);
     ui_free_blocks[i]->set_play_once(false);
@@ -1328,12 +1252,10 @@ void Courtroom::load_free_blocks()
 
   // And add names
   free_block_names.clear();
-  for (int i = 1; i <= ui_free_blocks.size(); ++i)
-  {
+  for (int i = 1; i <= ui_free_blocks.size(); ++i) {
     QString name =
         "free_block_" + ao_app->get_spbutton("[FREE BLOCKS]", i).trimmed();
-    if (!name.isEmpty())
-    {
+    if (!name.isEmpty()) {
       free_block_names.append(name);
       widget_names[name] = ui_free_blocks[i - 1];
       ui_free_blocks[i - 1]->setObjectName(name);
@@ -1342,8 +1264,7 @@ void Courtroom::load_free_blocks()
   qDebug() << "FREE BLOCKS HERE " << free_block_names;
 }
 
-void Courtroom::load_shouts()
-{
+void Courtroom::load_shouts() {
   for (QWidget *widget : ui_shouts)
     delete_widget(widget);
 
@@ -1353,8 +1274,7 @@ void Courtroom::load_shouts()
   shouts_enabled.resize(shout_number);
   ui_shouts.resize(shout_number);
 
-  for (int i = 0; i < ui_shouts.size(); ++i)
-  {
+  for (int i = 0; i < ui_shouts.size(); ++i) {
     ui_shouts[i] = new AOButton(this, ao_app);
     ui_shouts[i]->setProperty("shout_id", i + 1);
     ui_shouts[i]->stackUnder(ui_shout_up);
@@ -1367,11 +1287,9 @@ void Courtroom::load_shouts()
 
   // And add names
   shout_names.clear();
-  for (int i = 1; i <= ui_shouts.size(); ++i)
-  {
+  for (int i = 1; i <= ui_shouts.size(); ++i) {
     QString name = ao_app->get_spbutton("[SHOUTS]", i).trimmed();
-    if (!name.isEmpty())
-    {
+    if (!name.isEmpty()) {
       qDebug() << "SHOUT " << name << " " << ui_shouts[i - 1];
       shout_names.append(name);
       widget_names[name] = ui_shouts[i - 1];
@@ -1381,8 +1299,7 @@ void Courtroom::load_shouts()
   qDebug() << widget_names;
 }
 
-void Courtroom::load_wtce()
-{
+void Courtroom::load_wtce() {
   for (QWidget *widget : ui_wtce)
     delete_widget(widget);
 
@@ -1391,8 +1308,7 @@ void Courtroom::load_wtce()
   wtce_enabled.resize(wtce_number);
   ui_wtce.resize(wtce_number);
 
-  for (int i = 0; i < ui_wtce.size(); ++i)
-  {
+  for (int i = 0; i < ui_wtce.size(); ++i) {
     ui_wtce[i] = new AOButton(this, ao_app);
     ui_wtce[i]->setProperty("wtce_id", i + 1);
     ui_wtce[i]->stackUnder(ui_wtce_up);
@@ -1405,11 +1321,9 @@ void Courtroom::load_wtce()
 
   // And add names
   wtce_names.clear();
-  for (int i = 1; i <= ui_wtce.size(); ++i)
-  {
+  for (int i = 1; i <= ui_wtce.size(); ++i) {
     QString name = ao_app->get_spbutton("[WTCE]", i).trimmed();
-    if (!name.isEmpty())
-    {
+    if (!name.isEmpty()) {
       wtce_names.append(name);
       widget_names[name] = ui_wtce[i - 1];
       ui_wtce[i - 1]->setObjectName(name);
@@ -1417,16 +1331,14 @@ void Courtroom::load_wtce()
   }
 }
 
-void Courtroom::set_shouts()
-{
+void Courtroom::set_shouts() {
   for (auto &shout : ui_shouts)
     shout->hide();
   if (ui_shouts.size() > 0)
     ui_shouts[m_shout_state]->show(); // check to prevent crashing
 }
 
-void Courtroom::set_effects()
-{
+void Courtroom::set_effects() {
   for (auto &effect : ui_effects)
     effect->hide();
 
@@ -1435,8 +1347,7 @@ void Courtroom::set_effects()
     ui_effects[m_effect_current]->show();
 }
 
-void Courtroom::set_judge_enabled(bool p_enabled)
-{
+void Courtroom::set_judge_enabled(bool p_enabled) {
   is_judge = p_enabled;
 
   // set judge button visibility
@@ -1448,8 +1359,7 @@ void Courtroom::set_judge_enabled(bool p_enabled)
   set_judge_wtce();
 }
 
-void Courtroom::set_judge_wtce()
-{
+void Courtroom::set_judge_wtce() {
   // hide all wtce before enabling visibility
   for (auto &wtce : ui_wtce)
     wtce->hide();
@@ -1467,36 +1377,29 @@ void Courtroom::set_judge_wtce()
     return;
 
   // set visibility based off parameter
-  if (is_single_wtce == true)
-  {
+  if (is_single_wtce == true) {
     ui_wtce[m_wtce_current]->show();
-  }
-  else
-  {
+  } else {
     for (AOButton *i_wtce : ui_wtce)
       i_wtce->show();
   }
 }
 
-void Courtroom::set_free_blocks()
-{
-  for (int i = 0; i < ui_free_blocks.size(); i++)
-  {
+void Courtroom::set_free_blocks() {
+  for (int i = 0; i < ui_free_blocks.size(); i++) {
     AOMovie *free_block = ui_free_blocks[i];
     free_block->play(free_block_names[i]);
   }
 }
 
-void Courtroom::set_dropdown(QWidget *widget, QString target_tag)
-{
+void Courtroom::set_dropdown(QWidget *widget, QString target_tag) {
   QString f_file = "courtroom_stylesheets.css";
   QString style_sheet_string = ao_app->get_stylesheet(target_tag, f_file);
   if (style_sheet_string != "")
     widget->setStyleSheet(style_sheet_string);
 }
 
-void Courtroom::set_dropdowns()
-{
+void Courtroom::set_dropdowns() {
   set_dropdown(ui_text_color, "[TEXT COLOR]");
   set_dropdown(ui_pos_dropdown, "[POS DROPDOWN]");
   set_dropdown(ui_emote_dropdown, "[EMOTE DROPDOWN]");
@@ -1505,14 +1408,12 @@ void Courtroom::set_dropdowns()
   set_dropdown(ui_ooc_chat_message, "[OOC LINE]");
 }
 
-void Courtroom::set_font(QWidget *widget, QString p_identifier)
-{
+void Courtroom::set_font(QWidget *widget, QString p_identifier) {
   set_font(widget, p_identifier, "");
 }
 
 void Courtroom::set_font(QWidget *widget, QString p_identifier,
-                         QString override_color)
-{
+                         QString override_color) {
   QString design_file = fonts_ini;
   QString class_name = widget->metaObject()->className();
 
@@ -1521,8 +1422,7 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier,
       ao_app->get_font_name("font_" + p_identifier, design_file);
   widget->setFont(QFont(font_name, f_weight));
 
-  if (override_color.isEmpty())
-  {
+  if (override_color.isEmpty()) {
     QString color =
         ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
     if (color.isEmpty())
@@ -1542,14 +1442,12 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier,
   widget->setStyleSheet(style_sheet_string);
 }
 
-void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier)
-{
+void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier) {
   set_qtextedit_font(widget, p_identifier, "");
 }
 
 void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier,
-                                   QString override_color)
-{
+                                   QString override_color) {
   set_font(widget, p_identifier, override_color);
 
   QString design_file = fonts_ini;
@@ -1561,8 +1459,7 @@ void Courtroom::set_qtextedit_font(QTextEdit *widget, QString p_identifier,
   widget->setCurrentCharFormat(widget_format);
 }
 
-void Courtroom::set_fonts()
-{
+void Courtroom::set_fonts() {
   set_qtextedit_font(ui_vp_showname, "showname");
   set_qtextedit_font(ui_vp_message, "message");
   set_qtextedit_font(ui_ic_chatlog, "ic_chatlog");
@@ -1573,19 +1470,16 @@ void Courtroom::set_fonts()
   set_font(ui_sfx_list, "sfx_list");
   set_qtextedit_font(ui_vp_music_name, "music_name");
   set_qtextedit_font(ui_vp_notepad, "notepad");
-  for (int i = 0; i < timer_number; i++)
-  {
+  for (int i = 0; i < timer_number; i++) {
     set_qtextedit_font(ui_timers[i], "timer_" + QString::number(i));
   }
 }
 
-void Courtroom::set_mute_list()
-{
+void Courtroom::set_mute_list() {
   mute_map.clear();
 
   // maps which characters are muted based on cid, none are muted by default
-  for (int n_cid = 0; n_cid < char_list.size(); n_cid++)
-  {
+  for (int n_cid = 0; n_cid < char_list.size(); n_cid++) {
     mute_map.insert(n_cid, false);
   }
 
@@ -1596,8 +1490,7 @@ void Courtroom::set_mute_list()
 
   sorted_mute_list.sort();
 
-  for (QString i_name : sorted_mute_list)
-  {
+  for (QString i_name : sorted_mute_list) {
     // mute_map.insert(i_name, false);
     ui_mute_list->addItem(i_name);
   }

--- a/datatypes.h
+++ b/datatypes.h
@@ -1,8 +1,8 @@
 #ifndef DATATYPES_H
 #define DATATYPES_H
 
-#include <memory>
 #include <QString>
+#include <memory>
 
 struct record_type
 {
@@ -27,107 +27,107 @@ typedef QVector<record_type_ptr> record_type_array;
 
 struct server_type
 {
-    QString name;
-    QString desc;
-    QString ip;
-    int port;
+  QString name;
+  QString desc;
+  QString ip;
+  int port;
 };
 
 struct emote_type
 {
-    QString comment;
-    QString preanim;
-    QString anim;
-    int mod;
-    QString sfx_name;
-    int sfx_delay;
-    int sfx_duration;
+  QString comment;
+  QString preanim;
+  QString anim;
+  int mod;
+  QString sfx_name;
+  int sfx_delay;
+  int sfx_duration;
 };
 
 struct char_type
 {
-    QString name;
-    QString description;
-    QString evidence_string;
-    bool taken;
+  QString name;
+  QString description;
+  QString evidence_string;
+  bool taken;
 };
 
 struct evi_type
 {
-    QString name;
-    QString description;
-    QString image;
+  QString name;
+  QString description;
+  QString image;
 };
 
 struct chatmessage_type
 {
-    QString message;
-    QString character;
-    QString side;
-    QString sfx_name;
-    QString pre_emote;
-    QString emote;
-    int emote_modifier;
-    int objection_modifier;
-    int realization;
-    int text_color;
-    int evidence;
-    int cid;
-    int sfx_delay;
-    int flip;
+  QString message;
+  QString character;
+  QString side;
+  QString sfx_name;
+  QString pre_emote;
+  QString emote;
+  int emote_modifier;
+  int objection_modifier;
+  int realization;
+  int text_color;
+  int evidence;
+  int cid;
+  int sfx_delay;
+  int flip;
 };
 
 struct area_type
 {
-    QString name;
-    QString background;
+  QString name;
+  QString background;
 };
 
 struct pos_type
 {
-    int x;
-    int y;
+  int x;
+  int y;
 };
 
 struct pos_size_type
 {
-    int x = 0;
-    int y = 0;
-    int width = 0;
-    int height = 0;
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
 };
 
 enum CHAT_MESSAGE
 {
-    DESK_MOD = 0,
-    PRE_EMOTE,
-    CHAR_NAME,
-    EMOTE,
-    MESSAGE,
-    SIDE,
-    SFX_NAME,
-    EMOTE_MOD,
-    CHAR_ID,
-    SFX_DELAY,
-    OBJECTION_MOD,
-    EVIDENCE_ID,
-    FLIP,
-    EFFECT_STATE,
-    TEXT_COLOR,
-    SHOWNAME
+  DESK_MOD = 0,
+  PRE_EMOTE,
+  CHAR_NAME,
+  EMOTE,
+  MESSAGE,
+  SIDE,
+  SFX_NAME,
+  EMOTE_MOD,
+  CHAR_ID,
+  SFX_DELAY,
+  OBJECTION_MOD,
+  EVIDENCE_ID,
+  FLIP,
+  EFFECT_STATE,
+  TEXT_COLOR,
+  SHOWNAME
 };
 
 enum COLOR
 {
-    WHITE = 0,
-    GREEN,
-    RED,
-    ORANGE,
-    BLUE,
-    YELLOW,
-    PURPLE,
-    PINK,
-    RAINBOW
+  WHITE = 0,
+  GREEN,
+  RED,
+  ORANGE,
+  BLUE,
+  YELLOW,
+  PURPLE,
+  PINK,
+  RAINBOW
 };
 
 #endif // DATATYPES_H

--- a/debug_functions.cpp
+++ b/debug_functions.cpp
@@ -1,7 +1,7 @@
 #include "debug_functions.h"
 
-#include <QMessageBox>
 #include <QDebug>
+#include <QMessageBox>
 
 void call_error(QString p_message)
 {
@@ -11,7 +11,7 @@ void call_error(QString p_message)
   f_box->setWindowTitle("Error");
   qDebug() << f_box->text();
 
-  //msgBox->setWindowModality(Qt::NonModal);
+  // msgBox->setWindowModality(Qt::NonModal);
   f_box->exec();
   delete f_box;
 }
@@ -24,7 +24,7 @@ void call_notice(QString p_message)
   f_box->setWindowTitle("Notice");
   qDebug() << f_box->text();
 
-  //msgBox->setWindowModality(Qt::NonModal);
+  // msgBox->setWindowModality(Qt::NonModal);
   f_box->exec();
   delete f_box;
 }

--- a/discord-rpc.h
+++ b/discord-rpc.h
@@ -20,65 +20,72 @@
 // clang-format on
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct DiscordRichPresence {
-    const char* state;   /* max 128 bytes */
-    const char* details; /* max 128 bytes */
+  typedef struct DiscordRichPresence
+  {
+    const char *state;   /* max 128 bytes */
+    const char *details; /* max 128 bytes */
     int64_t startTimestamp;
     int64_t endTimestamp;
-    const char* largeImageKey;  /* max 32 bytes */
-    const char* largeImageText; /* max 128 bytes */
-    const char* smallImageKey;  /* max 32 bytes */
-    const char* smallImageText; /* max 128 bytes */
-    const char* partyId;        /* max 128 bytes */
+    const char *largeImageKey;  /* max 32 bytes */
+    const char *largeImageText; /* max 128 bytes */
+    const char *smallImageKey;  /* max 32 bytes */
+    const char *smallImageText; /* max 128 bytes */
+    const char *partyId;        /* max 128 bytes */
     int partySize;
     int partyMax;
-    const char* matchSecret;    /* max 128 bytes */
-    const char* joinSecret;     /* max 128 bytes */
-    const char* spectateSecret; /* max 128 bytes */
+    const char *matchSecret;    /* max 128 bytes */
+    const char *joinSecret;     /* max 128 bytes */
+    const char *spectateSecret; /* max 128 bytes */
     int8_t instance;
-} DiscordRichPresence;
+  } DiscordRichPresence;
 
-typedef struct DiscordJoinRequest {
-    const char* userId;
-    const char* username;
-    const char* discriminator;
-    const char* avatar;
-} DiscordJoinRequest;
+  typedef struct DiscordJoinRequest
+  {
+    const char *userId;
+    const char *username;
+    const char *discriminator;
+    const char *avatar;
+  } DiscordJoinRequest;
 
-typedef struct DiscordEventHandlers {
+  typedef struct DiscordEventHandlers
+  {
     void (*ready)(void);
-    void (*disconnected)(int errorCode, const char* message);
-    void (*errored)(int errorCode, const char* message);
-    void (*joinGame)(const char* joinSecret);
-    void (*spectateGame)(const char* spectateSecret);
-    void (*joinRequest)(const DiscordJoinRequest* request);
-} DiscordEventHandlers;
+    void (*disconnected)(int errorCode, const char *message);
+    void (*errored)(int errorCode, const char *message);
+    void (*joinGame)(const char *joinSecret);
+    void (*spectateGame)(const char *spectateSecret);
+    void (*joinRequest)(const DiscordJoinRequest *request);
+  } DiscordEventHandlers;
 
 #define DISCORD_REPLY_NO 0
 #define DISCORD_REPLY_YES 1
 #define DISCORD_REPLY_IGNORE 2
 
-DISCORD_EXPORT void Discord_Initialize(const char* applicationId,
-                                       DiscordEventHandlers* handlers,
-                                       int autoRegister,
-                                       const char* optionalSteamId);
-DISCORD_EXPORT void Discord_Shutdown(void);
+  DISCORD_EXPORT void Discord_Initialize(const char *applicationId,
+                                         DiscordEventHandlers *handlers,
+                                         int autoRegister,
+                                         const char *optionalSteamId);
+  DISCORD_EXPORT void Discord_Shutdown(void);
 
-/* checks for incoming messages, dispatches callbacks */
-DISCORD_EXPORT void Discord_RunCallbacks(void);
+  /* checks for incoming messages, dispatches callbacks */
+  DISCORD_EXPORT void Discord_RunCallbacks(void);
 
-/* If you disable the lib starting its own io thread, you'll need to call this from your own */
+/* If you disable the lib starting its own io thread, you'll need to call this
+ * from your own */
 #ifdef DISCORD_DISABLE_IO_THREAD
-DISCORD_EXPORT void Discord_UpdateConnection(void);
+  DISCORD_EXPORT void Discord_UpdateConnection(void);
 #endif
 
-DISCORD_EXPORT void Discord_UpdatePresence(const DiscordRichPresence* presence);
-DISCORD_EXPORT void Discord_ClearPresence(void);
+  DISCORD_EXPORT void
+  Discord_UpdatePresence(const DiscordRichPresence *presence);
+  DISCORD_EXPORT void Discord_ClearPresence(void);
 
-DISCORD_EXPORT void Discord_Respond(const char* userid, /* DISCORD_REPLY_ */ int reply);
+  DISCORD_EXPORT void Discord_Respond(const char *userid,
+                                      /* DISCORD_REPLY_ */ int reply);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/discord_register.h
+++ b/discord_register.h
@@ -1,25 +1,28 @@
 #pragma once
 
 #if defined(DISCORD_DYNAMIC_LIB)
-#  if defined(_WIN32)
-#    if defined(DISCORD_BUILDING_SDK)
-#      define DISCORD_EXPORT __declspec(dllexport)
-#    else
-#      define DISCORD_EXPORT __declspec(dllimport)
-#    endif
-#  else
-#    define DISCORD_EXPORT __attribute__((visibility("default")))
-#  endif
+#if defined(_WIN32)
+#if defined(DISCORD_BUILDING_SDK)
+#define DISCORD_EXPORT __declspec(dllexport)
 #else
-#  define DISCORD_EXPORT
+#define DISCORD_EXPORT __declspec(dllimport)
+#endif
+#else
+#define DISCORD_EXPORT __attribute__((visibility("default")))
+#endif
+#else
+#define DISCORD_EXPORT
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-DISCORD_EXPORT void Discord_Register(const char* applicationId, const char* command);
-DISCORD_EXPORT void Discord_RegisterSteamGame(const char* applicationId, const char* steamId);
+  DISCORD_EXPORT void Discord_Register(const char *applicationId,
+                                       const char *command);
+  DISCORD_EXPORT void Discord_RegisterSteamGame(const char *applicationId,
+                                                const char *steamId);
 
 #ifdef __cplusplus
 }

--- a/discord_rich_presence.cpp
+++ b/discord_rich_presence.cpp
@@ -5,24 +5,25 @@
 
 #include <QDebug>
 
-namespace AttorneyOnline {
+namespace AttorneyOnline
+{
 
 Discord::Discord()
 {
-//  DiscordEventHandlers handlers;
-//  std::memset(&handlers, 0, sizeof(handlers));
-//  handlers = {};
-//  handlers.ready = [] {
-//    qInfo() << "Discord RPC ready";
-//  };
-//  handlers.disconnected = [](int errorCode, const char* message) {
-//    qInfo() << "Discord RPC disconnected! " << message;
-//  };
-//  handlers.errored = [](int errorCode, const char* message) {
-//    qWarning() << "Discord RPC errored out! " << message;
-//  };
-//  qInfo() << "Initializing Discord RPC";
-//  Discord_Initialize(APPLICATION_ID1, &handlers, 1, nullptr);
+  //  DiscordEventHandlers handlers;
+  //  std::memset(&handlers, 0, sizeof(handlers));
+  //  handlers = {};
+  //  handlers.ready = [] {
+  //    qInfo() << "Discord RPC ready";
+  //  };
+  //  handlers.disconnected = [](int errorCode, const char* message) {
+  //    qInfo() << "Discord RPC disconnected! " << message;
+  //  };
+  //  handlers.errored = [](int errorCode, const char* message) {
+  //    qWarning() << "Discord RPC errored out! " << message;
+  //  };
+  //  qInfo() << "Initializing Discord RPC";
+  //  Discord_Initialize(APPLICATION_ID1, &handlers, 1, nullptr);
 
   start(APPLICATION_ID[0]);
 }
@@ -35,10 +36,10 @@ void Discord::start(const char *APPLICATION_ID)
   handlers.ready = [] {
     qInfo() << "Discord RPC ready";
   };
-  handlers.disconnected = [](int errorCode, const char* message) {
+  handlers.disconnected = [](int errorCode, const char *message) {
     qInfo() << "Discord RPC disconnected! " << message;
   };
-  handlers.errored = [](int errorCode, const char* message) {
+  handlers.errored = [](int errorCode, const char *message) {
     qWarning() << "Discord RPC errored out! " << message;
   };
   qInfo() << "Initializing Discord RPC";
@@ -58,11 +59,16 @@ void Discord::restart(const char *APPLICATION_ID)
 
 void Discord::toggle(int p_index)
 {
-  if(p_index >=0 && p_index < 2)
+  if (p_index >= 0 && p_index < 2)
+  {
+    if (p_index != m_index)
     {
-      if(p_index!=m_index) { restart(APPLICATION_ID[p_index]); m_index = p_index; }
+      restart(APPLICATION_ID[p_index]);
+      m_index = p_index;
     }
-  else qDebug() << p_index << "is not a valid APPLICATION_ID Index";
+  }
+  else
+    qDebug() << p_index << "is not a valid APPLICATION_ID Index";
 }
 
 void Discord::state_lobby()
@@ -103,10 +109,12 @@ void Discord::state_server(std::string name, std::string server_id)
 
 void Discord::state_character(std::string name)
 {
-  auto name_internal = QString(name.c_str()).toLower().replace(' ', '_').toStdString();
+  auto name_internal =
+      QString(name.c_str()).toLower().replace(' ', '_').toStdString();
   auto name_friendly = QString(name.c_str()).replace('_', ' ').toStdString();
   const std::string playing_as = "Playing as " + name_friendly;
-  qDebug() << "Discord RPC: Setting character state (" << playing_as.c_str() << ")";
+  qDebug() << "Discord RPC: Setting character state (" << playing_as.c_str()
+           << ")";
 
   DiscordRichPresence presence;
   std::memset(&presence, 0, sizeof(presence));
@@ -117,7 +125,7 @@ void Discord::state_character(std::string name)
   presence.startTimestamp = this->timestamp;
 
   presence.state = playing_as.c_str();
-//  presence.smallImageKey = "danganronpa_online";
+  //  presence.smallImageKey = "danganronpa_online";
   presence.smallImageKey = "danganronpa_online";
   presence.smallImageText = "Danganronpa Online";
   Discord_UpdatePresence(&presence);
@@ -140,4 +148,4 @@ void Discord::state_spectate()
   Discord_UpdatePresence(&presence);
 }
 
-}
+} // namespace AttorneyOnline

--- a/discord_rich_presence.cpp
+++ b/discord_rich_presence.cpp
@@ -33,7 +33,9 @@ void Discord::start(const char *APPLICATION_ID)
   DiscordEventHandlers handlers;
   std::memset(&handlers, 0, sizeof(handlers));
   handlers = {};
-  handlers.ready = [] { qInfo() << "Discord RPC ready"; };
+  handlers.ready = [] {
+    qInfo() << "Discord RPC ready";
+  };
   handlers.disconnected = [](int errorCode, const char *message) {
     qInfo() << "Discord RPC disconnected! " << message;
   };
@@ -44,7 +46,10 @@ void Discord::start(const char *APPLICATION_ID)
   Discord_Initialize(APPLICATION_ID, &handlers, 1, nullptr);
 }
 
-Discord::~Discord() { Discord_Shutdown(); }
+Discord::~Discord()
+{
+  Discord_Shutdown();
+}
 
 void Discord::restart(const char *APPLICATION_ID)
 {

--- a/discord_rich_presence.cpp
+++ b/discord_rich_presence.cpp
@@ -33,9 +33,7 @@ void Discord::start(const char *APPLICATION_ID)
   DiscordEventHandlers handlers;
   std::memset(&handlers, 0, sizeof(handlers));
   handlers = {};
-  handlers.ready = [] {
-    qInfo() << "Discord RPC ready";
-  };
+  handlers.ready = [] { qInfo() << "Discord RPC ready"; };
   handlers.disconnected = [](int errorCode, const char *message) {
     qInfo() << "Discord RPC disconnected! " << message;
   };
@@ -46,10 +44,7 @@ void Discord::start(const char *APPLICATION_ID)
   Discord_Initialize(APPLICATION_ID, &handlers, 1, nullptr);
 }
 
-Discord::~Discord()
-{
-  Discord_Shutdown();
-}
+Discord::~Discord() { Discord_Shutdown(); }
 
 void Discord::restart(const char *APPLICATION_ID)
 {

--- a/discord_rich_presence.h
+++ b/discord_rich_presence.h
@@ -1,18 +1,23 @@
 #ifndef DISCORD_RICH_PRESENCE_H
 #define DISCORD_RICH_PRESENCE_H
 
-#include <string>
 #include <discord-rpc.h>
+#include <string>
 
-namespace AttorneyOnline {
+namespace AttorneyOnline
+{
 
 class Discord
 {
 private:
-  const char* APPLICATION_ID[2] = { "538080629535801347" , "538080629535801347", }; // insert second one here blah blah
+  const char *APPLICATION_ID[2] = {
+      "538080629535801347",
+      "538080629535801347",
+  }; // insert second one here blah blah
   int m_index = 0;
   std::string server_name, server_id;
   int64_t timestamp;
+
 public:
   Discord();
   ~Discord();
@@ -26,5 +31,5 @@ public:
   void toggle(int p_index);
 };
 
-}
+} // namespace AttorneyOnline
 #endif // DISCORD_RICH_PRESENCE_H

--- a/discord_rpc.h
+++ b/discord_rpc.h
@@ -20,65 +20,72 @@
 // clang-format on
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct DiscordRichPresence {
-    const char* state;   /* max 128 bytes */
-    const char* details; /* max 128 bytes */
+  typedef struct DiscordRichPresence
+  {
+    const char *state;   /* max 128 bytes */
+    const char *details; /* max 128 bytes */
     int64_t startTimestamp;
     int64_t endTimestamp;
-    const char* largeImageKey;  /* max 32 bytes */
-    const char* largeImageText; /* max 128 bytes */
-    const char* smallImageKey;  /* max 32 bytes */
-    const char* smallImageText; /* max 128 bytes */
-    const char* partyId;        /* max 128 bytes */
+    const char *largeImageKey;  /* max 32 bytes */
+    const char *largeImageText; /* max 128 bytes */
+    const char *smallImageKey;  /* max 32 bytes */
+    const char *smallImageText; /* max 128 bytes */
+    const char *partyId;        /* max 128 bytes */
     int partySize;
     int partyMax;
-    const char* matchSecret;    /* max 128 bytes */
-    const char* joinSecret;     /* max 128 bytes */
-    const char* spectateSecret; /* max 128 bytes */
+    const char *matchSecret;    /* max 128 bytes */
+    const char *joinSecret;     /* max 128 bytes */
+    const char *spectateSecret; /* max 128 bytes */
     int8_t instance;
-} DiscordRichPresence;
+  } DiscordRichPresence;
 
-typedef struct DiscordJoinRequest {
-    const char* userId;
-    const char* username;
-    const char* discriminator;
-    const char* avatar;
-} DiscordJoinRequest;
+  typedef struct DiscordJoinRequest
+  {
+    const char *userId;
+    const char *username;
+    const char *discriminator;
+    const char *avatar;
+  } DiscordJoinRequest;
 
-typedef struct DiscordEventHandlers {
+  typedef struct DiscordEventHandlers
+  {
     void (*ready)(void);
-    void (*disconnected)(int errorCode, const char* message);
-    void (*errored)(int errorCode, const char* message);
-    void (*joinGame)(const char* joinSecret);
-    void (*spectateGame)(const char* spectateSecret);
-    void (*joinRequest)(const DiscordJoinRequest* request);
-} DiscordEventHandlers;
+    void (*disconnected)(int errorCode, const char *message);
+    void (*errored)(int errorCode, const char *message);
+    void (*joinGame)(const char *joinSecret);
+    void (*spectateGame)(const char *spectateSecret);
+    void (*joinRequest)(const DiscordJoinRequest *request);
+  } DiscordEventHandlers;
 
 #define DISCORD_REPLY_NO 0
 #define DISCORD_REPLY_YES 1
 #define DISCORD_REPLY_IGNORE 2
 
-DISCORD_EXPORT void Discord_Initialize(const char* applicationId,
-                                       DiscordEventHandlers* handlers,
-                                       int autoRegister,
-                                       const char* optionalSteamId);
-DISCORD_EXPORT void Discord_Shutdown(void);
+  DISCORD_EXPORT void Discord_Initialize(const char *applicationId,
+                                         DiscordEventHandlers *handlers,
+                                         int autoRegister,
+                                         const char *optionalSteamId);
+  DISCORD_EXPORT void Discord_Shutdown(void);
 
-/* checks for incoming messages, dispatches callbacks */
-DISCORD_EXPORT void Discord_RunCallbacks(void);
+  /* checks for incoming messages, dispatches callbacks */
+  DISCORD_EXPORT void Discord_RunCallbacks(void);
 
-/* If you disable the lib starting its own io thread, you'll need to call this from your own */
+/* If you disable the lib starting its own io thread, you'll need to call this
+ * from your own */
 #ifdef DISCORD_DISABLE_IO_THREAD
-DISCORD_EXPORT void Discord_UpdateConnection(void);
+  DISCORD_EXPORT void Discord_UpdateConnection(void);
 #endif
 
-DISCORD_EXPORT void Discord_UpdatePresence(const DiscordRichPresence* presence);
-DISCORD_EXPORT void Discord_ClearPresence(void);
+  DISCORD_EXPORT void
+  Discord_UpdatePresence(const DiscordRichPresence *presence);
+  DISCORD_EXPORT void Discord_ClearPresence(void);
 
-DISCORD_EXPORT void Discord_Respond(const char* userid, /* DISCORD_REPLY_ */ int reply);
+  DISCORD_EXPORT void Discord_Respond(const char *userid,
+                                      /* DISCORD_REPLY_ */ int reply);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/emotes.cpp
+++ b/emotes.cpp
@@ -6,84 +6,88 @@
 
 void Courtroom::construct_emotes()
 {
-    ui_emotes = new QWidget(this);
+  ui_emotes = new QWidget(this);
 
-    ui_emote_left = new AOButton(this, ao_app);
-    ui_emote_right = new AOButton(this, ao_app);
+  ui_emote_left = new AOButton(this, ao_app);
+  ui_emote_right = new AOButton(this, ao_app);
 
-    ui_emote_dropdown = new QComboBox(this);
-    ui_pos_dropdown = new QComboBox(this);
-    ui_pos_dropdown->addItem("wit", "wit");
-    ui_pos_dropdown->addItem("def", "def");
-    ui_pos_dropdown->addItem("pro", "pro");
-    ui_pos_dropdown->addItem("jud", "jud");
-    ui_pos_dropdown->addItem("hld", "hld");
-    ui_pos_dropdown->addItem("hlp", "hlp");
+  ui_emote_dropdown = new QComboBox(this);
+  ui_pos_dropdown = new QComboBox(this);
+  ui_pos_dropdown->addItem("wit", "wit");
+  ui_pos_dropdown->addItem("def", "def");
+  ui_pos_dropdown->addItem("pro", "pro");
+  ui_pos_dropdown->addItem("jud", "jud");
+  ui_pos_dropdown->addItem("hld", "hld");
+  ui_pos_dropdown->addItem("hlp", "hlp");
 
-    reconstruct_emotes();
+  reconstruct_emotes();
 }
 
 void Courtroom::reconstruct_emotes()
 {
-    // delete previous buttons
-    while (!ui_emote_list.isEmpty())
-        delete ui_emote_list.takeLast();
+  // delete previous buttons
+  while (!ui_emote_list.isEmpty())
+    delete ui_emote_list.takeLast();
 
-    // resize and move
-    set_size_and_pos(ui_emotes, "emotes");
+  // resize and move
+  set_size_and_pos(ui_emotes, "emotes");
 
-    QPoint f_spacing = ao_app->get_button_spacing("emote_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = ao_app->get_button_spacing("emote_button_spacing",
+                                                "courtroom_design.ini");
 
-    const int button_width = 40;
-    int x_spacing = f_spacing.x();
-    int x_mod_count = 0;
+  const int button_width = 40;
+  int x_spacing = f_spacing.x();
+  int x_mod_count = 0;
 
-    const int button_height = 40;
-    int y_spacing = f_spacing.y();
-    int y_mod_count = 0;
+  const int button_height = 40;
+  int y_spacing = f_spacing.y();
+  int y_mod_count = 0;
 
-    emote_columns = ((ui_emotes->width() - button_width) / (x_spacing + button_width)) + 1;
-    emote_rows = ((ui_emotes->height() - button_height) / (y_spacing + button_height)) + 1;
+  emote_columns =
+      ((ui_emotes->width() - button_width) / (x_spacing + button_width)) + 1;
+  emote_rows =
+      ((ui_emotes->height() - button_height) / (y_spacing + button_height)) + 1;
 
-    max_emotes_on_page = emote_columns * emote_rows;
+  max_emotes_on_page = emote_columns * emote_rows;
 
-    for (int n = 0 ; n < max_emotes_on_page ; ++n)
+  for (int n = 0; n < max_emotes_on_page; ++n)
+  {
+    int x_pos = (button_width + x_spacing) * x_mod_count;
+    int y_pos = (button_height + y_spacing) * y_mod_count;
+
+    AOEmoteButton *f_emote = new AOEmoteButton(ui_emotes, ao_app, x_pos, y_pos);
+
+    ui_emote_list.append(f_emote);
+
+    f_emote->set_id(n);
+
+    connect(f_emote, SIGNAL(emote_clicked(int)), this,
+            SLOT(on_emote_clicked(int)));
+
+    ++x_mod_count;
+
+    if (x_mod_count == emote_columns)
     {
-        int x_pos = (button_width + x_spacing) * x_mod_count;
-        int y_pos = (button_height + y_spacing) * y_mod_count;
-
-        AOEmoteButton *f_emote = new AOEmoteButton(ui_emotes, ao_app, x_pos, y_pos);
-
-        ui_emote_list.append(f_emote);
-
-        f_emote->set_id(n);
-
-        connect(f_emote, SIGNAL(emote_clicked(int)), this, SLOT(on_emote_clicked(int)));
-
-        ++x_mod_count;
-
-        if (x_mod_count == emote_columns)
-        {
-            ++y_mod_count;
-            x_mod_count = 0;
-        }
+      ++y_mod_count;
+      x_mod_count = 0;
     }
+  }
 
-    reset_emote_page();
+  reset_emote_page();
 }
 
 void Courtroom::reset_emote_page()
 {
-    current_emote_page = 0;
-    current_emote = 0;
+  current_emote_page = 0;
+  current_emote = 0;
 
-    if (m_cid == -1)
-        ui_emotes->hide();
-    else
-        ui_emotes->show();
+  if (m_cid == -1)
+    ui_emotes->hide();
+  else
+    ui_emotes->show();
 
-    set_emote_page();
-    set_emote_dropdown();
+  set_emote_page();
+  set_emote_dropdown();
 }
 
 void Courtroom::set_emote_page()
@@ -107,12 +111,11 @@ void Courtroom::set_emote_page()
   if (total_emotes % max_emotes_on_page != 0)
   {
     ++total_pages;
-    //i. e. not on the last page
+    // i. e. not on the last page
     if (total_pages > current_emote_page + 1)
       emotes_on_page = max_emotes_on_page;
     else
       emotes_on_page = total_emotes % max_emotes_on_page;
-
   }
   else
     emotes_on_page = max_emotes_on_page;
@@ -123,7 +126,7 @@ void Courtroom::set_emote_page()
   if (current_emote_page > 0)
     ui_emote_left->show();
 
-  for (int n_emote = 0 ; n_emote < emotes_on_page ; ++n_emote)
+  for (int n_emote = 0; n_emote < emotes_on_page; ++n_emote)
   {
     int n_real_emote = n_emote + current_emote_page * max_emotes_on_page;
     AOEmoteButton *f_emote = ui_emote_list.at(n_emote);
@@ -135,7 +138,6 @@ void Courtroom::set_emote_page()
 
     f_emote->show();
   }
-
 }
 
 void Courtroom::set_emote_dropdown()
@@ -145,7 +147,7 @@ void Courtroom::set_emote_dropdown()
   int total_emotes = ao_app->get_emote_number(current_char);
   QStringList emote_list;
 
-  for (int n = 0 ; n < total_emotes ; ++n)
+  for (int n = 0; n < total_emotes; ++n)
   {
     emote_list.append(ao_app->get_emote_comment(current_char, n));
   }
@@ -159,14 +161,16 @@ void Courtroom::select_emote(int p_id)
   int max = (max_emotes_on_page - 1) + current_emote_page * max_emotes_on_page;
 
   if (current_emote >= min && current_emote <= max)
-    ui_emote_list.at(current_emote % max_emotes_on_page)->set_image(current_char, current_emote, "_off.png");
+    ui_emote_list.at(current_emote % max_emotes_on_page)
+        ->set_image(current_char, current_emote, "_off.png");
 
   int old_emote = current_emote;
 
   current_emote = p_id;
 
   if (current_emote >= min && current_emote <= max)
-    ui_emote_list.at(current_emote % max_emotes_on_page)->set_image(current_char, current_emote, "_on.png");
+    ui_emote_list.at(current_emote % max_emotes_on_page)
+        ->set_image(current_char, current_emote, "_on.png");
 
   int emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 

--- a/encryption_functions.cpp
+++ b/encryption_functions.cpp
@@ -2,16 +2,16 @@
 
 #include "hex_functions.h"
 
-#include <cstddef>
-#include <stdlib.h>
-#include <sstream>
-#include <iomanip>
 #include <QVector>
+#include <cstddef>
+#include <iomanip>
+#include <sstream>
+#include <stdlib.h>
 
 QString fanta_encrypt(QString temp_input, unsigned int p_key)
 {
-  //using standard stdlib types is actually easier here because of implicit char<->int conversion
-  //which in turn makes encryption arithmetic easier
+  // using standard stdlib types is actually easier here because of implicit
+  // char<->int conversion which in turn makes encryption arithmetic easier
 
   unsigned int key = p_key;
   unsigned int C1 = 53761;
@@ -20,7 +20,7 @@ QString fanta_encrypt(QString temp_input, unsigned int p_key)
   QVector<uint_fast8_t> temp_result;
   std::string input = temp_input.toUtf8().constData();
 
-  for (unsigned int pos = 0 ; pos < input.size() ; ++pos)
+  for (unsigned int pos = 0; pos < input.size(); ++pos)
   {
     uint_fast8_t output = input.at(pos) ^ (key >> 8) % 256;
     temp_result.append(output);
@@ -45,9 +45,9 @@ QString fanta_decrypt(QString temp_input, unsigned int key)
 
   QVector<unsigned int> unhexed_vector;
 
-  for(unsigned int i=0; i< input.length(); i+=2)
+  for (unsigned int i = 0; i < input.length(); i += 2)
   {
-    std::string byte = input.substr(i,2);
+    std::string byte = input.substr(i, 2);
     unsigned int hex_int = strtoul(byte.c_str(), nullptr, 16);
     unhexed_vector.append(hex_int);
   }
@@ -57,7 +57,7 @@ QString fanta_decrypt(QString temp_input, unsigned int key)
 
   std::string result = "";
 
-  for (int pos = 0 ; pos < unhexed_vector.size() ; ++pos)
+  for (int pos = 0; pos < unhexed_vector.size(); ++pos)
   {
     unsigned char output = unhexed_vector.at(pos) ^ (key >> 8) % 256;
     result += output;
@@ -65,5 +65,4 @@ QString fanta_decrypt(QString temp_input, unsigned int key)
   }
 
   return QString::fromStdString(result);
-
 }

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -7,7 +7,7 @@ void Courtroom::construct_evidence()
 {
   ui_evidence = new AOImage(this, ao_app);
 
-  //ui_evidence_name = new QLabel(ui_evidence);
+  // ui_evidence_name = new QLabel(ui_evidence);
   ui_evidence_name = new AOLineEdit(ui_evidence);
   ui_evidence_name->setAlignment(Qt::AlignCenter);
   ui_evidence_name->setFont(QFont("Arial", 14, QFont::Bold));
@@ -35,7 +35,8 @@ void Courtroom::construct_evidence()
   set_size_and_pos(ui_evidence, "evidence_background");
   set_size_and_pos(ui_evidence_buttons, "evidence_buttons");
 
-  QPoint f_spacing = ao_app->get_button_spacing("evidence_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = ao_app->get_button_spacing("evidence_button_spacing",
+                                                "courtroom_design.ini");
 
   const int button_width = 70;
   int x_spacing = f_spacing.x();
@@ -45,25 +46,33 @@ void Courtroom::construct_evidence()
   int y_spacing = f_spacing.y();
   int y_mod_count = 0;
 
-  evidence_columns = ((ui_evidence_buttons->width() - button_width) / (x_spacing + button_width)) + 1;
-  evidence_rows = ((ui_evidence_buttons->height() - button_height) / (y_spacing + button_height)) + 1;
+  evidence_columns = ((ui_evidence_buttons->width() - button_width) /
+                      (x_spacing + button_width)) +
+                     1;
+  evidence_rows = ((ui_evidence_buttons->height() - button_height) /
+                   (y_spacing + button_height)) +
+                  1;
 
   max_evidence_on_page = evidence_columns * evidence_rows;
 
-  for (int n = 0 ; n < max_evidence_on_page ; ++n)
+  for (int n = 0; n < max_evidence_on_page; ++n)
   {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
-    AOEvidenceButton *f_evidence = new AOEvidenceButton(ui_evidence_buttons, ao_app, x_pos, y_pos);
+    AOEvidenceButton *f_evidence =
+        new AOEvidenceButton(ui_evidence_buttons, ao_app, x_pos, y_pos);
 
     ui_evidence_list.append(f_evidence);
 
     f_evidence->set_id(n);
 
-    connect(f_evidence, SIGNAL(evidence_clicked(int)), this, SLOT(on_evidence_clicked(int)));
-    connect(f_evidence, SIGNAL(evidence_double_clicked(int)), this, SLOT(on_evidence_double_clicked(int)));
-    connect(f_evidence, SIGNAL(on_hover(int, bool)), this, SLOT(on_evidence_hover(int, bool)));
+    connect(f_evidence, SIGNAL(evidence_clicked(int)), this,
+            SLOT(on_evidence_clicked(int)));
+    connect(f_evidence, SIGNAL(evidence_double_clicked(int)), this,
+            SLOT(on_evidence_double_clicked(int)));
+    connect(f_evidence, SIGNAL(on_hover(int, bool)), this,
+            SLOT(on_evidence_hover(int, bool)));
 
     ++x_mod_count;
 
@@ -74,14 +83,22 @@ void Courtroom::construct_evidence()
     }
   }
 
-  connect(ui_evidence_name, SIGNAL(returnPressed()), this, SLOT(on_evidence_name_edited()));
-  connect(ui_evidence_left, SIGNAL(clicked()), this, SLOT(on_evidence_left_clicked()));
-  connect(ui_evidence_right, SIGNAL(clicked()), this, SLOT(on_evidence_right_clicked()));
-  connect(ui_evidence_present, SIGNAL(clicked()), this, SLOT(on_evidence_present_clicked()));
-  connect(ui_evidence_delete, SIGNAL(clicked()), this, SLOT(on_evidence_delete_clicked()));
-  connect(ui_evidence_image_name, SIGNAL(returnPressed()), this, SLOT(on_evidence_image_name_edited()));
-  connect(ui_evidence_image_button, SIGNAL(clicked()), this, SLOT(on_evidence_image_button_clicked()));
-  connect(ui_evidence_x, SIGNAL(clicked()), this, SLOT(on_evidence_x_clicked()));
+  connect(ui_evidence_name, SIGNAL(returnPressed()), this,
+          SLOT(on_evidence_name_edited()));
+  connect(ui_evidence_left, SIGNAL(clicked()), this,
+          SLOT(on_evidence_left_clicked()));
+  connect(ui_evidence_right, SIGNAL(clicked()), this,
+          SLOT(on_evidence_right_clicked()));
+  connect(ui_evidence_present, SIGNAL(clicked()), this,
+          SLOT(on_evidence_present_clicked()));
+  connect(ui_evidence_delete, SIGNAL(clicked()), this,
+          SLOT(on_evidence_delete_clicked()));
+  connect(ui_evidence_image_name, SIGNAL(returnPressed()), this,
+          SLOT(on_evidence_image_name_edited()));
+  connect(ui_evidence_image_button, SIGNAL(clicked()), this,
+          SLOT(on_evidence_image_button_clicked()));
+  connect(ui_evidence_x, SIGNAL(clicked()), this,
+          SLOT(on_evidence_x_clicked()));
 
   ui_evidence->hide();
 }
@@ -106,7 +123,7 @@ void Courtroom::set_evidence_page()
     i_button->reset();
   }
 
-  //to account for the "add evidence" button
+  // to account for the "add evidence" button
   ++total_evidence;
 
   int total_pages = total_evidence / max_evidence_on_page;
@@ -115,12 +132,11 @@ void Courtroom::set_evidence_page()
   if ((total_evidence % max_evidence_on_page) != 0)
   {
     ++total_pages;
-    //i. e. not on the last page
+    // i. e. not on the last page
     if (total_pages > current_evidence_page + 1)
       evidence_on_page = max_evidence_on_page;
     else
       evidence_on_page = total_evidence % max_evidence_on_page;
-
   }
   else
     evidence_on_page = max_evidence_on_page;
@@ -131,17 +147,21 @@ void Courtroom::set_evidence_page()
   if (current_evidence_page > 0)
     ui_evidence_left->show();
 
-  for (int n_evidence_button = 0 ; n_evidence_button < evidence_on_page ; ++n_evidence_button)
+  for (int n_evidence_button = 0; n_evidence_button < evidence_on_page;
+       ++n_evidence_button)
   {
-    int n_real_evidence = n_evidence_button + current_evidence_page * max_evidence_on_page;
-    AOEvidenceButton *f_evidence_button = ui_evidence_list.at(n_evidence_button);
+    int n_real_evidence =
+        n_evidence_button + current_evidence_page * max_evidence_on_page;
+    AOEvidenceButton *f_evidence_button =
+        ui_evidence_list.at(n_evidence_button);
 
-    //ie. the add evidence button
+    // ie. the add evidence button
     if (n_real_evidence == (total_evidence - 1))
       f_evidence_button->set_theme_image("addevidence.png");
     else if (n_real_evidence < (total_evidence - 1))
     {
-      f_evidence_button->set_image(local_evidence_list.at(n_real_evidence).image);
+      f_evidence_button->set_image(
+          local_evidence_list.at(n_real_evidence).image);
 
       if (n_real_evidence == current_evidence)
         f_evidence_button->set_selected(true);
@@ -200,7 +220,7 @@ void Courtroom::on_evidence_image_button_clicked()
   QStringList filenames;
 
   if (dialog.exec())
-      filenames = dialog.selectedFiles();
+    filenames = dialog.selectedFiles();
 
   if (filenames.size() != 1)
     return;
@@ -224,7 +244,8 @@ void Courtroom::on_evidence_clicked(int p_id)
 
   if (f_real_id == local_evidence_list.size())
   {
-    ao_app->send_server_packet(new AOPacket("PE#<name>#<description>#empty.png#%"));
+    ao_app->send_server_packet(
+        new AOPacket("PE#<name>#<description>#empty.png#%"));
     return;
   }
   else if (f_real_id > local_evidence_list.size())
@@ -240,7 +261,6 @@ void Courtroom::on_evidence_clicked(int p_id)
   current_evidence = f_real_id;
 
   ui_ic_chat_message->setFocus();
-
 }
 
 void Courtroom::on_evidence_double_clicked(int p_id)
@@ -317,7 +337,8 @@ void Courtroom::on_evidence_delete_clicked()
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 
-  ao_app->send_server_packet(new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
+  ao_app->send_server_packet(
+      new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
 
   current_evidence = 0;
 
@@ -345,4 +366,3 @@ void Courtroom::on_evidence_x_clicked()
 
   ui_ic_chat_message->setFocus();
 }
-

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -3,7 +3,8 @@
 #include <QDebug>
 #include <QFileDialog>
 
-void Courtroom::construct_evidence() {
+void Courtroom::construct_evidence()
+{
   ui_evidence = new AOImage(this, ao_app);
 
   // ui_evidence_name = new QLabel(ui_evidence);
@@ -54,7 +55,8 @@ void Courtroom::construct_evidence() {
 
   max_evidence_on_page = evidence_columns * evidence_rows;
 
-  for (int n = 0; n < max_evidence_on_page; ++n) {
+  for (int n = 0; n < max_evidence_on_page; ++n)
+  {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
@@ -74,7 +76,8 @@ void Courtroom::construct_evidence() {
 
     ++x_mod_count;
 
-    if (x_mod_count == evidence_columns) {
+    if (x_mod_count == evidence_columns)
+    {
       ++y_mod_count;
       x_mod_count = 0;
     }
@@ -100,20 +103,23 @@ void Courtroom::construct_evidence() {
   ui_evidence->hide();
 }
 
-void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list) {
+void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list)
+{
   local_evidence_list.clear();
   local_evidence_list = p_evi_list;
 
   set_evidence_page();
 }
 
-void Courtroom::set_evidence_page() {
+void Courtroom::set_evidence_page()
+{
   int total_evidence = local_evidence_list.size();
 
   ui_evidence_left->hide();
   ui_evidence_right->hide();
 
-  for (AOEvidenceButton *i_button : ui_evidence_list) {
+  for (AOEvidenceButton *i_button : ui_evidence_list)
+  {
     i_button->reset();
   }
 
@@ -123,15 +129,16 @@ void Courtroom::set_evidence_page() {
   int total_pages = total_evidence / max_evidence_on_page;
   int evidence_on_page = 0;
 
-  if ((total_evidence % max_evidence_on_page) != 0) {
+  if ((total_evidence % max_evidence_on_page) != 0)
+  {
     ++total_pages;
     // i. e. not on the last page
     if (total_pages > current_evidence_page + 1)
       evidence_on_page = max_evidence_on_page;
     else
       evidence_on_page = total_evidence % max_evidence_on_page;
-
-  } else
+  }
+  else
     evidence_on_page = max_evidence_on_page;
 
   if (total_pages > current_evidence_page + 1)
@@ -141,7 +148,8 @@ void Courtroom::set_evidence_page() {
     ui_evidence_left->show();
 
   for (int n_evidence_button = 0; n_evidence_button < evidence_on_page;
-       ++n_evidence_button) {
+       ++n_evidence_button)
+  {
     int n_real_evidence =
         n_evidence_button + current_evidence_page * max_evidence_on_page;
     AOEvidenceButton *f_evidence_button =
@@ -150,7 +158,8 @@ void Courtroom::set_evidence_page() {
     // ie. the add evidence button
     if (n_real_evidence == (total_evidence - 1))
       f_evidence_button->set_theme_image("addevidence.png");
-    else if (n_real_evidence < (total_evidence - 1)) {
+    else if (n_real_evidence < (total_evidence - 1))
+    {
       f_evidence_button->set_image(
           local_evidence_list.at(n_real_evidence).image);
 
@@ -158,14 +167,16 @@ void Courtroom::set_evidence_page() {
         f_evidence_button->set_selected(true);
       else
         f_evidence_button->set_selected(false);
-    } else
+    }
+    else
       f_evidence_button->set_image("");
 
     f_evidence_button->show();
   }
 }
 
-void Courtroom::on_evidence_name_edited() {
+void Courtroom::on_evidence_name_edited()
+{
   if (current_evidence >= local_evidence_list.size())
     return;
 
@@ -181,7 +192,8 @@ void Courtroom::on_evidence_name_edited() {
   ao_app->send_server_packet(new AOPacket("EE", f_contents));
 }
 
-void Courtroom::on_evidence_image_name_edited() {
+void Courtroom::on_evidence_image_name_edited()
+{
   if (current_evidence >= local_evidence_list.size())
     return;
 
@@ -197,7 +209,8 @@ void Courtroom::on_evidence_image_name_edited() {
   ao_app->send_server_packet(new AOPacket("EE", f_contents));
 }
 
-void Courtroom::on_evidence_image_button_clicked() {
+void Courtroom::on_evidence_image_button_clicked()
+{
   QFileDialog dialog(this);
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilter(tr("Images (*.png)"));
@@ -223,16 +236,19 @@ void Courtroom::on_evidence_image_button_clicked() {
   on_evidence_image_name_edited();
 }
 
-void Courtroom::on_evidence_clicked(int p_id) {
+void Courtroom::on_evidence_clicked(int p_id)
+{
   ui_evidence_name->setReadOnly(true);
 
   int f_real_id = p_id + max_evidence_on_page * current_evidence_page;
 
-  if (f_real_id == local_evidence_list.size()) {
+  if (f_real_id == local_evidence_list.size())
+  {
     ao_app->send_server_packet(
         new AOPacket("PE#<name>#<description>#empty.png#%"));
     return;
-  } else if (f_real_id > local_evidence_list.size())
+  }
+  else if (f_real_id > local_evidence_list.size())
     return;
 
   ui_evidence_name->setText(local_evidence_list.at(f_real_id).name);
@@ -247,7 +263,8 @@ void Courtroom::on_evidence_clicked(int p_id) {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_double_clicked(int p_id) {
+void Courtroom::on_evidence_double_clicked(int p_id)
+{
   int f_real_id = p_id + max_evidence_on_page * current_evidence_page;
 
   if (f_real_id >= local_evidence_list.size())
@@ -267,22 +284,26 @@ void Courtroom::on_evidence_double_clicked(int p_id) {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_hover(int p_id, bool p_state) {
+void Courtroom::on_evidence_hover(int p_id, bool p_state)
+{
   ui_evidence_name->setReadOnly(true);
   int final_id = p_id + max_evidence_on_page * current_evidence_page;
 
-  if (p_state) {
+  if (p_state)
+  {
     if (final_id == local_evidence_list.size())
       ui_evidence_name->setText("Add new evidence...");
     else if (final_id < local_evidence_list.size())
       ui_evidence_name->setText(local_evidence_list.at(final_id).name);
-  } else if (current_evidence < local_evidence_list.size())
+  }
+  else if (current_evidence < local_evidence_list.size())
     ui_evidence_name->setText(local_evidence_list.at(current_evidence).name);
   else
     ui_evidence_name->setText("");
 }
 
-void Courtroom::on_evidence_left_clicked() {
+void Courtroom::on_evidence_left_clicked()
+{
   --current_evidence_page;
 
   set_evidence_page();
@@ -290,7 +311,8 @@ void Courtroom::on_evidence_left_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_right_clicked() {
+void Courtroom::on_evidence_right_clicked()
+{
   ++current_evidence_page;
 
   set_evidence_page();
@@ -298,7 +320,8 @@ void Courtroom::on_evidence_right_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_present_clicked() {
+void Courtroom::on_evidence_present_clicked()
+{
   if (is_presenting_evidence)
     ui_evidence_present->set_image("present_disabled.png");
   else
@@ -309,7 +332,8 @@ void Courtroom::on_evidence_present_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_delete_clicked() {
+void Courtroom::on_evidence_delete_clicked()
+{
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 
@@ -321,7 +345,8 @@ void Courtroom::on_evidence_delete_clicked() {
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_x_clicked() {
+void Courtroom::on_evidence_x_clicked()
+{
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -3,8 +3,7 @@
 #include <QDebug>
 #include <QFileDialog>
 
-void Courtroom::construct_evidence()
-{
+void Courtroom::construct_evidence() {
   ui_evidence = new AOImage(this, ao_app);
 
   // ui_evidence_name = new QLabel(ui_evidence);
@@ -55,8 +54,7 @@ void Courtroom::construct_evidence()
 
   max_evidence_on_page = evidence_columns * evidence_rows;
 
-  for (int n = 0; n < max_evidence_on_page; ++n)
-  {
+  for (int n = 0; n < max_evidence_on_page; ++n) {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
@@ -76,8 +74,7 @@ void Courtroom::construct_evidence()
 
     ++x_mod_count;
 
-    if (x_mod_count == evidence_columns)
-    {
+    if (x_mod_count == evidence_columns) {
       ++y_mod_count;
       x_mod_count = 0;
     }
@@ -103,23 +100,20 @@ void Courtroom::construct_evidence()
   ui_evidence->hide();
 }
 
-void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list)
-{
+void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list) {
   local_evidence_list.clear();
   local_evidence_list = p_evi_list;
 
   set_evidence_page();
 }
 
-void Courtroom::set_evidence_page()
-{
+void Courtroom::set_evidence_page() {
   int total_evidence = local_evidence_list.size();
 
   ui_evidence_left->hide();
   ui_evidence_right->hide();
 
-  for (AOEvidenceButton *i_button : ui_evidence_list)
-  {
+  for (AOEvidenceButton *i_button : ui_evidence_list) {
     i_button->reset();
   }
 
@@ -129,16 +123,15 @@ void Courtroom::set_evidence_page()
   int total_pages = total_evidence / max_evidence_on_page;
   int evidence_on_page = 0;
 
-  if ((total_evidence % max_evidence_on_page) != 0)
-  {
+  if ((total_evidence % max_evidence_on_page) != 0) {
     ++total_pages;
     // i. e. not on the last page
     if (total_pages > current_evidence_page + 1)
       evidence_on_page = max_evidence_on_page;
     else
       evidence_on_page = total_evidence % max_evidence_on_page;
-  }
-  else
+
+  } else
     evidence_on_page = max_evidence_on_page;
 
   if (total_pages > current_evidence_page + 1)
@@ -148,8 +141,7 @@ void Courtroom::set_evidence_page()
     ui_evidence_left->show();
 
   for (int n_evidence_button = 0; n_evidence_button < evidence_on_page;
-       ++n_evidence_button)
-  {
+       ++n_evidence_button) {
     int n_real_evidence =
         n_evidence_button + current_evidence_page * max_evidence_on_page;
     AOEvidenceButton *f_evidence_button =
@@ -158,8 +150,7 @@ void Courtroom::set_evidence_page()
     // ie. the add evidence button
     if (n_real_evidence == (total_evidence - 1))
       f_evidence_button->set_theme_image("addevidence.png");
-    else if (n_real_evidence < (total_evidence - 1))
-    {
+    else if (n_real_evidence < (total_evidence - 1)) {
       f_evidence_button->set_image(
           local_evidence_list.at(n_real_evidence).image);
 
@@ -167,16 +158,14 @@ void Courtroom::set_evidence_page()
         f_evidence_button->set_selected(true);
       else
         f_evidence_button->set_selected(false);
-    }
-    else
+    } else
       f_evidence_button->set_image("");
 
     f_evidence_button->show();
   }
 }
 
-void Courtroom::on_evidence_name_edited()
-{
+void Courtroom::on_evidence_name_edited() {
   if (current_evidence >= local_evidence_list.size())
     return;
 
@@ -192,8 +181,7 @@ void Courtroom::on_evidence_name_edited()
   ao_app->send_server_packet(new AOPacket("EE", f_contents));
 }
 
-void Courtroom::on_evidence_image_name_edited()
-{
+void Courtroom::on_evidence_image_name_edited() {
   if (current_evidence >= local_evidence_list.size())
     return;
 
@@ -209,13 +197,12 @@ void Courtroom::on_evidence_image_name_edited()
   ao_app->send_server_packet(new AOPacket("EE", f_contents));
 }
 
-void Courtroom::on_evidence_image_button_clicked()
-{
+void Courtroom::on_evidence_image_button_clicked() {
   QFileDialog dialog(this);
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilter(tr("Images (*.png)"));
   dialog.setViewMode(QFileDialog::List);
-  dialog.setDirectory(ao_app->get_evidence_path());
+  dialog.setDirectory(ao_app->get_evidence_path(""));
 
   QStringList filenames;
 
@@ -236,19 +223,16 @@ void Courtroom::on_evidence_image_button_clicked()
   on_evidence_image_name_edited();
 }
 
-void Courtroom::on_evidence_clicked(int p_id)
-{
+void Courtroom::on_evidence_clicked(int p_id) {
   ui_evidence_name->setReadOnly(true);
 
   int f_real_id = p_id + max_evidence_on_page * current_evidence_page;
 
-  if (f_real_id == local_evidence_list.size())
-  {
+  if (f_real_id == local_evidence_list.size()) {
     ao_app->send_server_packet(
         new AOPacket("PE#<name>#<description>#empty.png#%"));
     return;
-  }
-  else if (f_real_id > local_evidence_list.size())
+  } else if (f_real_id > local_evidence_list.size())
     return;
 
   ui_evidence_name->setText(local_evidence_list.at(f_real_id).name);
@@ -263,8 +247,7 @@ void Courtroom::on_evidence_clicked(int p_id)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_double_clicked(int p_id)
-{
+void Courtroom::on_evidence_double_clicked(int p_id) {
   int f_real_id = p_id + max_evidence_on_page * current_evidence_page;
 
   if (f_real_id >= local_evidence_list.size())
@@ -284,26 +267,22 @@ void Courtroom::on_evidence_double_clicked(int p_id)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_hover(int p_id, bool p_state)
-{
+void Courtroom::on_evidence_hover(int p_id, bool p_state) {
   ui_evidence_name->setReadOnly(true);
   int final_id = p_id + max_evidence_on_page * current_evidence_page;
 
-  if (p_state)
-  {
+  if (p_state) {
     if (final_id == local_evidence_list.size())
       ui_evidence_name->setText("Add new evidence...");
     else if (final_id < local_evidence_list.size())
       ui_evidence_name->setText(local_evidence_list.at(final_id).name);
-  }
-  else if (current_evidence < local_evidence_list.size())
+  } else if (current_evidence < local_evidence_list.size())
     ui_evidence_name->setText(local_evidence_list.at(current_evidence).name);
   else
     ui_evidence_name->setText("");
 }
 
-void Courtroom::on_evidence_left_clicked()
-{
+void Courtroom::on_evidence_left_clicked() {
   --current_evidence_page;
 
   set_evidence_page();
@@ -311,8 +290,7 @@ void Courtroom::on_evidence_left_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_right_clicked()
-{
+void Courtroom::on_evidence_right_clicked() {
   ++current_evidence_page;
 
   set_evidence_page();
@@ -320,8 +298,7 @@ void Courtroom::on_evidence_right_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_present_clicked()
-{
+void Courtroom::on_evidence_present_clicked() {
   if (is_presenting_evidence)
     ui_evidence_present->set_image("present_disabled.png");
   else
@@ -332,8 +309,7 @@ void Courtroom::on_evidence_present_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_delete_clicked()
-{
+void Courtroom::on_evidence_delete_clicked() {
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 
@@ -345,8 +321,7 @@ void Courtroom::on_evidence_delete_clicked()
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_evidence_x_clicked()
-{
+void Courtroom::on_evidence_x_clicked() {
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 

--- a/file_functions.cpp
+++ b/file_functions.cpp
@@ -1,5 +1,5 @@
-#include <QFileInfo>
 #include <QDir>
+#include <QFileInfo>
 
 #include "file_functions.h"
 
@@ -12,9 +12,9 @@ bool file_exists(QString file_path)
 
 QString file_exists(QString file_path, QVector<QString> p_exts)
 {
-  for(auto &ext : p_exts)
+  for (auto &ext : p_exts)
   {
-    if(file_exists(file_path + ext))
+    if (file_exists(file_path + ext))
       return ext;
   }
   return "";

--- a/file_functions.cpp
+++ b/file_functions.cpp
@@ -3,13 +3,15 @@
 
 #include "file_functions.h"
 
-bool file_exists(QString file_path) {
+bool file_exists(QString file_path)
+{
   QFileInfo check_file(file_path);
 
   return check_file.exists() && check_file.isFile();
 }
 
-bool dir_exists(QString dir_path) {
+bool dir_exists(QString dir_path)
+{
   QDir check_dir(dir_path);
 
   return check_dir.exists();

--- a/file_functions.cpp
+++ b/file_functions.cpp
@@ -3,25 +3,13 @@
 
 #include "file_functions.h"
 
-bool file_exists(QString file_path)
-{
+bool file_exists(QString file_path) {
   QFileInfo check_file(file_path);
 
   return check_file.exists() && check_file.isFile();
 }
 
-QString file_exists(QString file_path, QVector<QString> p_exts)
-{
-  for (auto &ext : p_exts)
-  {
-    if (file_exists(file_path + ext))
-      return ext;
-  }
-  return "";
-}
-
-bool dir_exists(QString dir_path)
-{
+bool dir_exists(QString dir_path) {
   QDir check_dir(dir_path);
 
   return check_dir.exists();

--- a/file_functions.h
+++ b/file_functions.h
@@ -5,7 +5,6 @@
 #include <QVector>
 
 bool file_exists(QString file_path);
-QString file_exists(QString file_path, QVector<QString> p_exts);
 bool dir_exists(QString file_path);
 
 #endif // FILE_FUNCTIONS_H

--- a/hardware_functions.cpp
+++ b/hardware_functions.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-#if (defined (_WIN32) || defined (_WIN64))
+#if (defined(_WIN32) || defined(_WIN64))
 #include <windows.h>
 
 DWORD dwVolSerial;
@@ -10,18 +10,18 @@ BOOL bIsRetrieved;
 
 QString get_hdid()
 {
-  bIsRetrieved = GetVolumeInformation(TEXT("C:\\"), NULL, NULL, &dwVolSerial, NULL, NULL, NULL, NULL);
+  bIsRetrieved = GetVolumeInformation(TEXT("C:\\"), NULL, NULL, &dwVolSerial,
+                                      NULL, NULL, NULL, NULL);
 
   if (bIsRetrieved)
     return QString::number(dwVolSerial, 16);
   else
-    //a totally random string
-    //what could possibly go wrong
+    // a totally random string
+    // what could possibly go wrong
     return "gxsps32sa9fnwic92mfbs0";
-
 }
 
-#elif (defined (LINUX) || defined (__linux__))
+#elif (defined(LINUX) || defined(__linux__))
 
 #include <QFile>
 #include <QTextStream>
@@ -34,7 +34,7 @@ QString get_hdid()
 
   QTextStream in(&fstab_file);
 
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString line = in.readLine();
 

--- a/hex_functions.cpp
+++ b/hex_functions.cpp
@@ -1,83 +1,85 @@
-//WELCOME TO THE EXTREMELY GHETTO HEX CONVERSION KLUDGE BECAUSE I COULDNT MAKE ANYTHING ELSE WORK
+// WELCOME TO THE EXTREMELY GHETTO HEX CONVERSION KLUDGE BECAUSE I COULDNT MAKE
+// ANYTHING ELSE WORK
 
 #include "hex_functions.h"
 
 namespace omni
 {
-  char halfword_to_hex_char(unsigned int input)
+char halfword_to_hex_char(unsigned int input)
+{
+  if (input > 127)
+    return 'F';
+
+  switch (input)
   {
-    if (input > 127)
-      return 'F';
-
-    switch (input)
-    {
-    case 0:
-      return '0';
-    case 1:
-      return '1';
-    case 2:
-      return '2';
-    case 3:
-      return '3';
-    case 4:
-      return '4';
-    case 5:
-      return '5';
-    case 6:
-      return '6';
-    case 7:
-      return '7';
-    case 8:
-      return '8';
-    case 9:
-      return '9';
-    case 10:
-      return 'A';
-    case 11:
-      return 'B';
-    case 12:
-      return 'C';
-    case 13:
-      return 'D';
-    case 14:
-      return 'E';
-    case 15:
-      return 'F';
-    default:
-      return 'F';
-    }
+  case 0:
+    return '0';
+  case 1:
+    return '1';
+  case 2:
+    return '2';
+  case 3:
+    return '3';
+  case 4:
+    return '4';
+  case 5:
+    return '5';
+  case 6:
+    return '6';
+  case 7:
+    return '7';
+  case 8:
+    return '8';
+  case 9:
+    return '9';
+  case 10:
+    return 'A';
+  case 11:
+    return 'B';
+  case 12:
+    return 'C';
+  case 13:
+    return 'D';
+  case 14:
+    return 'E';
+  case 15:
+    return 'F';
+  default:
+    return 'F';
   }
+}
 
-  std::string int_to_hex(unsigned int input)
-  {
-    if (input > 255)
-      return "FF";
+std::string int_to_hex(unsigned int input)
+{
+  if (input > 255)
+    return "FF";
 
-    std::bitset<8> whole_byte(input);
-    //240 represents 11110000, our needed bitmask
-    uint8_t left_mask_int = 240;
-    std::bitset<8> left_mask(left_mask_int);
-    std::bitset<8> left_halfword((whole_byte & left_mask) >> 4);
-    //likewise, 15 represents 00001111
-    uint8_t right_mask_int = 15;
-    std::bitset<8> right_mask(right_mask_int);
-    std::bitset<8> right_halfword((whole_byte & right_mask));
+  std::bitset<8> whole_byte(input);
+  // 240 represents 11110000, our needed bitmask
+  uint8_t left_mask_int = 240;
+  std::bitset<8> left_mask(left_mask_int);
+  std::bitset<8> left_halfword((whole_byte & left_mask) >> 4);
+  // likewise, 15 represents 00001111
+  uint8_t right_mask_int = 15;
+  std::bitset<8> right_mask(right_mask_int);
+  std::bitset<8> right_halfword((whole_byte & right_mask));
 
-    unsigned int left = left_halfword.to_ulong();
-    unsigned int right = right_halfword.to_ulong();
+  unsigned int left = left_halfword.to_ulong();
+  unsigned int right = right_halfword.to_ulong();
 
-    //std::cout << "now have have " << left << " and " << right << '\n';
+  // std::cout << "now have have " << left << " and " << right << '\n';
 
-    char a = halfword_to_hex_char(left);
-    char b = halfword_to_hex_char(right);
+  char a = halfword_to_hex_char(left);
+  char b = halfword_to_hex_char(right);
 
-    std::string left_string(1, a);
-    std::string right_string(1, b);
+  std::string left_string(1, a);
+  std::string right_string(1, b);
 
-    std::string final_byte = left_string + right_string;
+  std::string final_byte = left_string + right_string;
 
-    //std::string final_byte = halfword_to_hex_char(left) + "" + halfword_to_hex_char(right);
+  // std::string final_byte = halfword_to_hex_char(left) + "" +
+  // halfword_to_hex_char(right);
 
-    return final_byte;
-  }
-} //namespace omni
+  return final_byte;
+}
+} // namespace omni

--- a/hex_functions.h
+++ b/hex_functions.h
@@ -7,8 +7,8 @@
 
 namespace omni
 {
-  char halfword_to_hex_char(unsigned int input);
-  std::string int_to_hex(unsigned int input);
-}
+char halfword_to_hex_char(unsigned int input);
+std::string int_to_hex(unsigned int input);
+} // namespace omni
 
-#endif //HEX_OPERATIONS_H
+#endif // HEX_OPERATIONS_H

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -284,7 +284,10 @@ QString Lobby::get_chatlog()
   return return_value;
 }
 
-int Lobby::get_selected_server() { return ui_server_list->currentRow(); }
+int Lobby::get_selected_server()
+{
+  return ui_server_list->currentRow();
+}
 
 void Lobby::set_loading_value(int p_value)
 {

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -12,236 +12,249 @@
 
 Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 {
-    ao_app = p_ao_app;
+  ao_app = p_ao_app;
 
-    this->setWindowTitle("Danganronpa Online");
+  this->setWindowTitle("Danganronpa Online");
 
-    ui_background     = new AOImage(this, ao_app);
-    ui_public_servers = new AOButton(this, ao_app);
-    ui_favorites      = new AOButton(this, ao_app);
-    ui_refresh        = new AOButton(this, ao_app);
-    ui_add_to_fav     = new AOButton(this, ao_app);
-    ui_connect        = new AOButton(this, ao_app);
-    ui_version        = new QTextEdit(this);
-    ui_version->setFrameStyle(QFrame::NoFrame);
-    ui_version->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    ui_version->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    ui_version->setReadOnly(true);
-    ui_about          = new AOButton(this, ao_app);
-    ui_server_list    = new QListWidget(this);
-    ui_player_count   = new QTextEdit(this);
-    ui_player_count->setFrameStyle(QFrame::NoFrame);
-    ui_player_count->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    ui_player_count->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    ui_player_count->setReadOnly(true);
-    ui_description    = new AOTextArea(this);
-    ui_chatbox        = new AOTextArea(this);
-    ui_chatbox->setOpenExternalLinks(true);
-    ui_chatname = new QLineEdit(this);
-    ui_chatname->setPlaceholderText("Name");
-    ui_chatmessage        = new QLineEdit(this);
-    ui_loading_background = new AOImage(this, ao_app);
-    ui_loading_text       = new QTextEdit(ui_loading_background);
-    ui_progress_bar       = new QProgressBar(ui_loading_background);
-    ui_progress_bar->setMinimum(0);
-    ui_progress_bar->setMaximum(100);
-    ui_progress_bar->setStyleSheet("QProgressBar{ color: white; }");
-    ui_cancel = new AOButton(ui_loading_background, ao_app);
+  ui_background = new AOImage(this, ao_app);
+  ui_public_servers = new AOButton(this, ao_app);
+  ui_favorites = new AOButton(this, ao_app);
+  ui_refresh = new AOButton(this, ao_app);
+  ui_add_to_fav = new AOButton(this, ao_app);
+  ui_connect = new AOButton(this, ao_app);
+  ui_version = new QTextEdit(this);
+  ui_version->setFrameStyle(QFrame::NoFrame);
+  ui_version->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  ui_version->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  ui_version->setReadOnly(true);
+  ui_about = new AOButton(this, ao_app);
+  ui_server_list = new QListWidget(this);
+  ui_player_count = new QTextEdit(this);
+  ui_player_count->setFrameStyle(QFrame::NoFrame);
+  ui_player_count->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  ui_player_count->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  ui_player_count->setReadOnly(true);
+  ui_description = new AOTextArea(this);
+  ui_chatbox = new AOTextArea(this);
+  ui_chatbox->setOpenExternalLinks(true);
+  ui_chatname = new QLineEdit(this);
+  ui_chatname->setPlaceholderText("Name");
+  ui_chatmessage = new QLineEdit(this);
+  ui_loading_background = new AOImage(this, ao_app);
+  ui_loading_text = new QTextEdit(ui_loading_background);
+  ui_progress_bar = new QProgressBar(ui_loading_background);
+  ui_progress_bar->setMinimum(0);
+  ui_progress_bar->setMaximum(100);
+  ui_progress_bar->setStyleSheet("QProgressBar{ color: white; }");
+  ui_cancel = new AOButton(ui_loading_background, ao_app);
 
-    connect(ui_public_servers, SIGNAL(clicked()), this, SLOT(on_public_servers_clicked()));
-    connect(ui_favorites, SIGNAL(clicked()), this, SLOT(on_favorites_clicked()));
-    connect(ui_refresh, SIGNAL(pressed()), this, SLOT(on_refresh_pressed()));
-    connect(ui_refresh, SIGNAL(released()), this, SLOT(on_refresh_released()));
-    connect(ui_add_to_fav, SIGNAL(pressed()), this, SLOT(on_add_to_fav_pressed()));
-    connect(ui_add_to_fav, SIGNAL(released()), this, SLOT(on_add_to_fav_released()));
-    connect(ui_connect, SIGNAL(pressed()), this, SLOT(on_connect_pressed()));
-    connect(ui_connect, SIGNAL(released()), this, SLOT(on_connect_released()));
-    connect(ui_about, SIGNAL(clicked()), this, SLOT(on_about_clicked()));
-    connect(ui_server_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_server_list_clicked(QModelIndex)));
-    connect(ui_chatmessage, SIGNAL(returnPressed()), this, SLOT(on_chatfield_return_pressed()));
-    connect(ui_cancel, SIGNAL(clicked()), ao_app, SLOT(loading_cancelled()));
+  connect(ui_public_servers, SIGNAL(clicked()), this,
+          SLOT(on_public_servers_clicked()));
+  connect(ui_favorites, SIGNAL(clicked()), this, SLOT(on_favorites_clicked()));
+  connect(ui_refresh, SIGNAL(pressed()), this, SLOT(on_refresh_pressed()));
+  connect(ui_refresh, SIGNAL(released()), this, SLOT(on_refresh_released()));
+  connect(ui_add_to_fav, SIGNAL(pressed()), this,
+          SLOT(on_add_to_fav_pressed()));
+  connect(ui_add_to_fav, SIGNAL(released()), this,
+          SLOT(on_add_to_fav_released()));
+  connect(ui_connect, SIGNAL(pressed()), this, SLOT(on_connect_pressed()));
+  connect(ui_connect, SIGNAL(released()), this, SLOT(on_connect_released()));
+  connect(ui_about, SIGNAL(clicked()), this, SLOT(on_about_clicked()));
+  connect(ui_server_list, SIGNAL(clicked(QModelIndex)), this,
+          SLOT(on_server_list_clicked(QModelIndex)));
+  connect(ui_chatmessage, SIGNAL(returnPressed()), this,
+          SLOT(on_chatfield_return_pressed()));
+  connect(ui_cancel, SIGNAL(clicked()), ao_app, SLOT(loading_cancelled()));
 
-    set_widgets();
+  set_widgets();
 }
 
-//sets images, position and size
+// sets images, position and size
 void Lobby::set_widgets()
 {
-    QString filename = "lobby_design.ini";
+  QString filename = "lobby_design.ini";
 
-    pos_size_type f_lobby = ao_app->get_element_dimensions("lobby", filename);
+  pos_size_type f_lobby = ao_app->get_element_dimensions("lobby", filename);
 
-    if (f_lobby.width < 0 || f_lobby.height < 0)
-    {
-        qDebug() << "W: did not find lobby width or height in " << filename;
+  if (f_lobby.width < 0 || f_lobby.height < 0)
+  {
+    qDebug() << "W: did not find lobby width or height in " << filename;
 
-        // Most common symptom of bad config files and missing assets.
-        call_notice("It doesn't look like your client is set up correctly "
-                    "at " + QDir::currentPath() + "\n"
-                    "Did you download all resources correctly from the DRO Discord "
-                    "including the large 'base' folder?");
+    // Most common symptom of bad config files and missing assets.
+    call_notice("It doesn't look like your client is set up correctly "
+                "at " +
+                QDir::currentPath() +
+                "\n"
+                "Did you download all resources correctly from the DRO Discord "
+                "including the large 'base' folder?");
 
-        this->resize(517, 666);
-    }
-    else
-    {
-        this->resize(f_lobby.width, f_lobby.height);
-    }
+    this->resize(517, 666);
+  }
+  else
+  {
+    this->resize(f_lobby.width, f_lobby.height);
+  }
 
-    set_size_and_pos(ui_background, "lobby");
-    ui_background->set_image("lobbybackground.png");
+  set_size_and_pos(ui_background, "lobby");
+  ui_background->set_image("lobbybackground.png");
 
-    set_size_and_pos(ui_public_servers, "public_servers");
-    ui_public_servers->set_image("publicservers_selected.png");
+  set_size_and_pos(ui_public_servers, "public_servers");
+  ui_public_servers->set_image("publicservers_selected.png");
 
-    set_size_and_pos(ui_favorites, "favorites");
-    ui_favorites->set_image("favorites.png");
+  set_size_and_pos(ui_favorites, "favorites");
+  ui_favorites->set_image("favorites.png");
 
-    set_size_and_pos(ui_refresh, "refresh");
-    ui_refresh->set_image("refresh.png");
+  set_size_and_pos(ui_refresh, "refresh");
+  ui_refresh->set_image("refresh.png");
 
-    set_size_and_pos(ui_add_to_fav, "add_to_fav");
-    ui_add_to_fav->set_image("addtofav.png");
+  set_size_and_pos(ui_add_to_fav, "add_to_fav");
+  ui_add_to_fav->set_image("addtofav.png");
 
-    set_size_and_pos(ui_connect, "connect");
-    ui_connect->set_image("connect.png");
+  set_size_and_pos(ui_connect, "connect");
+  ui_connect->set_image("connect.png");
 
-    set_size_and_pos(ui_version, "version");
-    ui_version->setText("Version: " + ao_app->get_version_string());
+  set_size_and_pos(ui_version, "version");
+  ui_version->setText("Version: " + ao_app->get_version_string());
 
-    set_size_and_pos(ui_about, "about");
-    ui_about->set_image("about.png");
+  set_size_and_pos(ui_about, "about");
+  ui_about->set_image("about.png");
 
-    set_size_and_pos(ui_server_list, "server_list");
-    ui_server_list->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                                  "font: bold;");
+  set_size_and_pos(ui_server_list, "server_list");
+  ui_server_list->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
+                                "font: bold;");
 
-    set_size_and_pos(ui_player_count, "player_count");
-    ui_player_count->setStyleSheet("font: bold;"
-                                   "color: white;"
-                                   "qproperty-alignment: AlignCenter;");
+  set_size_and_pos(ui_player_count, "player_count");
+  ui_player_count->setStyleSheet("font: bold;"
+                                 "color: white;"
+                                 "qproperty-alignment: AlignCenter;");
 
-    set_size_and_pos(ui_description, "description");
-    ui_description->setReadOnly(true);
-    ui_description->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                                  "color: white;");
+  set_size_and_pos(ui_description, "description");
+  ui_description->setReadOnly(true);
+  ui_description->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
+                                "color: white;");
 
-    set_size_and_pos(ui_chatbox, "chatbox");
-    ui_chatbox->setReadOnly(true);
-    ui_chatbox->setStyleSheet("QTextBrowser{background-color: rgba(0, 0, 0, 0);}");
+  set_size_and_pos(ui_chatbox, "chatbox");
+  ui_chatbox->setReadOnly(true);
+  ui_chatbox->setStyleSheet(
+      "QTextBrowser{background-color: rgba(0, 0, 0, 0);}");
 
-    set_size_and_pos(ui_chatname, "chatname");
-    ui_chatname->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                               "selection-background-color: rgba(0, 0, 0, 0);");
+  set_size_and_pos(ui_chatname, "chatname");
+  ui_chatname->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
+                             "selection-background-color: rgba(0, 0, 0, 0);");
 
-    set_size_and_pos(ui_chatmessage, "chatmessage");
-    ui_chatmessage->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                                  "selection-background-color: rgba(0, 0, 0, 0);");
+  set_size_and_pos(ui_chatmessage, "chatmessage");
+  ui_chatmessage->setStyleSheet(
+      "background-color: rgba(0, 0, 0, 0);"
+      "selection-background-color: rgba(0, 0, 0, 0);");
 
-    ui_loading_background->resize(this->width(), this->height());
-    ui_loading_background->set_image("loadingbackground.png");
+  ui_loading_background->resize(this->width(), this->height());
+  ui_loading_background->set_image("loadingbackground.png");
 
-    set_size_and_pos(ui_loading_text, "loading_label");
-    ui_loading_text->setFont(QFont("Arial", 20, QFont::Bold));
-    ui_loading_text->setReadOnly(true);
-    ui_loading_text->setAlignment(Qt::AlignCenter);
-    ui_loading_text->setFrameStyle(QFrame::NoFrame);
-    ui_loading_text->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                                   "color: rgba(255, 128, 0, 255);");
-    ui_loading_text->append("Loading");
+  set_size_and_pos(ui_loading_text, "loading_label");
+  ui_loading_text->setFont(QFont("Arial", 20, QFont::Bold));
+  ui_loading_text->setReadOnly(true);
+  ui_loading_text->setAlignment(Qt::AlignCenter);
+  ui_loading_text->setFrameStyle(QFrame::NoFrame);
+  ui_loading_text->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
+                                 "color: rgba(255, 128, 0, 255);");
+  ui_loading_text->append("Loading");
 
-    set_size_and_pos(ui_progress_bar, "progress_bar");
-    set_size_and_pos(ui_cancel, "cancel");
-    ui_cancel->setText("Cancel");
+  set_size_and_pos(ui_progress_bar, "progress_bar");
+  set_size_and_pos(ui_cancel, "cancel");
+  ui_cancel->setText("Cancel");
 
-    ui_loading_background->hide();
+  ui_loading_background->hide();
 
-    set_fonts();
-    set_stylesheets();
-    set_choose_a_server();
+  set_fonts();
+  set_stylesheets();
+  set_choose_a_server();
 }
 
 void Lobby::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
-    QString filename = "lobby_design.ini";
+  QString filename = "lobby_design.ini";
 
-    pos_size_type design_ini_result = ao_app->get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result =
+      ao_app->get_element_dimensions(p_identifier, filename);
 
-    if (design_ini_result.width < 0 || design_ini_result.height < 0)
-    {
-        qDebug() << "W: could not find " << p_identifier << " in " << filename;
-        p_widget->hide();
-    }
-    else
-    {
-        p_widget->move(design_ini_result.x, design_ini_result.y);
-        p_widget->resize(design_ini_result.width, design_ini_result.height);
-    }
+  if (design_ini_result.width < 0 || design_ini_result.height < 0)
+  {
+    qDebug() << "W: could not find " << p_identifier << " in " << filename;
+    p_widget->hide();
+  }
+  else
+  {
+    p_widget->move(design_ini_result.x, design_ini_result.y);
+    p_widget->resize(design_ini_result.width, design_ini_result.height);
+  }
 }
 
 void Lobby::set_fonts()
 {
-    set_qtextedit_font(ui_player_count, "player_count");
-    set_qtextedit_font(ui_description, "description");
-    set_font(ui_chatbox, "chatbox");
-    set_font(ui_chatname, "chatname");
-    set_font(ui_chatmessage, "chatmessage");
-    set_qtextedit_font(ui_loading_text, "loading_text");
-    set_font(ui_server_list, "server_list");
+  set_qtextedit_font(ui_player_count, "player_count");
+  set_qtextedit_font(ui_description, "description");
+  set_font(ui_chatbox, "chatbox");
+  set_font(ui_chatname, "chatname");
+  set_font(ui_chatmessage, "chatmessage");
+  set_qtextedit_font(ui_loading_text, "loading_text");
+  set_font(ui_server_list, "server_list");
 }
 
 void Lobby::set_stylesheet(QWidget *widget, QString target_tag)
 {
-    QString f_file             = "lobby_stylesheets.css";
-    QString style_sheet_string = ao_app->get_stylesheet(target_tag, f_file);
-    if (style_sheet_string != "")
-        widget->setStyleSheet(style_sheet_string);
+  QString f_file = "lobby_stylesheets.css";
+  QString style_sheet_string = ao_app->get_stylesheet(target_tag, f_file);
+  if (style_sheet_string != "")
+    widget->setStyleSheet(style_sheet_string);
 }
 
 void Lobby::set_stylesheets()
 {
-    set_stylesheet(ui_player_count, "[PLAYER COUNT]");
-    set_stylesheet(ui_description, "[DESCRIPTION]");
-    set_stylesheet(ui_chatbox, "[CHAT BOX]");
-    set_stylesheet(ui_chatname, "[CHAT NAME]");
-    set_stylesheet(ui_chatmessage, "[CHAT MESSAGE]");
-    set_stylesheet(ui_loading_text, "[LOADING TEXT]");
-    set_stylesheet(ui_server_list, "[SERVER LIST]");
+  set_stylesheet(ui_player_count, "[PLAYER COUNT]");
+  set_stylesheet(ui_description, "[DESCRIPTION]");
+  set_stylesheet(ui_chatbox, "[CHAT BOX]");
+  set_stylesheet(ui_chatname, "[CHAT NAME]");
+  set_stylesheet(ui_chatmessage, "[CHAT MESSAGE]");
+  set_stylesheet(ui_loading_text, "[LOADING TEXT]");
+  set_stylesheet(ui_server_list, "[SERVER LIST]");
 }
 
 void Lobby::set_font(QWidget *widget, QString p_identifier)
 {
-    QString design_file = "lobby_fonts.ini";
+  QString design_file = "lobby_fonts.ini";
 
-    if (!(bool)ao_app->get_font_property("use_custom_fonts", design_file))
-        return;
+  if (!(bool)ao_app->get_font_property("use_custom_fonts", design_file))
+    return;
 
-    int f_weight        = ao_app->get_font_property(p_identifier, design_file);
-    QString class_name  = widget->metaObject()->className();
+  int f_weight = ao_app->get_font_property(p_identifier, design_file);
+  QString class_name = widget->metaObject()->className();
 
-    QString font_name = ao_app->get_font_name("font_" + p_identifier, design_file);
-    QFont font(font_name, f_weight);
-    widget->setFont(font);
+  QString font_name =
+      ao_app->get_font_name("font_" + p_identifier, design_file);
+  QFont font(font_name, f_weight);
+  widget->setFont(font);
 
-    QColor f_color = ao_app->get_color(p_identifier + "_color", design_file);
+  QColor f_color = ao_app->get_color(p_identifier + "_color", design_file);
 
-    bool bold   = (bool)ao_app->get_font_property(p_identifier + "_bold", design_file);
-    QString is_bold = "";
-    if (bold) is_bold = "bold";
+  bool bold =
+      (bool)ao_app->get_font_property(p_identifier + "_bold", design_file);
+  QString is_bold = "";
+  if (bold)
+    is_bold = "bold";
 
-    bool center = (bool)ao_app->get_font_property(p_identifier + "_center", design_file);
-    QString is_center = "";
-    if (center) is_center = "qproperty-alignment: AlignCenter;";
+  bool center =
+      (bool)ao_app->get_font_property(p_identifier + "_center", design_file);
+  QString is_center = "";
+  if (center)
+    is_center = "qproperty-alignment: AlignCenter;";
 
-    QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" +
-                                 "color: rgba(" +
-                                 QString::number(f_color.red()) + ", " +
-                                 QString::number(f_color.green()) + ", " +
-                                 QString::number(f_color.blue()) + ", 255);\n" +
-                                 is_center + "\n" +
-                                 "font: " + is_bold + "; }";
+  QString style_sheet_string =
+      class_name + " { background-color: rgba(0, 0, 0, 0);\n" + "color: rgba(" +
+      QString::number(f_color.red()) + ", " + QString::number(f_color.green()) +
+      ", " + QString::number(f_color.blue()) + ", 255);\n" + is_center + "\n" +
+      "font: " + is_bold + "; }";
 
-    widget->setStyleSheet(style_sheet_string);
+  widget->setStyleSheet(style_sheet_string);
 }
 
 void Lobby::set_qtextedit_font(QTextEdit *widget, QString p_identifier)
@@ -259,212 +272,213 @@ void Lobby::set_qtextedit_font(QTextEdit *widget, QString p_identifier)
 
 void Lobby::set_loading_text(QString p_text)
 {
-    ui_loading_text->clear();
-    ui_loading_text->setAlignment(Qt::AlignCenter);
-    ui_loading_text->append(p_text);
+  ui_loading_text->clear();
+  ui_loading_text->setAlignment(Qt::AlignCenter);
+  ui_loading_text->append(p_text);
 }
 
 QString Lobby::get_chatlog()
 {
-    QString return_value = ui_chatbox->toPlainText();
+  QString return_value = ui_chatbox->toPlainText();
 
-    return return_value;
+  return return_value;
 }
 
 int Lobby::get_selected_server()
 {
-    return ui_server_list->currentRow();
+  return ui_server_list->currentRow();
 }
 
 void Lobby::set_loading_value(int p_value)
 {
-    ui_progress_bar->setValue(p_value);
+  ui_progress_bar->setValue(p_value);
 }
 
 void Lobby::on_public_servers_clicked()
 {
-    ui_public_servers->set_image("publicservers_selected.png");
-    ui_favorites->set_image("favorites.png");
+  ui_public_servers->set_image("publicservers_selected.png");
+  ui_favorites->set_image("favorites.png");
 
-    list_servers();
+  list_servers();
 
-    public_servers_selected = true;
+  public_servers_selected = true;
 }
 
 void Lobby::on_favorites_clicked()
 {
-    ui_favorites->set_image("favorites_selected.png");
-    ui_public_servers->set_image("publicservers.png");
+  ui_favorites->set_image("favorites_selected.png");
+  ui_public_servers->set_image("publicservers.png");
 
-    ao_app->set_favorite_list();
-    //ao_app->favorite_list = read_serverlist_txt();
+  ao_app->set_favorite_list();
+  // ao_app->favorite_list = read_serverlist_txt();
 
-    list_favorites();
+  list_favorites();
 
-    public_servers_selected = false;
+  public_servers_selected = false;
 }
 
 void Lobby::on_refresh_pressed()
 {
-    ui_refresh->set_image("refresh_pressed.png");
+  ui_refresh->set_image("refresh_pressed.png");
 }
 
 void Lobby::on_refresh_released()
 {
-    ui_refresh->set_image("refresh.png");
+  ui_refresh->set_image("refresh.png");
 
-    AOPacket *f_packet = new AOPacket("ALL#%");
+  AOPacket *f_packet = new AOPacket("ALL#%");
 
-    ao_app->send_ms_packet(f_packet);
+  ao_app->send_ms_packet(f_packet);
 }
 
 void Lobby::on_add_to_fav_pressed()
 {
-    ui_add_to_fav->set_image("addtofav_pressed.png");
+  ui_add_to_fav->set_image("addtofav_pressed.png");
 }
 
 void Lobby::on_add_to_fav_released()
 {
-    ui_add_to_fav->set_image("addtofav.png");
+  ui_add_to_fav->set_image("addtofav.png");
 
-    //you cant add favorites from favorites m8
-    if (!public_servers_selected)
-        return;
+  // you cant add favorites from favorites m8
+  if (!public_servers_selected)
+    return;
 
-    ao_app->add_favorite_server(ui_server_list->currentRow());
+  ao_app->add_favorite_server(ui_server_list->currentRow());
 }
 
 void Lobby::on_connect_pressed()
 {
-    ui_connect->set_image("connect_pressed.png");
+  ui_connect->set_image("connect_pressed.png");
 }
 
 void Lobby::on_connect_released()
 {
-    ui_connect->set_image("connect.png");
+  ui_connect->set_image("connect.png");
 
-    AOPacket *f_packet;
+  AOPacket *f_packet;
 
-    f_packet = new AOPacket("askchaa#%");
+  f_packet = new AOPacket("askchaa#%");
 
-    ao_app->send_server_packet(f_packet);
+  ao_app->send_server_packet(f_packet);
 }
 
 void Lobby::on_about_clicked()
 {
-    call_notice("Attorney Online 2 is built using Qt.\n\n"
-                "Lead development:\n"
-                "OmniTroid\n\n"
-                "stonedDiscord\n"
-                "longbyte1\n"
-                "Supporting development:\n"
-                "Fiercy\n\n"
-                "UI design:\n"
-                "Ruekasu\n"
-                "Draxirch\n\n"
-                "Special thanks:\n"
-                "Unishred\n"
-                "Argoneus\n"
-                "Noevain\n"
-                "Cronnicossy");
+  call_notice("Attorney Online 2 is built using Qt.\n\n"
+              "Lead development:\n"
+              "OmniTroid\n\n"
+              "stonedDiscord\n"
+              "longbyte1\n"
+              "Supporting development:\n"
+              "Fiercy\n\n"
+              "UI design:\n"
+              "Ruekasu\n"
+              "Draxirch\n\n"
+              "Special thanks:\n"
+              "Unishred\n"
+              "Argoneus\n"
+              "Noevain\n"
+              "Cronnicossy");
 }
 
 void Lobby::on_server_list_clicked(QModelIndex p_model)
 {
-    int n_server = p_model.row();
+  int n_server = p_model.row();
 
-    if (n_server < 0)
-        return;
+  if (n_server < 0)
+    return;
 
-    if (public_servers_selected)
-    {
-        QVector<server_type> f_server_list = ao_app->get_server_list();
+  if (public_servers_selected)
+  {
+    QVector<server_type> f_server_list = ao_app->get_server_list();
 
-        if (n_server >= f_server_list.size())
-            return;
+    if (n_server >= f_server_list.size())
+      return;
 
-        f_last_server = f_server_list.at(p_model.row());
-    }
-    else
-    {
-        if (n_server >= ao_app->get_favorite_list().size())
-            return;
+    f_last_server = f_server_list.at(p_model.row());
+  }
+  else
+  {
+    if (n_server >= ao_app->get_favorite_list().size())
+      return;
 
-        f_last_server = ao_app->get_favorite_list().at(p_model.row());
-    }
+    f_last_server = ao_app->get_favorite_list().at(p_model.row());
+  }
 
-    ui_player_count->setText(nullptr);
-    ui_description->moveCursor(QTextCursor::Start);
-    ui_description->setText("Connecting to " + f_last_server.name + "...\n\n");
-    ui_description->append(f_last_server.desc);
-    ui_description->ensureCursorVisible();
+  ui_player_count->setText(nullptr);
+  ui_description->moveCursor(QTextCursor::Start);
+  ui_description->setText("Connecting to " + f_last_server.name + "...\n\n");
+  ui_description->append(f_last_server.desc);
+  ui_description->ensureCursorVisible();
 
-    ao_app->net_manager->connect_to_server(f_last_server);
+  ao_app->net_manager->connect_to_server(f_last_server);
 }
 
 void Lobby::on_chatfield_return_pressed()
 {
-    //no you can't send empty messages
-    if (ui_chatname->text() == "" || ui_chatmessage->text() == "")
-        return;
+  // no you can't send empty messages
+  if (ui_chatname->text() == "" || ui_chatmessage->text() == "")
+    return;
 
-    QString f_header = "CT";
-    QStringList f_contents{ui_chatname->text(), ui_chatmessage->text()};
+  QString f_header = "CT";
+  QStringList f_contents{ui_chatname->text(), ui_chatmessage->text()};
 
-    AOPacket *f_packet = new AOPacket(f_header, f_contents);
+  AOPacket *f_packet = new AOPacket(f_header, f_contents);
 
-    ao_app->send_ms_packet(f_packet);
+  ao_app->send_ms_packet(f_packet);
 
-    ui_chatmessage->clear();
+  ui_chatmessage->clear();
 }
 
 void Lobby::list_servers()
 {
-    public_servers_selected = true;
-    ui_favorites->set_image("favorites.png");
-    ui_public_servers->set_image("publicservers_selected.png");
+  public_servers_selected = true;
+  ui_favorites->set_image("favorites.png");
+  ui_public_servers->set_image("publicservers_selected.png");
 
-    ui_server_list->clear();
+  ui_server_list->clear();
 
-    for (server_type i_server : ao_app->get_server_list())
-    {
-        ui_server_list->addItem(i_server.name);
-    }
+  for (server_type i_server : ao_app->get_server_list())
+  {
+    ui_server_list->addItem(i_server.name);
+  }
 }
 
 void Lobby::list_favorites()
 {
-    ui_server_list->clear();
+  ui_server_list->clear();
 
-    for (server_type i_server : ao_app->get_favorite_list())
-    {
-        ui_server_list->addItem(i_server.name);
-    }
+  for (server_type i_server : ao_app->get_favorite_list())
+  {
+    ui_server_list->addItem(i_server.name);
+  }
 }
 
 void Lobby::append_chatmessage(QString f_name, QString f_message)
 {
-    ui_chatbox->append_chatmessage(f_name, f_message);
+  ui_chatbox->append_chatmessage(f_name, f_message);
 }
 
 void Lobby::append_error(QString f_message)
 {
-    ui_chatbox->append_error(f_message);
+  ui_chatbox->append_error(f_message);
 }
 
 void Lobby::set_choose_a_server()
 {
-    ui_player_count->setText(nullptr);
-    ui_description->setText(tr("Choose a server."));
+  ui_player_count->setText(nullptr);
+  ui_description->setText(tr("Choose a server."));
 }
 
 void Lobby::set_player_count(int players_online, int max_players)
 {
-    QString f_string = "Online: " + QString::number(players_online) + "/" + QString::number(max_players);
-    ui_player_count->setText(f_string);
-    ui_player_count->setAlignment(Qt::AlignHCenter);
+  QString f_string = "Online: " + QString::number(players_online) + "/" +
+                     QString::number(max_players);
+  ui_player_count->setText(f_string);
+  ui_player_count->setAlignment(Qt::AlignHCenter);
 
-    ui_description->setText("Connected to " + f_last_server.name + "\n\n");
-    ui_description->append(f_last_server.desc);
-    ui_description->ensureCursorVisible();
+  ui_description->setText("Connected to " + f_last_server.name + "\n\n");
+  ui_description->append(f_last_server.desc);
+  ui_description->ensureCursorVisible();
 }

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -284,10 +284,7 @@ QString Lobby::get_chatlog()
   return return_value;
 }
 
-int Lobby::get_selected_server()
-{
-  return ui_server_list->currentRow();
-}
+int Lobby::get_selected_server() { return ui_server_list->currentRow(); }
 
 void Lobby::set_loading_value(int p_value)
 {

--- a/lobby.h
+++ b/lobby.h
@@ -18,80 +18,86 @@ class AOApplication;
 
 class Lobby : public QMainWindow
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    Lobby(AOApplication *p_ao_app);
+  Lobby(AOApplication *p_ao_app);
 
-    void set_widgets();
-    void list_servers();
-    void list_favorites();
-    void append_chatmessage(QString f_name, QString f_message);
-    void append_error(QString f_message);
-    void set_choose_a_server();
-    void set_player_count(int players_online, int max_players);
-    void set_loading_text(QString p_text);
-    void set_stylesheet(QWidget *widget, QString target_tag);
-    void set_stylesheets();
-    void set_fonts();
-    void set_font(QWidget *widget, QString p_identifier);
-    void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
-    void show_loading_overlay() { ui_loading_background->show(); }
-    void hide_loading_overlay() { ui_loading_background->hide(); }
-    QString get_chatlog();
-    int get_selected_server();
+  void set_widgets();
+  void list_servers();
+  void list_favorites();
+  void append_chatmessage(QString f_name, QString f_message);
+  void append_error(QString f_message);
+  void set_choose_a_server();
+  void set_player_count(int players_online, int max_players);
+  void set_loading_text(QString p_text);
+  void set_stylesheet(QWidget *widget, QString target_tag);
+  void set_stylesheets();
+  void set_fonts();
+  void set_font(QWidget *widget, QString p_identifier);
+  void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
+  void show_loading_overlay()
+  {
+    ui_loading_background->show();
+  }
+  void hide_loading_overlay()
+  {
+    ui_loading_background->hide();
+  }
+  QString get_chatlog();
+  int get_selected_server();
 
-    void set_loading_value(int p_value);
+  void set_loading_value(int p_value);
 
-    bool public_servers_selected = true;
+  bool public_servers_selected = true;
 
 private:
-    AOApplication *ao_app = nullptr;
+  AOApplication *ao_app = nullptr;
 
-    AOImage *ui_background;
+  AOImage *ui_background;
 
-    AOButton *ui_public_servers;
-    AOButton *ui_favorites;
+  AOButton *ui_public_servers;
+  AOButton *ui_favorites;
 
-    AOButton *ui_refresh;
-    AOButton *ui_add_to_fav;
-    AOButton *ui_connect;
+  AOButton *ui_refresh;
+  AOButton *ui_add_to_fav;
+  AOButton *ui_connect;
 
-    QTextEdit *ui_version;
-    AOButton *ui_about;
+  QTextEdit *ui_version;
+  AOButton *ui_about;
 
-    QListWidget *ui_server_list;
+  QListWidget *ui_server_list;
 
-    QTextEdit *ui_player_count;
-    AOTextArea *ui_description;
+  QTextEdit *ui_player_count;
+  AOTextArea *ui_description;
 
-    AOTextArea *ui_chatbox;
+  AOTextArea *ui_chatbox;
 
-    QLineEdit *ui_chatname;
-    QLineEdit *ui_chatmessage;
+  QLineEdit *ui_chatname;
+  QLineEdit *ui_chatmessage;
 
-    AOImage *ui_loading_background;
-    QTextEdit *ui_loading_text;
-    QProgressBar *ui_progress_bar;
-    AOButton *ui_cancel;
+  AOImage *ui_loading_background;
+  QTextEdit *ui_loading_text;
+  QProgressBar *ui_progress_bar;
+  AOButton *ui_cancel;
 
-    server_type f_last_server;
+  server_type f_last_server;
 
-    void set_size_and_pos(QWidget *p_widget, QString p_identifier);
+  void set_size_and_pos(QWidget *p_widget, QString p_identifier);
 
 private slots:
-    void on_public_servers_clicked();
-    void on_favorites_clicked();
+  void on_public_servers_clicked();
+  void on_favorites_clicked();
 
-    void on_refresh_pressed();
-    void on_refresh_released();
-    void on_add_to_fav_pressed();
-    void on_add_to_fav_released();
-    void on_connect_pressed();
-    void on_connect_released();
-    void on_about_clicked();
-    void on_server_list_clicked(QModelIndex p_model);
-    void on_chatfield_return_pressed();
+  void on_refresh_pressed();
+  void on_refresh_released();
+  void on_add_to_fav_pressed();
+  void on_add_to_fav_released();
+  void on_connect_pressed();
+  void on_connect_released();
+  void on_about_clicked();
+  void on_server_list_clicked(QModelIndex p_model);
+  void on_chatfield_return_pressed();
 };
 
 #endif // LOBBY_H

--- a/lobby.h
+++ b/lobby.h
@@ -36,8 +36,14 @@ public:
   void set_fonts();
   void set_font(QWidget *widget, QString p_identifier);
   void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
-  void show_loading_overlay() { ui_loading_background->show(); }
-  void hide_loading_overlay() { ui_loading_background->hide(); }
+  void show_loading_overlay()
+  {
+    ui_loading_background->show();
+  }
+  void hide_loading_overlay()
+  {
+    ui_loading_background->hide();
+  }
   QString get_chatlog();
   int get_selected_server();
 

--- a/lobby.h
+++ b/lobby.h
@@ -36,14 +36,8 @@ public:
   void set_fonts();
   void set_font(QWidget *widget, QString p_identifier);
   void set_qtextedit_font(QTextEdit *widget, QString p_identifier);
-  void show_loading_overlay()
-  {
-    ui_loading_background->show();
-  }
-  void hide_loading_overlay()
-  {
-    ui_loading_background->hide();
-  }
+  void show_loading_overlay() { ui_loading_background->show(); }
+  void hide_loading_overlay() { ui_loading_background->hide(); }
   QString get_chatlog();
   int get_selected_server();
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,26 +14,26 @@
 int main(int argc, char *argv[])
 {
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
-    // High-DPI support is for Qt version >=5.6.
-    // However, many Linux distros still haven't brought their stable/LTS
-    // packages up to Qt 5.6, so this is conditional.
-    AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  // High-DPI support is for Qt version >=5.6.
+  // However, many Linux distros still haven't brought their stable/LTS
+  // packages up to Qt 5.6, so this is conditional.
+  AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
-    AOApplication app(argc, argv);
+  AOApplication app(argc, argv);
 
-    QPluginLoader apng("qapng");
-    if (!apng.load())
-    {
+  QPluginLoader apng("qapng");
+  if (!apng.load())
+  {
 #ifdef QT_NO_DEBUG
-        call_error("APNG plugin could not be loaded.");
+    call_error("APNG plugin could not be loaded.");
 #endif
-    }
+  }
 
-    app.construct_lobby();
+  app.construct_lobby();
 #ifdef QT_NO_DEBUG
-    app.net_manager->connect_to_master();
+  app.net_manager->connect_to_master();
 #endif
-    app.w_lobby->show();
+  app.w_lobby->show();
 
-    return app.exec();
+  return app.exec();
 }

--- a/misc_functions.cpp
+++ b/misc_functions.cpp
@@ -1,12 +1,12 @@
 #include "misc_functions.h"
 
-#include <QTime>
 #include <QCoreApplication>
+#include <QTime>
 
 void delay(int p_milliseconds)
 {
   QTime dieTime = QTime::currentTime().addMSecs(p_milliseconds);
 
-  while(QTime::currentTime() < dieTime)
+  while (QTime::currentTime() < dieTime)
     QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
 }

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -26,7 +26,9 @@ NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
                    SLOT(server_disconnected()));
 }
 
-NetworkManager::~NetworkManager() {}
+NetworkManager::~NetworkManager()
+{
+}
 
 void NetworkManager::connect_to_master()
 {

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -15,16 +15,19 @@ NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
 
   ms_reconnect_timer = new QTimer(this);
   ms_reconnect_timer->setSingleShot(true);
-  QObject::connect(ms_reconnect_timer, SIGNAL(timeout()), this, SLOT(retry_ms_connect()));
+  QObject::connect(ms_reconnect_timer, SIGNAL(timeout()), this,
+                   SLOT(retry_ms_connect()));
 
-  QObject::connect(ms_socket, SIGNAL(readyRead()), this, SLOT(handle_ms_packet()));
-  QObject::connect(server_socket, SIGNAL(readyRead()), this, SLOT(handle_server_packet()));
-  QObject::connect(server_socket, SIGNAL(disconnected()), ao_app, SLOT(server_disconnected()));
+  QObject::connect(ms_socket, SIGNAL(readyRead()), this,
+                   SLOT(handle_ms_packet()));
+  QObject::connect(server_socket, SIGNAL(readyRead()), this,
+                   SLOT(handle_server_packet()));
+  QObject::connect(server_socket, SIGNAL(disconnected()), ao_app,
+                   SLOT(server_disconnected()));
 }
 
 NetworkManager::~NetworkManager()
 {
-
 }
 
 void NetworkManager::connect_to_master()
@@ -41,24 +44,24 @@ void NetworkManager::connect_to_master()
 
 void NetworkManager::connect_to_master_nosrv()
 {
-  QObject::connect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)),
-                   this, SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
+  QObject::connect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+                   SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
 
-  QObject::connect(ms_socket, SIGNAL(connected()),
-                   this, SLOT(on_ms_nosrv_connect_success()));
+  QObject::connect(ms_socket, SIGNAL(connected()), this,
+                   SLOT(on_ms_nosrv_connect_success()));
   ms_socket->connectToHost(ms_nosrv_hostname, ms_port);
 }
 
 void NetworkManager::connect_to_server(server_type p_server)
 {
-    disconnect_from_server();
-    server_socket->connectToHost(p_server.ip, p_server.port);
+  disconnect_from_server();
+  server_socket->connectToHost(p_server.ip, p_server.port);
 }
 
 void NetworkManager::disconnect_from_server()
 {
-    server_socket->close();
-    server_socket->abort();
+  server_socket->close();
+  server_socket->abort();
 }
 
 void NetworkManager::ship_ms_packet(QString p_packet)
@@ -100,7 +103,8 @@ void NetworkManager::handle_ms_packet()
     }
   }
 
-  QStringList packet_list = in_data.split("%", QString::SplitBehavior(QString::SkipEmptyParts));
+  QStringList packet_list =
+      in_data.split("%", QString::SplitBehavior(QString::SkipEmptyParts));
 
   for (QString packet : packet_list)
   {
@@ -110,20 +114,19 @@ void NetworkManager::handle_ms_packet()
   }
 }
 
-
 void NetworkManager::perform_srv_lookup()
 {
-  #ifdef MS_FAILOVER_SUPPORTED
+#ifdef MS_FAILOVER_SUPPORTED
   ms_dns = new QDnsLookup(QDnsLookup::SRV, ms_srv_hostname, this);
 
   connect(ms_dns, SIGNAL(finished()), this, SLOT(on_srv_lookup()));
   ms_dns->lookup();
-  #endif
+#endif
 }
 
 void NetworkManager::on_srv_lookup()
 {
-  #ifdef MS_FAILOVER_SUPPORTED
+#ifdef MS_FAILOVER_SUPPORTED
   bool connected = false;
   if (ms_dns->error() != QDnsLookup::NoError)
   {
@@ -148,22 +151,27 @@ void NetworkManager::on_srv_lookup()
           connected = true;
           break;
         }
-        else if (ms_socket->state() != QAbstractSocket::ConnectingState
-                 && ms_socket->state() != QAbstractSocket::HostLookupState
-                 && ms_socket->error() != -1)
+        else if (ms_socket->state() != QAbstractSocket::ConnectingState &&
+                 ms_socket->state() != QAbstractSocket::HostLookupState &&
+                 ms_socket->error() != -1)
         {
           qDebug() << ms_socket->error();
-          qWarning() << "Error connecting to master server:" << ms_socket->errorString();
+          qWarning() << "Error connecting to master server:"
+                     << ms_socket->errorString();
           ms_socket->abort();
           ms_socket->close();
           break;
         }
-      } while (timer.elapsed() < timeout_milliseconds); // Very expensive spin-wait loop - it will bring CPU to 100%!
+      } while (timer.elapsed() <
+               timeout_milliseconds); // Very expensive spin-wait loop - it will
+                                      // bring CPU to 100%!
       if (connected)
       {
-        // Connect a one-shot signal in case the master server disconnects randomly
-        QObject::connect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)),
-                         this, SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
+        // Connect a one-shot signal in case the master server disconnects
+        // randomly
+        QObject::connect(
+            ms_socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+            SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
         break;
       }
       else
@@ -179,29 +187,30 @@ void NetworkManager::on_srv_lookup()
     connect_to_master_nosrv();
   else
     emit ms_connect_finished(connected, false);
-  #endif
+#endif
 }
 
 void NetworkManager::on_ms_nosrv_connect_success()
 {
   emit ms_connect_finished(true, false);
 
-  QObject::disconnect(ms_socket, SIGNAL(connected()),
-                   this, SLOT(on_ms_nosrv_connect_success()));
+  QObject::disconnect(ms_socket, SIGNAL(connected()), this,
+                      SLOT(on_ms_nosrv_connect_success()));
 
-  QObject::connect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)),
-                   this, SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
+  QObject::connect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+                   SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
 }
 
 void NetworkManager::on_ms_socket_error(QAbstractSocket::SocketError error)
 {
-  qWarning() << "Master server socket error:" << ms_socket->errorString()
-             << "(" << error << ")";
+  qWarning() << "Master server socket error:" << ms_socket->errorString() << "("
+             << error << ")";
 
   // Disconnect the one-shot signal - this way, failover connect attempts
   // don't trigger a full retry
   QObject::disconnect(ms_socket, SIGNAL(error(QAbstractSocket::SocketError)),
-                   this, SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
+                      this,
+                      SLOT(on_ms_socket_error(QAbstractSocket::SocketError)));
 
   emit ms_connect_finished(false, true);
 
@@ -210,7 +219,8 @@ void NetworkManager::on_ms_socket_error(QAbstractSocket::SocketError error)
 
 void NetworkManager::retry_ms_connect()
 {
-  if (!ms_reconnect_timer->isActive() && ms_socket->state() != QAbstractSocket::ConnectingState)
+  if (!ms_reconnect_timer->isActive() &&
+      ms_socket->state() != QAbstractSocket::ConnectingState)
     connect_to_master();
 }
 
@@ -236,7 +246,8 @@ void NetworkManager::handle_server_packet()
     }
   }
 
-  QStringList packet_list = in_data.split("%", QString::SplitBehavior(QString::SkipEmptyParts));
+  QStringList packet_list =
+      in_data.split("%", QString::SplitBehavior(QString::SkipEmptyParts));
 
   for (QString packet : packet_list)
   {
@@ -245,4 +256,3 @@ void NetworkManager::handle_server_packet()
     ao_app->server_packet_received(f_packet);
   }
 }
-

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -26,9 +26,7 @@ NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
                    SLOT(server_disconnected()));
 }
 
-NetworkManager::~NetworkManager()
-{
-}
+NetworkManager::~NetworkManager() {}
 
 void NetworkManager::connect_to_master()
 {

--- a/networkmanager.h
+++ b/networkmanager.h
@@ -1,8 +1,8 @@
 #ifndef NETWORKMANAGER_H
 #define NETWORKMANAGER_H
 
-// Qt for Android has stubbed QDnsLookup. This is not documented in any part of their wiki.
-// This prevents SRV lookup/failover behavior from functioning.
+// Qt for Android has stubbed QDnsLookup. This is not documented in any part of
+// their wiki. This prevents SRV lookup/failover behavior from functioning.
 // https://bugreports.qt.io/browse/QTBUG-56143
 #ifndef ANDROID
 #define MS_FAILOVER_SUPPORTED
@@ -14,11 +14,11 @@
 #undef MS_FAILOVER_SUPPORTED
 #endif
 
-#include "aopacket.h"
 #include "aoapplication.h"
+#include "aopacket.h"
 
-#include <QTcpSocket>
 #include <QDnsLookup>
+#include <QTcpSocket>
 #include <QTime>
 #include <QTimer>
 

--- a/packet_distribution.cpp
+++ b/packet_distribution.cpp
@@ -1,14 +1,14 @@
 #include "aoapplication.h"
 
-#include "lobby.h"
 #include "courtroom.h"
-#include "networkmanager.h"
+#include "debug_functions.h"
 #include "encryption_functions.h"
 #include "hardware_functions.h"
-#include "debug_functions.h"
+#include "lobby.h"
+#include "networkmanager.h"
 
-#include <QDebug>
 #include <QCryptographicHash>
+#include <QDebug>
 
 void AOApplication::ms_packet_received(AOPacket *p_packet)
 {
@@ -100,8 +100,8 @@ void AOApplication::ms_packet_received(AOPacket *p_packet)
       }
     }
 
-    call_notice("Outdated version! Your version: " + get_version_string()
-                + "\nPlease go to aceattorneyonline.com to update.");
+    call_notice("Outdated version! Your version: " + get_version_string() +
+                "\nPlease go to aceattorneyonline.com to update.");
     destruct_courtroom();
     destruct_lobby();
   }
@@ -113,7 +113,7 @@ void AOApplication::ms_packet_received(AOPacket *p_packet)
     destruct_lobby();
   }
 
-  end:
+end:
 
   delete p_packet;
 }
@@ -134,10 +134,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (f_contents.size() == 0)
       goto end;
 
-    //you may ask where 322 comes from. that would be a good question.
+    // you may ask where 322 comes from. that would be a good question.
     s_decryptor = fanta_decrypt(f_contents.at(0), 322).toUInt();
 
-    //default(legacy) values
+    // default(legacy) values
     encryption_needed = true;
     yellow_text_enabled = false;
     prezoom_enabled = false;
@@ -147,7 +147,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     desk_mod_enabled = false;
     evidence_enabled = false;
 
-    //workaround for tsuserver4
+    // workaround for tsuserver4
     if (f_contents.at(0) == "NOENCRYPT")
       encryption_needed = false;
 
@@ -173,23 +173,24 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       goto end;
 
     if (courtroom_constructed)
-      w_courtroom->append_server_chatmessage(f_contents.at(0), f_contents.at(1));
+      w_courtroom->append_server_chatmessage(f_contents.at(0),
+                                             f_contents.at(1));
   }
   else if (header == "FL")
   {
-    if (f_packet.contains("yellowtext",Qt::CaseInsensitive))
+    if (f_packet.contains("yellowtext", Qt::CaseInsensitive))
       yellow_text_enabled = true;
-    if (f_packet.contains("flipping",Qt::CaseInsensitive))
+    if (f_packet.contains("flipping", Qt::CaseInsensitive))
       flipping_enabled = true;
-    if (f_packet.contains("customobjections",Qt::CaseInsensitive))
+    if (f_packet.contains("customobjections", Qt::CaseInsensitive))
       custom_objection_enabled = true;
-    if (f_packet.contains("fastloading",Qt::CaseInsensitive))
+    if (f_packet.contains("fastloading", Qt::CaseInsensitive))
       improved_loading_enabled = true;
-    if (f_packet.contains("noencryption",Qt::CaseInsensitive))
+    if (f_packet.contains("noencryption", Qt::CaseInsensitive))
       encryption_needed = false;
-    if (f_packet.contains("deskmod",Qt::CaseInsensitive))
+    if (f_packet.contains("deskmod", Qt::CaseInsensitive))
       desk_mod_enabled = true;
-    if (f_packet.contains("evidence",Qt::CaseInsensitive))
+    if (f_packet.contains("evidence", Qt::CaseInsensitive))
       evidence_enabled = true;
   }
   else if (header == "PN")
@@ -197,7 +198,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (f_contents.size() < 2)
       goto end;
 
-    w_lobby->set_player_count(f_contents.at(0).toInt(), f_contents.at(1).toInt());
+    w_lobby->set_player_count(f_contents.at(0).toInt(),
+                              f_contents.at(1).toInt());
   }
   else if (header == "SI")
   {
@@ -225,7 +227,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     QString server_address = "", server_name = "";
     if (w_lobby->public_servers_selected)
     {
-      if (selected_server >= 0 && selected_server < server_list.size()) {
+      if (selected_server >= 0 && selected_server < server_list.size())
+      {
         auto info = server_list.at(selected_server);
         server_name = info.name;
         server_address = info.ip + info.port;
@@ -234,7 +237,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     }
     else
     {
-      if (selected_server >= 0 && selected_server < favorite_list.size()) {
+      if (selected_server >= 0 && selected_server < favorite_list.size())
+      {
         auto info = favorite_list.at(selected_server);
         server_name = info.name;
         server_address = info.ip + info.port;
@@ -250,7 +254,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     AOPacket *f_packet;
 
-    if(improved_loading_enabled)
+    if (improved_loading_enabled)
       f_packet = new AOPacket("RC#%");
     else
       f_packet = new AOPacket("askchar2#%");
@@ -259,19 +263,21 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     QCryptographicHash hash(QCryptographicHash::Algorithm::Sha256);
     hash.addData(server_address.toUtf8());
-    discord->state_server(server_name.toStdString(), hash.result().toBase64().toStdString());
+    discord->state_server(server_name.toStdString(),
+                          hash.result().toBase64().toStdString());
   }
   else if (header == "CI")
   {
     if (!courtroom_constructed)
       goto end;
 
-    for (int n_element = 0 ; n_element < f_contents.size() ; n_element += 2)
+    for (int n_element = 0; n_element < f_contents.size(); n_element += 2)
     {
       if (f_contents.at(n_element).toInt() != loaded_chars)
         break;
 
-      //this means we are on the last element and checking n + 1 element will be game over so
+      // this means we are on the last element and checking n + 1 element will
+      // be game over so
       if (n_element == f_contents.size() - 1)
         break;
 
@@ -283,37 +289,40 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       f_char.name = sub_elements.at(0);
       f_char.description = sub_elements.at(1);
       f_char.evidence_string = sub_elements.at(3);
-      //temporary. the CharsCheck packet sets this properly
+      // temporary. the CharsCheck packet sets this properly
       f_char.taken = false;
 
       ++loaded_chars;
 
-      w_lobby->set_loading_text("Loading chars:\n" + QString::number(loaded_chars) + "/" + QString::number(char_list_size));
+      w_lobby->set_loading_text("Loading chars:\n" +
+                                QString::number(loaded_chars) + "/" +
+                                QString::number(char_list_size));
 
       w_courtroom->append_char(f_char);
     }
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
+    int total_loading_size =
+        char_list_size + evidence_list_size + music_list_size;
+    int loading_value =
+        (loaded_chars / static_cast<double>(total_loading_size)) * 100;
     w_lobby->set_loading_value(loading_value);
 
     if (improved_loading_enabled)
       send_server_packet(new AOPacket("RE#%"));
     else
     {
-      QString next_packet_number = QString::number(((loaded_chars - 1) / 10) + 1);
+      QString next_packet_number =
+          QString::number(((loaded_chars - 1) / 10) + 1);
       send_server_packet(new AOPacket("AN#" + next_packet_number + "#%"));
     }
-
   }
   else if (header == "EI")
   {
     if (!courtroom_constructed)
       goto end;
 
-
     // +1 because evidence starts at 1 rather than 0 for whatever reason
-    //enjoy fanta
+    // enjoy fanta
     if (f_contents.at(0).toInt() != loaded_evidence + 1)
       goto end;
 
@@ -327,22 +336,26 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     evi_type f_evi;
     f_evi.name = sub_elements.at(0);
     f_evi.description = sub_elements.at(1);
-    //no idea what the number at position 2 is. probably an identifier?
+    // no idea what the number at position 2 is. probably an identifier?
     f_evi.image = sub_elements.at(3);
 
     ++loaded_evidence;
 
-    w_lobby->set_loading_text("Loading evidence:\n" + QString::number(loaded_evidence) + "/" + QString::number(evidence_list_size));
+    w_lobby->set_loading_text("Loading evidence:\n" +
+                              QString::number(loaded_evidence) + "/" +
+                              QString::number(evidence_list_size));
 
     w_courtroom->append_evidence(f_evi);
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = ((loaded_chars + loaded_evidence) / static_cast<double>(total_loading_size)) * 100;
+    int total_loading_size =
+        char_list_size + evidence_list_size + music_list_size;
+    int loading_value = ((loaded_chars + loaded_evidence) /
+                         static_cast<double>(total_loading_size)) *
+                        100;
     w_lobby->set_loading_value(loading_value);
 
     QString next_packet_number = QString::number(loaded_evidence);
     send_server_packet(new AOPacket("AE#" + next_packet_number + "#%"));
-
   }
   else if (header == "EM")
   {
@@ -352,7 +365,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     bool music_turn = false;
     int areas = 0;
 
-    for (int n_element = 0 ; n_element < f_contents.size() ; n_element += 2)
+    for (int n_element = 0; n_element < f_contents.size(); n_element += 2)
     {
       if (f_contents.at(n_element).toInt() != loaded_music)
         break;
@@ -364,37 +377,39 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
       ++loaded_music;
 
-      w_lobby->set_loading_text("Loading music:\n" + QString::number(loaded_music) + "/" + QString::number(music_list_size));
+      w_lobby->set_loading_text("Loading music:\n" +
+                                QString::number(loaded_music) + "/" +
+                                QString::number(music_list_size));
 
       if (music_turn)
       {
-          w_courtroom->append_music(f_music);
+        w_courtroom->append_music(f_music);
       }
       else
       {
-          if (f_music.endsWith(".wav") ||
-                  f_music.endsWith(".mp3") ||
-                  f_music.endsWith(".mp4") ||
-                  f_music.endsWith(".ogg") ||
-                  f_music.endsWith(".opus"))
-          {
-              music_turn = true;
-              areas--;
-              w_courtroom->fix_last_area();
-              w_courtroom->append_music(f_music);
-          }
-          else
-          {
-              w_courtroom->append_area(f_music);
-              areas++;
-          }
+        if (f_music.endsWith(".wav") || f_music.endsWith(".mp3") ||
+            f_music.endsWith(".mp4") || f_music.endsWith(".ogg") ||
+            f_music.endsWith(".opus"))
+        {
+          music_turn = true;
+          areas--;
+          w_courtroom->fix_last_area();
+          w_courtroom->append_music(f_music);
+        }
+        else
+        {
+          w_courtroom->append_area(f_music);
+          areas++;
+        }
       }
       qDebug() << f_music;
 
-      int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-      int loading_value = ((loaded_chars + loaded_evidence + loaded_music) / static_cast<double>(total_loading_size)) * 100;
+      int total_loading_size =
+          char_list_size + evidence_list_size + music_list_size;
+      int loading_value = ((loaded_chars + loaded_evidence + loaded_music) /
+                           static_cast<double>(total_loading_size)) *
+                          100;
       w_lobby->set_loading_value(loading_value);
-
     }
 
     QString next_packet_number = QString::number(((loaded_music - 1) / 10) + 1);
@@ -405,7 +420,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
-    for (int n_char = 0 ; n_char < f_contents.size() ; ++n_char)
+    for (int n_char = 0; n_char < f_contents.size(); ++n_char)
     {
       if (f_contents.at(n_char) == "-1")
         w_courtroom->set_taken(n_char, true);
@@ -419,7 +434,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
-    for (int n_element = 0 ; n_element < f_contents.size() ; ++n_element)
+    for (int n_element = 0; n_element < f_contents.size(); ++n_element)
     {
       QStringList sub_elements = f_contents.at(n_element).split("&");
 
@@ -428,18 +443,22 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       if (sub_elements.size() >= 2)
         f_char.description = sub_elements.at(1);
 
-      //temporary. the CharsCheck packet sets this properly
+      // temporary. the CharsCheck packet sets this properly
       f_char.taken = false;
 
       ++loaded_chars;
 
-      w_lobby->set_loading_text("Loading chars:\n" + QString::number(loaded_chars) + "/" + QString::number(char_list_size));
+      w_lobby->set_loading_text("Loading chars:\n" +
+                                QString::number(loaded_chars) + "/" +
+                                QString::number(char_list_size));
 
       w_courtroom->append_char(f_char);
     }
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
+    int total_loading_size =
+        char_list_size + evidence_list_size + music_list_size;
+    int loading_value =
+        (loaded_chars / static_cast<double>(total_loading_size)) * 100;
     w_lobby->set_loading_value(loading_value);
 
     send_server_packet(new AOPacket("RM#%"));
@@ -452,40 +471,43 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     bool musics_time = false;
     int areas = 0;
 
-    for (int n_element = 0 ; n_element < f_contents.size() ; ++n_element)
+    for (int n_element = 0; n_element < f_contents.size(); ++n_element)
     {
       ++loaded_music;
 
-      w_lobby->set_loading_text("Loading music:\n" + QString::number(loaded_music) + "/" + QString::number(music_list_size));
+      w_lobby->set_loading_text("Loading music:\n" +
+                                QString::number(loaded_music) + "/" +
+                                QString::number(music_list_size));
 
       if (musics_time)
       {
-          w_courtroom->append_music(f_contents.at(n_element));
+        w_courtroom->append_music(f_contents.at(n_element));
       }
       else
       {
-          if (f_contents.at(n_element).endsWith(".wav") ||
-                  f_contents.at(n_element).endsWith(".mp3") ||
-                  f_contents.at(n_element).endsWith(".mp4") ||
-                  f_contents.at(n_element).endsWith(".ogg") ||
-                  f_contents.at(n_element).endsWith(".opus"))
-          {
-              musics_time = true;
-              w_courtroom->fix_last_area();
-              w_courtroom->append_music(f_contents.at(n_element));
-              areas--;
-          }
-          else
-          {
-              w_courtroom->append_area(f_contents.at(n_element));
-              areas++;
-          }
+        if (f_contents.at(n_element).endsWith(".wav") ||
+            f_contents.at(n_element).endsWith(".mp3") ||
+            f_contents.at(n_element).endsWith(".mp4") ||
+            f_contents.at(n_element).endsWith(".ogg") ||
+            f_contents.at(n_element).endsWith(".opus"))
+        {
+          musics_time = true;
+          w_courtroom->fix_last_area();
+          w_courtroom->append_music(f_contents.at(n_element));
+          areas--;
+        }
+        else
+        {
+          w_courtroom->append_area(f_contents.at(n_element));
+          areas++;
+        }
       }
 
-      int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-      int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
+      int total_loading_size =
+          char_list_size + evidence_list_size + music_list_size;
+      int loading_value =
+          (loaded_chars / static_cast<double>(total_loading_size)) * 100;
       w_lobby->set_loading_value(loading_value);
-
     }
 
     send_server_packet(new AOPacket("RD#%"));
@@ -501,31 +523,31 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     bool musics_time = false;
     int areas = 0;
 
-    for (int n_element = 0 ; n_element < f_contents.size() ; ++n_element)
+    for (int n_element = 0; n_element < f_contents.size(); ++n_element)
     {
       if (musics_time)
       {
-          w_courtroom->append_music(f_contents.at(n_element));
+        w_courtroom->append_music(f_contents.at(n_element));
       }
       else
       {
-          if (f_contents.at(n_element).endsWith(".wav") ||
-                  f_contents.at(n_element).endsWith(".mp3") ||
-                  f_contents.at(n_element).endsWith(".mp4") ||
-                  f_contents.at(n_element).endsWith(".ogg") ||
-                  f_contents.at(n_element).endsWith(".opus"))
-          {
-              musics_time = true;
-              w_courtroom->fix_last_area();
-              w_courtroom->append_music(f_contents.at(n_element));
-              areas--;
-//              qDebug() << "wtf!!" << f_contents.at(n_element);
-          }
-          else
-          {
-              w_courtroom->append_area(f_contents.at(n_element));
-              areas++;
-          }
+        if (f_contents.at(n_element).endsWith(".wav") ||
+            f_contents.at(n_element).endsWith(".mp3") ||
+            f_contents.at(n_element).endsWith(".mp4") ||
+            f_contents.at(n_element).endsWith(".ogg") ||
+            f_contents.at(n_element).endsWith(".opus"))
+        {
+          musics_time = true;
+          w_courtroom->fix_last_area();
+          w_courtroom->append_music(f_contents.at(n_element));
+          areas--;
+          //              qDebug() << "wtf!!" << f_contents.at(n_element);
+        }
+        else
+        {
+          w_courtroom->append_area(f_contents.at(n_element));
+          areas++;
+        }
       }
     }
 
@@ -548,12 +570,13 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (f_contents.size() < 1)
       goto end;
 
-    if (courtroom_constructed) {
+    if (courtroom_constructed)
+    {
       w_courtroom->set_background(f_contents.at(0));
       w_courtroom->set_scene();
     }
   }
-  //server accepting char request(CC) packet
+  // server accepting char request(CC) packet
   else if (header == "PV")
   {
     if (f_contents.size() < 3)
@@ -582,7 +605,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   else if (header == "HP")
   {
     if (courtroom_constructed && f_contents.size() > 1)
-      w_courtroom->set_hp_bar(f_contents.at(0).toInt(), f_contents.at(1).toInt());
+      w_courtroom->set_hp_bar(f_contents.at(0).toInt(),
+                              f_contents.at(1).toInt());
   }
   else if (header == "LE")
   {
@@ -637,7 +661,6 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       construct_lobby();
       destruct_courtroom();
     }
-
   }
   else if (header == "KB")
   {
@@ -672,7 +695,6 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     int timer_id = f_contents.at(0).toInt();
     w_courtroom->resume_timer(timer_id);
-
   }
   else if (header == "TST")
   {
@@ -722,7 +744,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     w_courtroom->set_character_position(f_contents.at(0), true);
   }
 
-  end:
+end:
 
   delete p_packet;
 }

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -1,8 +1,8 @@
 #include "aoapplication.h"
 #include "courtroom.h"
 #include "file_functions.h"
-#include <QDir>
 #include <QDebug>
+#include <QDir>
 #include <QStandardPaths>
 
 #ifdef BASE_OVERRIDE
@@ -12,23 +12,26 @@ QString base_path = "";
 
 QString AOApplication::get_base_path()
 {
-    if (base_path == "")
-    {
+  if (base_path == "")
+  {
 #ifdef BASE_OVERRIDE
-  base_path = base_override;
+    base_path = base_override;
 #elif defined(ANDROID)
-        QString sdcard_storage = getenv("SECONDARY_STORAGE");
-        if (dir_exists(sdcard_storage + "/AO2/")){
-            base_path = sdcard_storage + "/AO2/";
-        }else{
-            QString external_storage = getenv("EXTERNAL_STORAGE");
-            base_path = external_storage + "/AO2/";
-        }
+    QString sdcard_storage = getenv("SECONDARY_STORAGE");
+    if (dir_exists(sdcard_storage + "/AO2/"))
+    {
+      base_path = sdcard_storage + "/AO2/";
+    }
+    else
+    {
+      QString external_storage = getenv("EXTERNAL_STORAGE");
+      base_path = external_storage + "/AO2/";
+    }
 #else
-  base_path = QDir::currentPath() + "/base/";
+    base_path = QDir::currentPath() + "/base/";
 #endif
-}
-    return base_path;
+  }
+  return base_path;
 }
 
 QString AOApplication::get_data_path()
@@ -43,8 +46,8 @@ QString AOApplication::get_theme_path()
 
 QString AOApplication::get_theme_variant_path()
 {
-  return get_base_path() + "themes/" + get_theme().toLower() + "/variants/" + get_theme_variant()
-      + "/";
+  return get_base_path() + "themes/" + get_theme().toLower() + "/variants/" +
+         get_theme_variant() + "/";
 }
 
 QString AOApplication::get_default_theme_path()
@@ -81,7 +84,8 @@ QString AOApplication::get_background_path()
 {
   if (courtroom_constructed)
     return w_courtroom->get_background_path();
-  //this function being called when the courtroom isn't constructed makes no sense
+  // this function being called when the courtroom isn't constructed makes no
+  // sense
   return "";
 }
 
@@ -92,19 +96,20 @@ QString AOApplication::get_default_background_path()
 
 QString AOApplication::get_evidence_path()
 {
-    QString default_path = "evidence/";
-    QString alt_path = "items/";
-    if (dir_exists(default_path))
-      return get_base_path() + default_path;
-    else if (dir_exists(alt_path))
-      return get_base_path() + alt_path;
-    else
-      return get_base_path() + default_path;
+  QString default_path = "evidence/";
+  QString alt_path = "items/";
+  if (dir_exists(default_path))
+    return get_base_path() + default_path;
+  else if (dir_exists(alt_path))
+    return get_base_path() + alt_path;
+  else
+    return get_base_path() + default_path;
 }
 
 QString Courtroom::get_background_path()
 {
-  return ao_app->get_base_path() + "background/" + current_background.toLower() + "/";
+  return ao_app->get_base_path() + "background/" +
+         current_background.toLower() + "/";
 }
 
 QString Courtroom::get_default_background_path()

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -44,7 +44,10 @@ QString AOApplication::get_base_path()
   return base_path;
 }
 
-QString AOApplication::get_data_path() { return get_base_path() + "data/"; }
+QString AOApplication::get_data_path()
+{
+  return get_base_path() + "data/";
+}
 
 QString AOApplication::get_theme_path(QString p_file)
 {

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -5,25 +5,30 @@
 #include <QDir>
 #include <QStandardPaths>
 
+// Copied over from Vanilla.
+// As said in the comments there, this is a *super broad* definition.
+// Linux is guaranteed to be case-sensitive, however, in case of Mac, it...
+// depends. On Mac, it can be toggled. So, should the time ever come to that,
+// manually define CASE_SENSITIVE_FILESYSTEM if you're working on a Mac that
+// has, well, a case-sensitive filesystem.
+#if (defined(LINUX) || defined(__linux__))
+#define CASE_SENSITIVE_FILESYSTEM
+#endif
+
 #ifdef BASE_OVERRIDE
 #include "base_override.h"
 #endif
 QString base_path = "";
 
-QString AOApplication::get_base_path()
-{
-  if (base_path == "")
-  {
+QString AOApplication::get_base_path() {
+  if (base_path == "") {
 #ifdef BASE_OVERRIDE
     base_path = base_override;
 #elif defined(ANDROID)
     QString sdcard_storage = getenv("SECONDARY_STORAGE");
-    if (dir_exists(sdcard_storage + "/AO2/"))
-    {
+    if (dir_exists(sdcard_storage + "/AO2/")) {
       base_path = sdcard_storage + "/AO2/";
-    }
-    else
-    {
+    } else {
       QString external_storage = getenv("EXTERNAL_STORAGE");
       base_path = external_storage + "/AO2/";
     }
@@ -34,85 +39,125 @@ QString AOApplication::get_base_path()
   return base_path;
 }
 
-QString AOApplication::get_data_path()
-{
-  return get_base_path() + "data/";
+QString AOApplication::get_data_path() { return get_base_path() + "data/"; }
+
+QString AOApplication::get_theme_path(QString p_file) {
+  QString path = get_base_path() + "themes/" + get_theme() + "/" + p_file;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_theme_path()
-{
-  return get_base_path() + "themes/" + get_theme().toLower() + "/";
+QString AOApplication::get_theme_variant_path(QString p_file) {
+  QString path = get_base_path() + "themes/" + get_theme().toLower() +
+                 "/variants/" + get_theme_variant() + "/" + p_file;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_theme_variant_path()
-{
-  return get_base_path() + "themes/" + get_theme().toLower() + "/variants/" +
-         get_theme_variant() + "/";
+QString AOApplication::get_default_theme_path(QString p_file) {
+  QString path = get_base_path() + "themes/default/" + p_file;
+
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_default_theme_path()
-{
-  return get_base_path() + "themes/default/";
+QString AOApplication::get_character_path(QString p_character, QString p_file) {
+  QString path = get_base_path() + "characters/" + p_character + "/" + p_file;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_character_path(QString p_character)
-{
-  return get_base_path() + "characters/" + p_character.toLower() + "/";
+// QString AOApplication::get_demothings_path() {
+//  QString default_path = "misc/demothings/";
+//  QString alt_path = "misc/RosterImages";
+//  if (dir_exists(default_path))
+//    return get_base_path() + default_path;
+//  else if (dir_exists(alt_path))
+//    return get_base_path() + alt_path;
+//  else
+//    return get_base_path() + default_path;
+//}
+
+QString AOApplication::get_sounds_path(QString p_file) {
+  QString path = get_base_path() + "sounds/general/" + p_file;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_demothings_path()
-{
-  QString default_path = "misc/demothings/";
-  QString alt_path = "misc/RosterImages";
-  if (dir_exists(default_path))
-    return get_base_path() + default_path;
-  else if (dir_exists(alt_path))
-    return get_base_path() + alt_path;
-  else
-    return get_base_path() + default_path;
-}
-QString AOApplication::get_sounds_path()
-{
-  return get_base_path() + "sounds/general/";
-}
-QString AOApplication::get_music_path(QString p_song)
-{
-  return get_base_path() + "sounds/music/" + p_song.toLower();
+QString AOApplication::get_music_path(QString p_song) {
+  QString path = get_base_path() + "sounds/music/" + p_song;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_background_path()
-{
-  if (courtroom_constructed)
-    return w_courtroom->get_background_path();
+QString AOApplication::get_background_path(QString p_file) {
+  if (courtroom_constructed) {
+    return get_case_sensitive_path(w_courtroom->get_background_path(p_file));
+  }
   // this function being called when the courtroom isn't constructed makes no
   // sense
   return "";
 }
 
-QString AOApplication::get_default_background_path()
-{
-  return get_base_path() + "background/gs4/";
+QString AOApplication::get_default_background_path(QString p_file) {
+  QString path = get_base_path() + "background/gs4/" + p_file;
+  return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_evidence_path()
-{
-  QString default_path = "evidence/";
-  QString alt_path = "items/";
-  if (dir_exists(default_path))
-    return get_base_path() + default_path;
-  else if (dir_exists(alt_path))
-    return get_base_path() + alt_path;
+QString AOApplication::get_evidence_path(QString p_file) {
+  QString default_path =
+      get_case_sensitive_path(get_base_path() + "evidence/" + p_file);
+  QString alt_path =
+      get_case_sensitive_path(get_base_path() + "items/" + p_file);
+
+  if (QFile(default_path).exists())
+    return default_path;
   else
-    return get_base_path() + default_path;
+    return alt_path;
 }
 
-QString Courtroom::get_background_path()
-{
-  return ao_app->get_base_path() + "background/" +
-         current_background.toLower() + "/";
+QString Courtroom::get_background_path(QString p_file) {
+  return ao_app->get_base_path() + "background/" + current_background + "/" +
+         p_file;
 }
 
-QString Courtroom::get_default_background_path()
-{
-  return ao_app->get_base_path() + "background/gs4/";
+QString AOApplication::get_file_extension(QString p_file,
+                                          QVector<QString> p_exts) {
+  for (auto &ext : p_exts) {
+    if (file_exists(get_case_sensitive_path(p_file + ext)))
+      return ext;
+  }
+  return "";
 }
+
+#ifndef CASE_SENSITIVE_FILESYSTEM
+QString AOApplication::get_case_sensitive_path(QString p_file) {
+  return p_file;
+}
+#else
+QString AOApplication::get_case_sensitive_path(QString p_file) {
+  // First, check to see if the file already exists as it is.
+  if (QFile(p_file).exists())
+    return p_file;
+
+  QFileInfo file(p_file);
+
+  QString file_basename = file.fileName();
+  QString file_parent_dir = get_case_sensitive_path(file.absolutePath());
+
+  // Second, does it exist in the new parent directory?
+  if (QFile(file_parent_dir + "/" + file_basename).exists())
+    return file_parent_dir + "/" + file_basename;
+
+  // In case it doesn't, look through the entries in the parent directory, and
+  // try and find it based on a case-insensitive regex search.
+  // Note also the fixed string search here. This is so that, for example, music
+  // files with parentheses don't get interpreted as grouping for a regex
+  // search.
+  QRegExp file_rx =
+      QRegExp(file_basename, Qt::CaseInsensitive, QRegExp::FixedString);
+  QStringList files = QDir(file_parent_dir).entryList();
+
+  int result = files.indexOf(file_rx);
+
+  if (result != -1)
+    return file_parent_dir + "/" + files.at(result);
+
+  // If nothing is found, we let the caller handle that case.
+  return file_parent_dir + "/" + file_basename;
+}
+#endif

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -20,15 +20,20 @@
 #endif
 QString base_path = "";
 
-QString AOApplication::get_base_path() {
-  if (base_path == "") {
+QString AOApplication::get_base_path()
+{
+  if (base_path == "")
+  {
 #ifdef BASE_OVERRIDE
     base_path = base_override;
 #elif defined(ANDROID)
     QString sdcard_storage = getenv("SECONDARY_STORAGE");
-    if (dir_exists(sdcard_storage + "/AO2/")) {
+    if (dir_exists(sdcard_storage + "/AO2/"))
+    {
       base_path = sdcard_storage + "/AO2/";
-    } else {
+    }
+    else
+    {
       QString external_storage = getenv("EXTERNAL_STORAGE");
       base_path = external_storage + "/AO2/";
     }
@@ -41,24 +46,28 @@ QString AOApplication::get_base_path() {
 
 QString AOApplication::get_data_path() { return get_base_path() + "data/"; }
 
-QString AOApplication::get_theme_path(QString p_file) {
+QString AOApplication::get_theme_path(QString p_file)
+{
   QString path = get_base_path() + "themes/" + get_theme() + "/" + p_file;
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_theme_variant_path(QString p_file) {
+QString AOApplication::get_theme_variant_path(QString p_file)
+{
   QString path = get_base_path() + "themes/" + get_theme().toLower() +
                  "/variants/" + get_theme_variant() + "/" + p_file;
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_default_theme_path(QString p_file) {
+QString AOApplication::get_default_theme_path(QString p_file)
+{
   QString path = get_base_path() + "themes/default/" + p_file;
 
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_character_path(QString p_character, QString p_file) {
+QString AOApplication::get_character_path(QString p_character, QString p_file)
+{
   QString path = get_base_path() + "characters/" + p_character + "/" + p_file;
   return get_case_sensitive_path(path);
 }
@@ -74,18 +83,22 @@ QString AOApplication::get_character_path(QString p_character, QString p_file) {
 //    return get_base_path() + default_path;
 //}
 
-QString AOApplication::get_sounds_path(QString p_file) {
+QString AOApplication::get_sounds_path(QString p_file)
+{
   QString path = get_base_path() + "sounds/general/" + p_file;
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_music_path(QString p_song) {
+QString AOApplication::get_music_path(QString p_song)
+{
   QString path = get_base_path() + "sounds/music/" + p_song;
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_background_path(QString p_file) {
-  if (courtroom_constructed) {
+QString AOApplication::get_background_path(QString p_file)
+{
+  if (courtroom_constructed)
+  {
     return get_case_sensitive_path(w_courtroom->get_background_path(p_file));
   }
   // this function being called when the courtroom isn't constructed makes no
@@ -93,12 +106,14 @@ QString AOApplication::get_background_path(QString p_file) {
   return "";
 }
 
-QString AOApplication::get_default_background_path(QString p_file) {
+QString AOApplication::get_default_background_path(QString p_file)
+{
   QString path = get_base_path() + "background/gs4/" + p_file;
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_evidence_path(QString p_file) {
+QString AOApplication::get_evidence_path(QString p_file)
+{
   QString default_path =
       get_case_sensitive_path(get_base_path() + "evidence/" + p_file);
   QString alt_path =
@@ -110,14 +125,17 @@ QString AOApplication::get_evidence_path(QString p_file) {
     return alt_path;
 }
 
-QString Courtroom::get_background_path(QString p_file) {
+QString Courtroom::get_background_path(QString p_file)
+{
   return ao_app->get_base_path() + "background/" + current_background + "/" +
          p_file;
 }
 
 QString AOApplication::get_file_extension(QString p_file,
-                                          QVector<QString> p_exts) {
-  for (auto &ext : p_exts) {
+                                          QVector<QString> p_exts)
+{
+  for (auto &ext : p_exts)
+  {
     if (file_exists(get_case_sensitive_path(p_file + ext)))
       return ext;
   }
@@ -125,11 +143,13 @@ QString AOApplication::get_file_extension(QString p_file,
 }
 
 #ifndef CASE_SENSITIVE_FILESYSTEM
-QString AOApplication::get_case_sensitive_path(QString p_file) {
+QString AOApplication::get_case_sensitive_path(QString p_file)
+{
   return p_file;
 }
 #else
-QString AOApplication::get_case_sensitive_path(QString p_file) {
+QString AOApplication::get_case_sensitive_path(QString p_file)
+{
   // First, check to see if the file already exists as it is.
   if (QFile(p_file).exists())
     return p_file;

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -4,98 +4,98 @@
 
 #include "aoconfig.h"
 
-#include <QTextStream>
-#include <QStringList>
-#include <QVector>
-#include <QDebug>
 #include <QColor>
+#include <QDebug>
+#include <QStringList>
+#include <QTextStream>
+#include <QVector>
 
 QString AOApplication::get_theme()
 {
-    return config->theme();
+  return config->theme();
 }
 
 QString AOApplication::get_theme_variant()
 {
-    return config->theme_variant();
+  return config->theme_variant();
 }
 
 int AOApplication::read_blip_rate()
 {
-    return config->blip_rate();
+  return config->blip_rate();
 }
 
 bool AOApplication::read_chatlog_newline()
 {
-    return config->log_uses_newline_enabled();
+  return config->log_uses_newline_enabled();
 }
 
 int AOApplication::get_default_music()
 {
-    return config->music_volume();
+  return config->music_volume();
 }
 
 int AOApplication::get_default_sfx()
 {
-    return config->effects_volume();
+  return config->effects_volume();
 }
 
 int AOApplication::get_default_blip()
 {
-    return config->blips_volume();
+  return config->blips_volume();
 }
 
 QStringList AOApplication::get_callwords()
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    return config->callwords().split(" ", QString::SkipEmptyParts);
+  return config->callwords().split(" ", QString::SkipEmptyParts);
 #else
-    return config->callwords().split(" ", Qt::SkipEmptyParts);
+  return config->callwords().split(" ", Qt::SkipEmptyParts);
 #endif
 }
 
 QString AOApplication::read_note(QString filename)
 {
-    QFile note_txt(filename);
+  QFile note_txt(filename);
 
-    if(!note_txt.open(QIODevice::ReadOnly | QFile::Text))
-    {
-        qDebug() << "Couldn't open" << filename;
-        return "";
-    }
+  if (!note_txt.open(QIODevice::ReadOnly | QFile::Text))
+  {
+    qDebug() << "Couldn't open" << filename;
+    return "";
+  }
 
-    QTextStream in(&note_txt);
-    QString text = in.readAll();
-    note_txt.close();
-    return text;
+  QTextStream in(&note_txt);
+  QString text = in.readAll();
+  note_txt.close();
+  return text;
 }
 
 void AOApplication::write_note(QString p_text, QString p_file)
 {
-    QFile f_log(p_file);
-    if(f_log.open(QIODevice::WriteOnly | QFile::Text))
-    {
-        QTextStream out(&f_log);
+  QFile f_log(p_file);
+  if (f_log.open(QIODevice::WriteOnly | QFile::Text))
+  {
+    QTextStream out(&f_log);
 
-        out << p_text;
+    out << p_text;
 
-        f_log.flush();
-        f_log.close();
-    }
+    f_log.flush();
+    f_log.close();
+  }
 }
 
 void AOApplication::append_note(QString p_line, QString p_file)
 {
   QFile f_log(p_file);
-  if(f_log.open(QIODevice::WriteOnly | QIODevice::Append))
-    {
-      QTextStream out(&f_log);
+  if (f_log.open(QIODevice::WriteOnly | QIODevice::Append))
+  {
+    QTextStream out(&f_log);
 
-      out << p_line << "\r\n";
+    out << p_line << "\r\n";
 
-      f_log.flush();
-      f_log.close();
-    }
+    f_log.flush();
+    f_log.close();
+  }
 }
 
 void AOApplication::write_to_serverlist_txt(QString p_line)
@@ -133,14 +133,14 @@ QVector<server_type> AOApplication::read_serverlist_txt()
 
   QTextStream in(&serverlist_txt);
 
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString line = in.readLine();
     server_type f_server;
     QStringList line_contents = line.split(":");
 
     if (line_contents.size() < 3)
-        continue;
+      continue;
 
     f_server.ip = line_contents.at(0);
     f_server.port = line_contents.at(1).toInt();
@@ -153,7 +153,8 @@ QVector<server_type> AOApplication::read_serverlist_txt()
   return f_server_list;
 }
 
-QString AOApplication::read_design_ini(QString p_identifier, QString p_design_path)
+QString AOApplication::read_design_ini(QString p_identifier,
+                                       QString p_design_path)
 {
   QFile design_ini;
 
@@ -219,7 +220,8 @@ QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
   return return_value;
 }
 
-pos_size_type AOApplication::get_element_dimensions(QString p_identifier, QString p_file)
+pos_size_type AOApplication::get_element_dimensions(QString p_identifier,
+                                                    QString p_file)
 {
   pos_size_type return_value;
   return_value.x = 0;
@@ -290,7 +292,8 @@ QString AOApplication::get_sfx(QString p_identifier)
 
 QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
 {
-  QStringList paths{get_theme_variant_path() + p_file, get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path() + p_file,
+                    get_theme_path() + p_file};
 
   for (QString path : paths)
   {
@@ -332,7 +335,8 @@ QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
 QVector<QStringList> AOApplication::get_highlight_color()
 {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file, get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path() + p_file,
+                    get_theme_path() + p_file};
 
   for (QString path : paths)
   {
@@ -358,16 +362,16 @@ QVector<QStringList> AOApplication::get_highlight_color()
 
       if (tag_found)
       {
-        if((line.startsWith("[") && line.endsWith("]")))
+        if ((line.startsWith("[") && line.endsWith("]")))
           break;
         // Syntax
         // OpenercharCloserchar = Color, Shown
-        // Shown is 1 if the character should be displayed in IC, 0 otherwise. If not present,
-        // assume 1.
+        // Shown is 1 if the character should be displayed in IC, 0 otherwise.
+        // If not present, assume 1.
         QString chars = line.split("=")[0].trimmed();
-        QString chars_parameters = line.mid(line.indexOf("=")+1);
+        QString chars_parameters = line.mid(line.indexOf("=") + 1);
         QStringList parameters = chars_parameters.split(",");
-        for (int i=0; i<parameters.size(); i++)
+        for (int i = 0; i < parameters.size(); i++)
           parameters[i] = parameters[i].trimmed();
         if (parameters.size() == 1)
           parameters.append("1");
@@ -388,7 +392,8 @@ QVector<QStringList> AOApplication::get_highlight_color()
 QString AOApplication::get_spbutton(QString p_tag, int index)
 {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file, get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path() + p_file,
+                    get_theme_path() + p_file};
 
   for (QString path : paths)
   {
@@ -415,7 +420,7 @@ QString AOApplication::get_spbutton(QString p_tag, int index)
       if (tag_found)
       {
         if ((line.startsWith("[") && line.endsWith("]")))
-           break;
+          break;
 
         QStringList line_contents = line.split("=");
         if (line_contents.at(0).trimmed() == QString::number(index))
@@ -435,7 +440,8 @@ QString AOApplication::get_spbutton(QString p_tag, int index)
 QStringList AOApplication::get_effect(int index)
 {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file, get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path() + p_file,
+                    get_theme_path() + p_file};
 
   for (QString path : paths)
   {
@@ -490,9 +496,11 @@ QStringList AOApplication::get_sfx_list()
   QFile char_sfx_list_ini;
 
   base_sfx_list_ini.setFileName(get_base_path() + "configs/sounds.ini");
-  char_sfx_list_ini.setFileName(get_character_path(get_current_char()) + "sounds.ini");
+  char_sfx_list_ini.setFileName(get_character_path(get_current_char()) +
+                                "sounds.ini");
 
-  if (!char_sfx_list_ini.open(QIODevice::ReadOnly) && !base_sfx_list_ini.open(QIODevice::ReadOnly))
+  if (!char_sfx_list_ini.open(QIODevice::ReadOnly) &&
+      !base_sfx_list_ini.open(QIODevice::ReadOnly))
   {
     return return_value;
   }
@@ -515,9 +523,11 @@ QStringList AOApplication::get_sfx_list()
   return return_value;
 }
 
-//returns whatever is to the right of "search_line =" within target_tag and terminator_tag, trimmed
-//returns the empty string if the search line couldnt be found
-QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QString target_tag, QString terminator_tag)
+// returns whatever is to the right of "search_line =" within target_tag and
+// terminator_tag, trimmed returns the empty string if the search line couldnt
+// be found
+QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
+                                     QString target_tag, QString terminator_tag)
 {
   QString char_ini_path = get_character_path(p_char) + "char.ini";
 
@@ -532,7 +542,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QStr
 
   bool tag_found = false;
 
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString line = in.readLine();
 
@@ -550,7 +560,8 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QStr
 
     QStringList line_elements = line.split("=");
 
-    if (QString::compare(line_elements.at(0).trimmed(), p_search_line, Qt::CaseInsensitive) != 0)
+    if (QString::compare(line_elements.at(0).trimmed(), p_search_line,
+                         Qt::CaseInsensitive) != 0)
       continue;
 
     if (line_elements.size() < 2)
@@ -573,36 +584,41 @@ QString AOApplication::get_char_name(QString p_char)
 
   if (f_result == "")
     return p_char;
-  else return f_result;
+  else
+    return f_result;
 }
 
 QString AOApplication::get_showname(QString p_char)
 {
   QString f_result = read_showname(p_char);
-  if(f_result == "")
+  if (f_result == "")
     f_result = read_char_ini(p_char, "showname", "[Options]", "[Time]");
 
   if (f_result == "")
     return p_char;
-  else return f_result;
+  else
+    return f_result;
 }
 
 QString AOApplication::read_showname(QString p_char)
 {
   QString f_filename = get_base_path() + "configs/shownames.ini";
   QFile f_file(f_filename);
-  if(!f_file.open(QIODevice::ReadOnly))
-  { qDebug() << "Error reading" << f_filename; return ""; }
+  if (!f_file.open(QIODevice::ReadOnly))
+  {
+    qDebug() << "Error reading" << f_filename;
+    return "";
+  }
 
   QTextStream in(&f_file);
-  while(!in.atEnd())
+  while (!in.atEnd())
   {
     QString f_line = in.readLine();
-    if(!f_line.startsWith(p_char))
+    if (!f_line.startsWith(p_char))
       continue;
 
     QStringList line_elements = f_line.split("=");
-    if(line_elements.at(0).trimmed() == p_char)
+    if (line_elements.at(0).trimmed() == p_char)
       return line_elements.at(1).trimmed();
   }
   return "";
@@ -614,7 +630,8 @@ QString AOApplication::get_char_side(QString p_char)
 
   if (f_result == "")
     return "wit";
-  else return f_result;
+  else
+    return f_result;
 }
 
 QString AOApplication::get_gender(QString p_char)
@@ -623,14 +640,16 @@ QString AOApplication::get_gender(QString p_char)
 
   if (f_result == "")
     return "male";
-  else return f_result;
+  else
+    return f_result;
 }
 
 QString AOApplication::get_chat(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "chat", "[Options]", "[Time]");
 
-  //handling the correct order of chat is a bit complicated, we let the caller do it
+  // handling the correct order of chat is a bit complicated, we let the caller
+  // do it
   return f_result.toLower();
 }
 
@@ -647,12 +666,14 @@ int AOApplication::get_emote_number(QString p_char)
 
   if (f_result == "")
     return 0;
-  else return f_result.toInt();
+  else
+    return f_result.toInt();
 }
 
 QString AOApplication::get_emote_comment(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[Emotions]", "[Offsets]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
@@ -661,12 +682,14 @@ QString AOApplication::get_emote_comment(QString p_char, int p_emote)
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
   }
-  else return result_contents.at(0);
+  else
+    return result_contents.at(0);
 }
 
 QString AOApplication::get_pre_emote(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[Emotions]", "[Offsets]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
@@ -675,12 +698,14 @@ QString AOApplication::get_pre_emote(QString p_char, int p_emote)
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "";
   }
-  else return result_contents.at(1);
+  else
+    return result_contents.at(1);
 }
 
 QString AOApplication::get_emote(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[Emotions]", "[Offsets]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
@@ -689,26 +714,31 @@ QString AOApplication::get_emote(QString p_char, int p_emote)
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
   }
-  else return result_contents.at(2);
+  else
+    return result_contents.at(2);
 }
 
 int AOApplication::get_emote_mod(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[Emotions]", "[Offsets]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
   if (result_contents.size() < 4)
   {
-    qDebug() << "W: misformatted char.ini: " << p_char << ", " << QString::number(p_emote);
+    qDebug() << "W: misformatted char.ini: " << p_char << ", "
+             << QString::number(p_emote);
     return 0;
   }
-  else return result_contents.at(3).toInt();
+  else
+    return result_contents.at(3).toInt();
 }
 
 int AOApplication::get_desk_mod(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[Emotions]", "[Offsets]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
@@ -719,22 +749,27 @@ int AOApplication::get_desk_mod(QString p_char, int p_emote)
   if (string_result == "")
     return -1;
 
-  else return string_result.toInt();
+  else
+    return string_result.toInt();
 }
 
 QStringList AOApplication::get_effect_offset(QString p_char, int p_effect)
 {
-  QStringList f_result = read_char_ini(p_char, QString::number(p_effect), "[Offsets]", "[Overlay]").split(",");
+  QStringList f_result =
+      read_char_ini(p_char, QString::number(p_effect), "[Offsets]", "[Overlay]")
+          .split(",");
 
   if (f_result.size() < 2)
-    return decltype(f_result) {0, 0};
+    return decltype(f_result){0, 0};
 
   return f_result;
 }
 
 QStringList AOApplication::get_overlay(QString p_char, int p_effect)
 {
-  QStringList f_result = read_char_ini(p_char, QString::number(p_effect), "[Overlay]", "[SoundN]").split("#");
+  QStringList f_result =
+      read_char_ini(p_char, QString::number(p_effect), "[Overlay]", "[SoundN]")
+          .split("#");
 
   if (f_result.size() < 2)
     f_result.push_back("");
@@ -744,34 +779,40 @@ QStringList AOApplication::get_overlay(QString p_char, int p_effect)
 
 QString AOApplication::get_sfx_name(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[SoundN]", "[SoundT]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[SoundN]", "[SoundT]");
 
   if (f_result == "")
     return "1";
-  else return f_result;
+  else
+    return f_result;
 }
 
 int AOApplication::get_sfx_delay(QString p_char, int p_emote)
 {
-  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "[SoundT]", "[TextDelay]");
+  QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
+                                   "[SoundT]", "[TextDelay]");
 
   if (f_result == "")
     return 1;
-  else return f_result.toInt();
+  else
+    return f_result.toInt();
 }
 
 int AOApplication::get_text_delay(QString p_char, QString p_emote)
 {
-  QString f_result = read_char_ini(p_char, p_emote, "[TextDelay]", "END_OF_FILE");
+  QString f_result =
+      read_char_ini(p_char, p_emote, "[TextDelay]", "END_OF_FILE");
 
   if (f_result == "")
     return -1;
-  else return f_result.toInt();
+  else
+    return f_result.toInt();
 }
 
 bool AOApplication::get_blank_blip()
 {
-    return config->blank_blips_enabled();
+  return config->blank_blips_enabled();
 }
 
 QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
@@ -779,12 +820,12 @@ QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
   // Try to obtain a theme ini from either the current theme variant folder,
   // the current theme folder or the default theme folder
   QStringList paths{
-    get_theme_variant_path() + p_file,
-    get_theme_path() + p_file,
-    get_default_theme_path() + p_file,
+      get_theme_variant_path() + p_file,
+      get_theme_path() + p_file,
+      get_default_theme_path() + p_file,
   };
 
-  for (QString path: paths)
+  for (QString path : paths)
   {
     QString f_result = read_design_ini(p_identifier, path);
     if (!f_result.isEmpty())

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -10,22 +10,40 @@
 #include <QTextStream>
 #include <QVector>
 
-QString AOApplication::get_theme() { return config->theme(); }
+QString AOApplication::get_theme()
+{
+  return config->theme();
+}
 
-QString AOApplication::get_theme_variant() { return config->theme_variant(); }
+QString AOApplication::get_theme_variant()
+{
+  return config->theme_variant();
+}
 
-int AOApplication::read_blip_rate() { return config->blip_rate(); }
+int AOApplication::read_blip_rate()
+{
+  return config->blip_rate();
+}
 
 bool AOApplication::read_chatlog_newline()
 {
   return config->log_uses_newline_enabled();
 }
 
-int AOApplication::get_default_music() { return config->music_volume(); }
+int AOApplication::get_default_music()
+{
+  return config->music_volume();
+}
 
-int AOApplication::get_default_sfx() { return config->effects_volume(); }
+int AOApplication::get_default_sfx()
+{
+  return config->effects_volume();
+}
 
-int AOApplication::get_default_blip() { return config->blips_volume(); }
+int AOApplication::get_default_blip()
+{
+  return config->blips_volume();
+}
 
 QStringList AOApplication::get_callwords()
 {
@@ -788,7 +806,10 @@ int AOApplication::get_text_delay(QString p_char, QString p_emote)
     return f_result.toInt();
 }
 
-bool AOApplication::get_blank_blip() { return config->blank_blips_enabled(); }
+bool AOApplication::get_blank_blip()
+{
+  return config->blank_blips_enabled();
+}
 
 QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
 {

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -16,7 +16,8 @@ QString AOApplication::get_theme_variant() { return config->theme_variant(); }
 
 int AOApplication::read_blip_rate() { return config->blip_rate(); }
 
-bool AOApplication::read_chatlog_newline() {
+bool AOApplication::read_chatlog_newline()
+{
   return config->log_uses_newline_enabled();
 }
 
@@ -26,7 +27,8 @@ int AOApplication::get_default_sfx() { return config->effects_volume(); }
 
 int AOApplication::get_default_blip() { return config->blips_volume(); }
 
-QStringList AOApplication::get_callwords() {
+QStringList AOApplication::get_callwords()
+{
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   return config->callwords().split(" ", QString::SkipEmptyParts);
 #else
@@ -34,10 +36,12 @@ QStringList AOApplication::get_callwords() {
 #endif
 }
 
-QString AOApplication::read_note(QString filename) {
+QString AOApplication::read_note(QString filename)
+{
   QFile note_txt(filename);
 
-  if (!note_txt.open(QIODevice::ReadOnly | QFile::Text)) {
+  if (!note_txt.open(QIODevice::ReadOnly | QFile::Text))
+  {
     qDebug() << "Couldn't open" << filename;
     return "";
   }
@@ -48,9 +52,11 @@ QString AOApplication::read_note(QString filename) {
   return text;
 }
 
-void AOApplication::write_note(QString p_text, QString p_file) {
+void AOApplication::write_note(QString p_text, QString p_file)
+{
   QFile f_log(p_file);
-  if (f_log.open(QIODevice::WriteOnly | QFile::Text)) {
+  if (f_log.open(QIODevice::WriteOnly | QFile::Text))
+  {
     QTextStream out(&f_log);
 
     out << p_text;
@@ -60,9 +66,11 @@ void AOApplication::write_note(QString p_text, QString p_file) {
   }
 }
 
-void AOApplication::append_note(QString p_line, QString p_file) {
+void AOApplication::append_note(QString p_line, QString p_file)
+{
   QFile f_log(p_file);
-  if (f_log.open(QIODevice::WriteOnly | QIODevice::Append)) {
+  if (f_log.open(QIODevice::WriteOnly | QIODevice::Append))
+  {
     QTextStream out(&f_log);
 
     out << p_line << "\r\n";
@@ -72,13 +80,15 @@ void AOApplication::append_note(QString p_line, QString p_file) {
   }
 }
 
-void AOApplication::write_to_serverlist_txt(QString p_line) {
+void AOApplication::write_to_serverlist_txt(QString p_line)
+{
   QFile serverlist_txt;
   QString serverlist_txt_path = get_base_path() + "serverlist.txt";
 
   serverlist_txt.setFileName(serverlist_txt_path);
 
-  if (!serverlist_txt.open(QIODevice::WriteOnly | QIODevice::Append)) {
+  if (!serverlist_txt.open(QIODevice::WriteOnly | QIODevice::Append))
+  {
     return;
   }
 
@@ -89,7 +99,8 @@ void AOApplication::write_to_serverlist_txt(QString p_line) {
   serverlist_txt.close();
 }
 
-QVector<server_type> AOApplication::read_serverlist_txt() {
+QVector<server_type> AOApplication::read_serverlist_txt()
+{
   QVector<server_type> f_server_list;
 
   QFile serverlist_txt;
@@ -97,13 +108,15 @@ QVector<server_type> AOApplication::read_serverlist_txt() {
 
   serverlist_txt.setFileName(serverlist_txt_path);
 
-  if (!serverlist_txt.open(QIODevice::ReadOnly)) {
+  if (!serverlist_txt.open(QIODevice::ReadOnly))
+  {
     return f_server_list;
   }
 
   QTextStream in(&serverlist_txt);
 
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString line = in.readLine();
     server_type f_server;
     QStringList line_contents = line.split(":");
@@ -123,19 +136,22 @@ QVector<server_type> AOApplication::read_serverlist_txt() {
 }
 
 QString AOApplication::read_design_ini(QString p_identifier,
-                                       QString p_design_path) {
+                                       QString p_design_path)
+{
   QFile design_ini;
 
   design_ini.setFileName(p_design_path);
 
-  if (!design_ini.open(QIODevice::ReadOnly)) {
+  if (!design_ini.open(QIODevice::ReadOnly))
+  {
     return "";
   }
   QTextStream in(&design_ini);
 
   QString result = "";
 
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString f_line = in.readLine().trimmed();
 
     if (!f_line.startsWith(p_identifier))
@@ -158,14 +174,16 @@ QString AOApplication::read_design_ini(QString p_identifier,
   return result;
 }
 
-int AOApplication::get_design_ini_value(QString p_identifier, QString p_file) {
+int AOApplication::get_design_ini_value(QString p_identifier, QString p_file)
+{
   QString result = read_theme_ini(p_identifier, p_file);
   if (result.isEmpty())
     return 0;
   return result.toInt();
 }
 
-QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file) {
+QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
+{
   QPoint return_value;
   return_value.setX(0);
   return_value.setY(0);
@@ -185,7 +203,8 @@ QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file) {
 }
 
 pos_size_type AOApplication::get_element_dimensions(QString p_identifier,
-                                                    QString p_file) {
+                                                    QString p_file)
+{
   pos_size_type return_value;
   return_value.x = 0;
   return_value.y = 0;
@@ -209,7 +228,8 @@ pos_size_type AOApplication::get_element_dimensions(QString p_identifier,
   return return_value;
 }
 
-int AOApplication::get_font_property(QString p_identifier, QString p_file) {
+int AOApplication::get_font_property(QString p_identifier, QString p_file)
+{
   QString f_result = read_theme_ini(p_identifier, p_file);
 
   if (f_result.isEmpty())
@@ -217,7 +237,8 @@ int AOApplication::get_font_property(QString p_identifier, QString p_file) {
   return f_result.toInt();
 }
 
-QColor AOApplication::get_color(QString p_identifier, QString p_file) {
+QColor AOApplication::get_color(QString p_identifier, QString p_file)
+{
   QColor return_color(255, 255, 255);
 
   QString f_result = read_theme_ini(p_identifier, p_file);
@@ -236,7 +257,8 @@ QColor AOApplication::get_color(QString p_identifier, QString p_file) {
   return return_color;
 }
 
-QString AOApplication::get_font_name(QString p_identifier, QString p_file) {
+QString AOApplication::get_font_name(QString p_identifier, QString p_file)
+{
   QString f_result = read_theme_ini(p_identifier, p_file);
 
   if (f_result.isEmpty())
@@ -245,14 +267,17 @@ QString AOApplication::get_font_name(QString p_identifier, QString p_file) {
   return f_result;
 }
 
-QString AOApplication::get_sfx(QString p_identifier) {
+QString AOApplication::get_sfx(QString p_identifier)
+{
   return read_theme_ini(p_identifier, "courtroom_sounds.ini");
 }
 
-QString AOApplication::get_stylesheet(QString target_tag, QString p_file) {
+QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
+{
   QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QFile design_ini;
     design_ini.setFileName(path);
     if (!design_ini.open(QIODevice::ReadOnly))
@@ -262,14 +287,17 @@ QString AOApplication::get_stylesheet(QString target_tag, QString p_file) {
     QString f_text;
     bool tag_found = false;
 
-    while (!in.atEnd()) {
+    while (!in.atEnd())
+    {
       QString line = in.readLine();
-      if (line.startsWith(target_tag, Qt::CaseInsensitive)) {
+      if (line.startsWith(target_tag, Qt::CaseInsensitive))
+      {
         tag_found = true;
         continue;
       }
 
-      if (tag_found) {
+      if (tag_found)
+      {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
         f_text.append(line);
@@ -285,11 +313,13 @@ QString AOApplication::get_stylesheet(QString target_tag, QString p_file) {
   return "";
 }
 
-QVector<QStringList> AOApplication::get_highlight_color() {
+QVector<QStringList> AOApplication::get_highlight_color()
+{
   QString p_file = "courtroom_config.ini";
   QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QVector<QStringList> f_vec;
 
     QFile design_ini;
@@ -300,15 +330,18 @@ QVector<QStringList> AOApplication::get_highlight_color() {
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd()) {
+    while (!in.atEnd())
+    {
       QString line = in.readLine();
 
-      if (line.startsWith("[HIGHLIGHTS]", Qt::CaseInsensitive)) {
+      if (line.startsWith("[HIGHLIGHTS]", Qt::CaseInsensitive))
+      {
         tag_found = true;
         continue;
       }
 
-      if (tag_found) {
+      if (tag_found)
+      {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
         // Syntax
@@ -336,11 +369,13 @@ QVector<QStringList> AOApplication::get_highlight_color() {
   return f_vec;
 }
 
-QString AOApplication::get_spbutton(QString p_tag, int index) {
+QString AOApplication::get_spbutton(QString p_tag, int index)
+{
   QString p_file = "courtroom_config.ini";
   QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QString res = "";
 
     QFile design_ini;
@@ -351,15 +386,18 @@ QString AOApplication::get_spbutton(QString p_tag, int index) {
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd()) {
+    while (!in.atEnd())
+    {
       QString line = in.readLine();
 
-      if (line.startsWith(p_tag, Qt::CaseInsensitive)) {
+      if (line.startsWith(p_tag, Qt::CaseInsensitive))
+      {
         tag_found = true;
         continue;
       }
 
-      if (tag_found) {
+      if (tag_found)
+      {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
 
@@ -378,11 +416,13 @@ QString AOApplication::get_spbutton(QString p_tag, int index) {
   return "";
 }
 
-QStringList AOApplication::get_effect(int index) {
+QStringList AOApplication::get_effect(int index)
+{
   QString p_file = "courtroom_config.ini";
   QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QStringList res;
 
     QFile design_ini;
@@ -393,15 +433,18 @@ QStringList AOApplication::get_effect(int index) {
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd()) {
+    while (!in.atEnd())
+    {
       QString line = in.readLine();
 
-      if (line.startsWith("[EFFECTS]", Qt::CaseInsensitive)) {
+      if (line.startsWith("[EFFECTS]", Qt::CaseInsensitive))
+      {
         tag_found = true;
         continue;
       }
 
-      if (tag_found) {
+      if (tag_found)
+      {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
 
@@ -424,7 +467,8 @@ QStringList AOApplication::get_effect(int index) {
   return res;
 }
 
-QStringList AOApplication::get_sfx_list() {
+QStringList AOApplication::get_sfx_list()
+{
   QStringList return_value;
   QFile base_sfx_list_ini;
   QFile char_sfx_list_ini;
@@ -434,19 +478,22 @@ QStringList AOApplication::get_sfx_list() {
       get_character_path(get_current_char(), "sounds.ini"));
 
   if (!char_sfx_list_ini.open(QIODevice::ReadOnly) &&
-      !base_sfx_list_ini.open(QIODevice::ReadOnly)) {
+      !base_sfx_list_ini.open(QIODevice::ReadOnly))
+  {
     return return_value;
   }
 
   QTextStream in_a(&base_sfx_list_ini);
   QTextStream in_b(&char_sfx_list_ini);
 
-  while (!in_a.atEnd()) {
+  while (!in_a.atEnd())
+  {
     QString line = in_a.readLine();
     return_value.append(line);
   }
 
-  while (!in_b.atEnd()) {
+  while (!in_b.atEnd())
+  {
     QString line = in_b.readLine();
     return_value.append(line);
   }
@@ -458,8 +505,8 @@ QStringList AOApplication::get_sfx_list() {
 // terminator_tag, trimmed returns the empty string if the search line couldnt
 // be found
 QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
-                                     QString target_tag,
-                                     QString terminator_tag) {
+                                     QString target_tag, QString terminator_tag)
+{
   QString char_ini_path = get_character_path(p_char, "char.ini");
 
   QFile char_ini;
@@ -473,13 +520,15 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
 
   bool tag_found = false;
 
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString line = in.readLine();
 
     if (QString::compare(line, terminator_tag, Qt::CaseInsensitive) == 0)
       break;
 
-    if (line.startsWith(target_tag, Qt::CaseInsensitive)) {
+    if (line.startsWith(target_tag, Qt::CaseInsensitive))
+    {
       tag_found = true;
       continue;
     }
@@ -496,7 +545,8 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
     if (line_elements.size() < 2)
       continue;
 
-    if (tag_found) {
+    if (tag_found)
+    {
       char_ini.close();
       return line_elements.at(1).trimmed();
     }
@@ -506,7 +556,8 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
   return "";
 }
 
-QString AOApplication::get_char_name(QString p_char) {
+QString AOApplication::get_char_name(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "name", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -515,7 +566,8 @@ QString AOApplication::get_char_name(QString p_char) {
     return f_result;
 }
 
-QString AOApplication::get_showname(QString p_char) {
+QString AOApplication::get_showname(QString p_char)
+{
   QString f_result = read_showname(p_char);
   if (f_result == "")
     f_result = read_char_ini(p_char, "showname", "[Options]", "[Time]");
@@ -526,16 +578,19 @@ QString AOApplication::get_showname(QString p_char) {
     return f_result;
 }
 
-QString AOApplication::read_showname(QString p_char) {
+QString AOApplication::read_showname(QString p_char)
+{
   QString f_filename = get_base_path() + "configs/shownames.ini";
   QFile f_file(f_filename);
-  if (!f_file.open(QIODevice::ReadOnly)) {
+  if (!f_file.open(QIODevice::ReadOnly))
+  {
     qDebug() << "Error reading" << f_filename;
     return "";
   }
 
   QTextStream in(&f_file);
-  while (!in.atEnd()) {
+  while (!in.atEnd())
+  {
     QString f_line = in.readLine();
     if (!f_line.startsWith(p_char))
       continue;
@@ -547,7 +602,8 @@ QString AOApplication::read_showname(QString p_char) {
   return "";
 }
 
-QString AOApplication::get_char_side(QString p_char) {
+QString AOApplication::get_char_side(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "side", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -556,7 +612,8 @@ QString AOApplication::get_char_side(QString p_char) {
     return f_result;
 }
 
-QString AOApplication::get_gender(QString p_char) {
+QString AOApplication::get_gender(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "gender", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -565,7 +622,8 @@ QString AOApplication::get_gender(QString p_char) {
     return f_result;
 }
 
-QString AOApplication::get_chat(QString p_char) {
+QString AOApplication::get_chat(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "chat", "[Options]", "[Time]");
 
   // handling the correct order of chat is a bit complicated, we let the caller
@@ -573,13 +631,15 @@ QString AOApplication::get_chat(QString p_char) {
   return f_result.toLower();
 }
 
-QString AOApplication::get_char_shouts(QString p_char) {
+QString AOApplication::get_char_shouts(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "shouts", "[Options]", "[Time]");
 
   return f_result.toLower();
 }
 
-int AOApplication::get_emote_number(QString p_char) {
+int AOApplication::get_emote_number(QString p_char)
+{
   QString f_result = read_char_ini(p_char, "number", "[Emotions]", "[Offsets]");
 
   if (f_result == "")
@@ -588,60 +648,73 @@ int AOApplication::get_emote_number(QString p_char) {
     return f_result.toInt();
 }
 
-QString AOApplication::get_emote_comment(QString p_char, int p_emote) {
+QString AOApplication::get_emote_comment(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4) {
+  if (result_contents.size() < 4)
+  {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
-  } else
+  }
+  else
     return result_contents.at(0);
 }
 
-QString AOApplication::get_pre_emote(QString p_char, int p_emote) {
+QString AOApplication::get_pre_emote(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4) {
+  if (result_contents.size() < 4)
+  {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "";
-  } else
+  }
+  else
     return result_contents.at(1);
 }
 
-QString AOApplication::get_emote(QString p_char, int p_emote) {
+QString AOApplication::get_emote(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4) {
+  if (result_contents.size() < 4)
+  {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
-  } else
+  }
+  else
     return result_contents.at(2);
 }
 
-int AOApplication::get_emote_mod(QString p_char, int p_emote) {
+int AOApplication::get_emote_mod(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4) {
+  if (result_contents.size() < 4)
+  {
     qDebug() << "W: misformatted char.ini: " << p_char << ", "
              << QString::number(p_emote);
     return 0;
-  } else
+  }
+  else
     return result_contents.at(3).toInt();
 }
 
-int AOApplication::get_desk_mod(QString p_char, int p_emote) {
+int AOApplication::get_desk_mod(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
@@ -658,7 +731,8 @@ int AOApplication::get_desk_mod(QString p_char, int p_emote) {
     return string_result.toInt();
 }
 
-QStringList AOApplication::get_effect_offset(QString p_char, int p_effect) {
+QStringList AOApplication::get_effect_offset(QString p_char, int p_effect)
+{
   QStringList f_result =
       read_char_ini(p_char, QString::number(p_effect), "[Offsets]", "[Overlay]")
           .split(",");
@@ -669,7 +743,8 @@ QStringList AOApplication::get_effect_offset(QString p_char, int p_effect) {
   return f_result;
 }
 
-QStringList AOApplication::get_overlay(QString p_char, int p_effect) {
+QStringList AOApplication::get_overlay(QString p_char, int p_effect)
+{
   QStringList f_result =
       read_char_ini(p_char, QString::number(p_effect), "[Overlay]", "[SoundN]")
           .split("#");
@@ -680,7 +755,8 @@ QStringList AOApplication::get_overlay(QString p_char, int p_effect) {
   return f_result;
 }
 
-QString AOApplication::get_sfx_name(QString p_char, int p_emote) {
+QString AOApplication::get_sfx_name(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[SoundN]", "[SoundT]");
 
@@ -690,7 +766,8 @@ QString AOApplication::get_sfx_name(QString p_char, int p_emote) {
     return f_result;
 }
 
-int AOApplication::get_sfx_delay(QString p_char, int p_emote) {
+int AOApplication::get_sfx_delay(QString p_char, int p_emote)
+{
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[SoundT]", "[TextDelay]");
 
@@ -700,7 +777,8 @@ int AOApplication::get_sfx_delay(QString p_char, int p_emote) {
     return f_result.toInt();
 }
 
-int AOApplication::get_text_delay(QString p_char, QString p_emote) {
+int AOApplication::get_text_delay(QString p_char, QString p_emote)
+{
   QString f_result =
       read_char_ini(p_char, p_emote, "[TextDelay]", "END_OF_FILE");
 
@@ -712,7 +790,8 @@ int AOApplication::get_text_delay(QString p_char, QString p_emote) {
 
 bool AOApplication::get_blank_blip() { return config->blank_blips_enabled(); }
 
-QString AOApplication::read_theme_ini(QString p_identifier, QString p_file) {
+QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
+{
   // Try to obtain a theme ini from either the current theme variant folder,
   // the current theme folder or the default theme folder
   QStringList paths{
@@ -721,7 +800,8 @@ QString AOApplication::read_theme_ini(QString p_identifier, QString p_file) {
       get_default_theme_path(p_file),
   };
 
-  for (QString path : paths) {
+  for (QString path : paths)
+  {
     QString f_result = read_design_ini(p_identifier, path);
     if (!f_result.isEmpty())
       return f_result;
@@ -730,7 +810,8 @@ QString AOApplication::read_theme_ini(QString p_identifier, QString p_file) {
   return "";
 }
 
-QString AOApplication::get_image_path(QString p_image) {
+QString AOApplication::get_image_path(QString p_image)
+{
   QString theme_variant_image_path = get_theme_variant_path(p_image);
   QString theme_image_path = get_theme_path(p_image);
   QString default_image_path = get_default_theme_path(p_image);

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -10,43 +10,23 @@
 #include <QTextStream>
 #include <QVector>
 
-QString AOApplication::get_theme()
-{
-  return config->theme();
-}
+QString AOApplication::get_theme() { return config->theme(); }
 
-QString AOApplication::get_theme_variant()
-{
-  return config->theme_variant();
-}
+QString AOApplication::get_theme_variant() { return config->theme_variant(); }
 
-int AOApplication::read_blip_rate()
-{
-  return config->blip_rate();
-}
+int AOApplication::read_blip_rate() { return config->blip_rate(); }
 
-bool AOApplication::read_chatlog_newline()
-{
+bool AOApplication::read_chatlog_newline() {
   return config->log_uses_newline_enabled();
 }
 
-int AOApplication::get_default_music()
-{
-  return config->music_volume();
-}
+int AOApplication::get_default_music() { return config->music_volume(); }
 
-int AOApplication::get_default_sfx()
-{
-  return config->effects_volume();
-}
+int AOApplication::get_default_sfx() { return config->effects_volume(); }
 
-int AOApplication::get_default_blip()
-{
-  return config->blips_volume();
-}
+int AOApplication::get_default_blip() { return config->blips_volume(); }
 
-QStringList AOApplication::get_callwords()
-{
+QStringList AOApplication::get_callwords() {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   return config->callwords().split(" ", QString::SkipEmptyParts);
 #else
@@ -54,12 +34,10 @@ QStringList AOApplication::get_callwords()
 #endif
 }
 
-QString AOApplication::read_note(QString filename)
-{
+QString AOApplication::read_note(QString filename) {
   QFile note_txt(filename);
 
-  if (!note_txt.open(QIODevice::ReadOnly | QFile::Text))
-  {
+  if (!note_txt.open(QIODevice::ReadOnly | QFile::Text)) {
     qDebug() << "Couldn't open" << filename;
     return "";
   }
@@ -70,11 +48,9 @@ QString AOApplication::read_note(QString filename)
   return text;
 }
 
-void AOApplication::write_note(QString p_text, QString p_file)
-{
+void AOApplication::write_note(QString p_text, QString p_file) {
   QFile f_log(p_file);
-  if (f_log.open(QIODevice::WriteOnly | QFile::Text))
-  {
+  if (f_log.open(QIODevice::WriteOnly | QFile::Text)) {
     QTextStream out(&f_log);
 
     out << p_text;
@@ -84,11 +60,9 @@ void AOApplication::write_note(QString p_text, QString p_file)
   }
 }
 
-void AOApplication::append_note(QString p_line, QString p_file)
-{
+void AOApplication::append_note(QString p_line, QString p_file) {
   QFile f_log(p_file);
-  if (f_log.open(QIODevice::WriteOnly | QIODevice::Append))
-  {
+  if (f_log.open(QIODevice::WriteOnly | QIODevice::Append)) {
     QTextStream out(&f_log);
 
     out << p_line << "\r\n";
@@ -98,15 +72,13 @@ void AOApplication::append_note(QString p_line, QString p_file)
   }
 }
 
-void AOApplication::write_to_serverlist_txt(QString p_line)
-{
+void AOApplication::write_to_serverlist_txt(QString p_line) {
   QFile serverlist_txt;
   QString serverlist_txt_path = get_base_path() + "serverlist.txt";
 
   serverlist_txt.setFileName(serverlist_txt_path);
 
-  if (!serverlist_txt.open(QIODevice::WriteOnly | QIODevice::Append))
-  {
+  if (!serverlist_txt.open(QIODevice::WriteOnly | QIODevice::Append)) {
     return;
   }
 
@@ -117,8 +89,7 @@ void AOApplication::write_to_serverlist_txt(QString p_line)
   serverlist_txt.close();
 }
 
-QVector<server_type> AOApplication::read_serverlist_txt()
-{
+QVector<server_type> AOApplication::read_serverlist_txt() {
   QVector<server_type> f_server_list;
 
   QFile serverlist_txt;
@@ -126,15 +97,13 @@ QVector<server_type> AOApplication::read_serverlist_txt()
 
   serverlist_txt.setFileName(serverlist_txt_path);
 
-  if (!serverlist_txt.open(QIODevice::ReadOnly))
-  {
+  if (!serverlist_txt.open(QIODevice::ReadOnly)) {
     return f_server_list;
   }
 
   QTextStream in(&serverlist_txt);
 
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString line = in.readLine();
     server_type f_server;
     QStringList line_contents = line.split(":");
@@ -154,22 +123,19 @@ QVector<server_type> AOApplication::read_serverlist_txt()
 }
 
 QString AOApplication::read_design_ini(QString p_identifier,
-                                       QString p_design_path)
-{
+                                       QString p_design_path) {
   QFile design_ini;
 
   design_ini.setFileName(p_design_path);
 
-  if (!design_ini.open(QIODevice::ReadOnly))
-  {
+  if (!design_ini.open(QIODevice::ReadOnly)) {
     return "";
   }
   QTextStream in(&design_ini);
 
   QString result = "";
 
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString f_line = in.readLine().trimmed();
 
     if (!f_line.startsWith(p_identifier))
@@ -192,16 +158,14 @@ QString AOApplication::read_design_ini(QString p_identifier,
   return result;
 }
 
-int AOApplication::get_design_ini_value(QString p_identifier, QString p_file)
-{
+int AOApplication::get_design_ini_value(QString p_identifier, QString p_file) {
   QString result = read_theme_ini(p_identifier, p_file);
   if (result.isEmpty())
     return 0;
   return result.toInt();
 }
 
-QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
-{
+QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file) {
   QPoint return_value;
   return_value.setX(0);
   return_value.setY(0);
@@ -221,8 +185,7 @@ QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
 }
 
 pos_size_type AOApplication::get_element_dimensions(QString p_identifier,
-                                                    QString p_file)
-{
+                                                    QString p_file) {
   pos_size_type return_value;
   return_value.x = 0;
   return_value.y = 0;
@@ -246,8 +209,7 @@ pos_size_type AOApplication::get_element_dimensions(QString p_identifier,
   return return_value;
 }
 
-int AOApplication::get_font_property(QString p_identifier, QString p_file)
-{
+int AOApplication::get_font_property(QString p_identifier, QString p_file) {
   QString f_result = read_theme_ini(p_identifier, p_file);
 
   if (f_result.isEmpty())
@@ -255,8 +217,7 @@ int AOApplication::get_font_property(QString p_identifier, QString p_file)
   return f_result.toInt();
 }
 
-QColor AOApplication::get_color(QString p_identifier, QString p_file)
-{
+QColor AOApplication::get_color(QString p_identifier, QString p_file) {
   QColor return_color(255, 255, 255);
 
   QString f_result = read_theme_ini(p_identifier, p_file);
@@ -275,8 +236,7 @@ QColor AOApplication::get_color(QString p_identifier, QString p_file)
   return return_color;
 }
 
-QString AOApplication::get_font_name(QString p_identifier, QString p_file)
-{
+QString AOApplication::get_font_name(QString p_identifier, QString p_file) {
   QString f_result = read_theme_ini(p_identifier, p_file);
 
   if (f_result.isEmpty())
@@ -285,18 +245,14 @@ QString AOApplication::get_font_name(QString p_identifier, QString p_file)
   return f_result;
 }
 
-QString AOApplication::get_sfx(QString p_identifier)
-{
+QString AOApplication::get_sfx(QString p_identifier) {
   return read_theme_ini(p_identifier, "courtroom_sounds.ini");
 }
 
-QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
-{
-  QStringList paths{get_theme_variant_path() + p_file,
-                    get_theme_path() + p_file};
+QString AOApplication::get_stylesheet(QString target_tag, QString p_file) {
+  QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QFile design_ini;
     design_ini.setFileName(path);
     if (!design_ini.open(QIODevice::ReadOnly))
@@ -306,17 +262,14 @@ QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
     QString f_text;
     bool tag_found = false;
 
-    while (!in.atEnd())
-    {
+    while (!in.atEnd()) {
       QString line = in.readLine();
-      if (line.startsWith(target_tag, Qt::CaseInsensitive))
-      {
+      if (line.startsWith(target_tag, Qt::CaseInsensitive)) {
         tag_found = true;
         continue;
       }
 
-      if (tag_found)
-      {
+      if (tag_found) {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
         f_text.append(line);
@@ -332,14 +285,11 @@ QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
   return "";
 }
 
-QVector<QStringList> AOApplication::get_highlight_color()
-{
+QVector<QStringList> AOApplication::get_highlight_color() {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file,
-                    get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QVector<QStringList> f_vec;
 
     QFile design_ini;
@@ -350,18 +300,15 @@ QVector<QStringList> AOApplication::get_highlight_color()
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd())
-    {
+    while (!in.atEnd()) {
       QString line = in.readLine();
 
-      if (line.startsWith("[HIGHLIGHTS]", Qt::CaseInsensitive))
-      {
+      if (line.startsWith("[HIGHLIGHTS]", Qt::CaseInsensitive)) {
         tag_found = true;
         continue;
       }
 
-      if (tag_found)
-      {
+      if (tag_found) {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
         // Syntax
@@ -389,14 +336,11 @@ QVector<QStringList> AOApplication::get_highlight_color()
   return f_vec;
 }
 
-QString AOApplication::get_spbutton(QString p_tag, int index)
-{
+QString AOApplication::get_spbutton(QString p_tag, int index) {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file,
-                    get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QString res = "";
 
     QFile design_ini;
@@ -407,18 +351,15 @@ QString AOApplication::get_spbutton(QString p_tag, int index)
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd())
-    {
+    while (!in.atEnd()) {
       QString line = in.readLine();
 
-      if (line.startsWith(p_tag, Qt::CaseInsensitive))
-      {
+      if (line.startsWith(p_tag, Qt::CaseInsensitive)) {
         tag_found = true;
         continue;
       }
 
-      if (tag_found)
-      {
+      if (tag_found) {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
 
@@ -437,14 +378,11 @@ QString AOApplication::get_spbutton(QString p_tag, int index)
   return "";
 }
 
-QStringList AOApplication::get_effect(int index)
-{
+QStringList AOApplication::get_effect(int index) {
   QString p_file = "courtroom_config.ini";
-  QStringList paths{get_theme_variant_path() + p_file,
-                    get_theme_path() + p_file};
+  QStringList paths{get_theme_variant_path(p_file), get_theme_path(p_file)};
 
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QStringList res;
 
     QFile design_ini;
@@ -455,18 +393,15 @@ QStringList AOApplication::get_effect(int index)
     QTextStream in(&design_ini);
     bool tag_found = false;
 
-    while (!in.atEnd())
-    {
+    while (!in.atEnd()) {
       QString line = in.readLine();
 
-      if (line.startsWith("[EFFECTS]", Qt::CaseInsensitive))
-      {
+      if (line.startsWith("[EFFECTS]", Qt::CaseInsensitive)) {
         tag_found = true;
         continue;
       }
 
-      if (tag_found)
-      {
+      if (tag_found) {
         if ((line.startsWith("[") && line.endsWith("]")))
           break;
 
@@ -489,33 +424,29 @@ QStringList AOApplication::get_effect(int index)
   return res;
 }
 
-QStringList AOApplication::get_sfx_list()
-{
+QStringList AOApplication::get_sfx_list() {
   QStringList return_value;
   QFile base_sfx_list_ini;
   QFile char_sfx_list_ini;
 
   base_sfx_list_ini.setFileName(get_base_path() + "configs/sounds.ini");
-  char_sfx_list_ini.setFileName(get_character_path(get_current_char()) +
-                                "sounds.ini");
+  char_sfx_list_ini.setFileName(
+      get_character_path(get_current_char(), "sounds.ini"));
 
   if (!char_sfx_list_ini.open(QIODevice::ReadOnly) &&
-      !base_sfx_list_ini.open(QIODevice::ReadOnly))
-  {
+      !base_sfx_list_ini.open(QIODevice::ReadOnly)) {
     return return_value;
   }
 
   QTextStream in_a(&base_sfx_list_ini);
   QTextStream in_b(&char_sfx_list_ini);
 
-  while (!in_a.atEnd())
-  {
+  while (!in_a.atEnd()) {
     QString line = in_a.readLine();
     return_value.append(line);
   }
 
-  while (!in_b.atEnd())
-  {
+  while (!in_b.atEnd()) {
     QString line = in_b.readLine();
     return_value.append(line);
   }
@@ -527,9 +458,9 @@ QStringList AOApplication::get_sfx_list()
 // terminator_tag, trimmed returns the empty string if the search line couldnt
 // be found
 QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
-                                     QString target_tag, QString terminator_tag)
-{
-  QString char_ini_path = get_character_path(p_char) + "char.ini";
+                                     QString target_tag,
+                                     QString terminator_tag) {
+  QString char_ini_path = get_character_path(p_char, "char.ini");
 
   QFile char_ini;
 
@@ -542,15 +473,13 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
 
   bool tag_found = false;
 
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString line = in.readLine();
 
     if (QString::compare(line, terminator_tag, Qt::CaseInsensitive) == 0)
       break;
 
-    if (line.startsWith(target_tag, Qt::CaseInsensitive))
-    {
+    if (line.startsWith(target_tag, Qt::CaseInsensitive)) {
       tag_found = true;
       continue;
     }
@@ -567,8 +496,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
     if (line_elements.size() < 2)
       continue;
 
-    if (tag_found)
-    {
+    if (tag_found) {
       char_ini.close();
       return line_elements.at(1).trimmed();
     }
@@ -578,8 +506,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
   return "";
 }
 
-QString AOApplication::get_char_name(QString p_char)
-{
+QString AOApplication::get_char_name(QString p_char) {
   QString f_result = read_char_ini(p_char, "name", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -588,8 +515,7 @@ QString AOApplication::get_char_name(QString p_char)
     return f_result;
 }
 
-QString AOApplication::get_showname(QString p_char)
-{
+QString AOApplication::get_showname(QString p_char) {
   QString f_result = read_showname(p_char);
   if (f_result == "")
     f_result = read_char_ini(p_char, "showname", "[Options]", "[Time]");
@@ -600,19 +526,16 @@ QString AOApplication::get_showname(QString p_char)
     return f_result;
 }
 
-QString AOApplication::read_showname(QString p_char)
-{
+QString AOApplication::read_showname(QString p_char) {
   QString f_filename = get_base_path() + "configs/shownames.ini";
   QFile f_file(f_filename);
-  if (!f_file.open(QIODevice::ReadOnly))
-  {
+  if (!f_file.open(QIODevice::ReadOnly)) {
     qDebug() << "Error reading" << f_filename;
     return "";
   }
 
   QTextStream in(&f_file);
-  while (!in.atEnd())
-  {
+  while (!in.atEnd()) {
     QString f_line = in.readLine();
     if (!f_line.startsWith(p_char))
       continue;
@@ -624,8 +547,7 @@ QString AOApplication::read_showname(QString p_char)
   return "";
 }
 
-QString AOApplication::get_char_side(QString p_char)
-{
+QString AOApplication::get_char_side(QString p_char) {
   QString f_result = read_char_ini(p_char, "side", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -634,8 +556,7 @@ QString AOApplication::get_char_side(QString p_char)
     return f_result;
 }
 
-QString AOApplication::get_gender(QString p_char)
-{
+QString AOApplication::get_gender(QString p_char) {
   QString f_result = read_char_ini(p_char, "gender", "[Options]", "[Time]");
 
   if (f_result == "")
@@ -644,8 +565,7 @@ QString AOApplication::get_gender(QString p_char)
     return f_result;
 }
 
-QString AOApplication::get_chat(QString p_char)
-{
+QString AOApplication::get_chat(QString p_char) {
   QString f_result = read_char_ini(p_char, "chat", "[Options]", "[Time]");
 
   // handling the correct order of chat is a bit complicated, we let the caller
@@ -653,15 +573,13 @@ QString AOApplication::get_chat(QString p_char)
   return f_result.toLower();
 }
 
-QString AOApplication::get_char_shouts(QString p_char)
-{
+QString AOApplication::get_char_shouts(QString p_char) {
   QString f_result = read_char_ini(p_char, "shouts", "[Options]", "[Time]");
 
   return f_result.toLower();
 }
 
-int AOApplication::get_emote_number(QString p_char)
-{
+int AOApplication::get_emote_number(QString p_char) {
   QString f_result = read_char_ini(p_char, "number", "[Emotions]", "[Offsets]");
 
   if (f_result == "")
@@ -670,73 +588,60 @@ int AOApplication::get_emote_number(QString p_char)
     return f_result.toInt();
 }
 
-QString AOApplication::get_emote_comment(QString p_char, int p_emote)
-{
+QString AOApplication::get_emote_comment(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4)
-  {
+  if (result_contents.size() < 4) {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
-  }
-  else
+  } else
     return result_contents.at(0);
 }
 
-QString AOApplication::get_pre_emote(QString p_char, int p_emote)
-{
+QString AOApplication::get_pre_emote(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4)
-  {
+  if (result_contents.size() < 4) {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "";
-  }
-  else
+  } else
     return result_contents.at(1);
 }
 
-QString AOApplication::get_emote(QString p_char, int p_emote)
-{
+QString AOApplication::get_emote(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4)
-  {
+  if (result_contents.size() < 4) {
     qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
-  }
-  else
+  } else
     return result_contents.at(2);
 }
 
-int AOApplication::get_emote_mod(QString p_char, int p_emote)
-{
+int AOApplication::get_emote_mod(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
   QStringList result_contents = f_result.split("#");
 
-  if (result_contents.size() < 4)
-  {
+  if (result_contents.size() < 4) {
     qDebug() << "W: misformatted char.ini: " << p_char << ", "
              << QString::number(p_emote);
     return 0;
-  }
-  else
+  } else
     return result_contents.at(3).toInt();
 }
 
-int AOApplication::get_desk_mod(QString p_char, int p_emote)
-{
+int AOApplication::get_desk_mod(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[Emotions]", "[Offsets]");
 
@@ -753,8 +658,7 @@ int AOApplication::get_desk_mod(QString p_char, int p_emote)
     return string_result.toInt();
 }
 
-QStringList AOApplication::get_effect_offset(QString p_char, int p_effect)
-{
+QStringList AOApplication::get_effect_offset(QString p_char, int p_effect) {
   QStringList f_result =
       read_char_ini(p_char, QString::number(p_effect), "[Offsets]", "[Overlay]")
           .split(",");
@@ -765,8 +669,7 @@ QStringList AOApplication::get_effect_offset(QString p_char, int p_effect)
   return f_result;
 }
 
-QStringList AOApplication::get_overlay(QString p_char, int p_effect)
-{
+QStringList AOApplication::get_overlay(QString p_char, int p_effect) {
   QStringList f_result =
       read_char_ini(p_char, QString::number(p_effect), "[Overlay]", "[SoundN]")
           .split("#");
@@ -777,8 +680,7 @@ QStringList AOApplication::get_overlay(QString p_char, int p_effect)
   return f_result;
 }
 
-QString AOApplication::get_sfx_name(QString p_char, int p_emote)
-{
+QString AOApplication::get_sfx_name(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[SoundN]", "[SoundT]");
 
@@ -788,8 +690,7 @@ QString AOApplication::get_sfx_name(QString p_char, int p_emote)
     return f_result;
 }
 
-int AOApplication::get_sfx_delay(QString p_char, int p_emote)
-{
+int AOApplication::get_sfx_delay(QString p_char, int p_emote) {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1),
                                    "[SoundT]", "[TextDelay]");
 
@@ -799,8 +700,7 @@ int AOApplication::get_sfx_delay(QString p_char, int p_emote)
     return f_result.toInt();
 }
 
-int AOApplication::get_text_delay(QString p_char, QString p_emote)
-{
+int AOApplication::get_text_delay(QString p_char, QString p_emote) {
   QString f_result =
       read_char_ini(p_char, p_emote, "[TextDelay]", "END_OF_FILE");
 
@@ -810,23 +710,18 @@ int AOApplication::get_text_delay(QString p_char, QString p_emote)
     return f_result.toInt();
 }
 
-bool AOApplication::get_blank_blip()
-{
-  return config->blank_blips_enabled();
-}
+bool AOApplication::get_blank_blip() { return config->blank_blips_enabled(); }
 
-QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
-{
+QString AOApplication::read_theme_ini(QString p_identifier, QString p_file) {
   // Try to obtain a theme ini from either the current theme variant folder,
   // the current theme folder or the default theme folder
   QStringList paths{
-      get_theme_variant_path() + p_file,
-      get_theme_path() + p_file,
-      get_default_theme_path() + p_file,
+      get_theme_variant_path(p_file),
+      get_theme_path(p_file),
+      get_default_theme_path(p_file),
   };
 
-  for (QString path : paths)
-  {
+  for (QString path : paths) {
     QString f_result = read_design_ini(p_identifier, path);
     if (!f_result.isEmpty())
       return f_result;
@@ -835,11 +730,10 @@ QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
   return "";
 }
 
-QString AOApplication::get_image_path(QString p_image)
-{
-  QString theme_variant_image_path = get_theme_variant_path() + p_image;
-  QString theme_image_path = get_theme_path() + p_image;
-  QString default_image_path = get_default_theme_path() + p_image;
+QString AOApplication::get_image_path(QString p_image) {
+  QString theme_variant_image_path = get_theme_variant_path(p_image);
+  QString theme_image_path = get_theme_path(p_image);
+  QString default_image_path = get_default_theme_path(p_image);
 
   QString final_image_path;
 


### PR DESCRIPTION
This PR focuses around fixing issues caused by case-sensitivity. 

It does so by introducing a function to calculate the "correct" case-sensitive path if a case-insensitive path was given as a parameter.
Most functions that handle pathing were also rewritten to:

1. Take the file they want to check as a parameter, rather than supply a base path to append text to,
2. Call the case sensitivity fixer function whenever possible.

On case-insensitive systems, this function should just return the parameter path back.

_Also `clang-format` happened, whoops._