### PR TITLE
Replace "[X]" with checkboxes in the mute list

### DIFF
--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1948,58 +1948,30 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
   // ao_app->send_server_packet(new AOPacket("SP#" + f_pos + "#%"));
 }
 
-void Courtroom::on_mute_list_clicked(QModelIndex p_index)
+void Courtroom::on_mute_list_item_changed(QListWidgetItem *p_item)
 {
-  QListWidgetItem *f_item = ui_mute_list->item(p_index.row());
-  QString f_char = f_item->text();
-  QString real_char;
-
-  if (f_char.endsWith(" [x]"))
-    real_char = f_char.left(f_char.size() - 4);
-  else
-    real_char = f_char;
-
   int f_cid = -1;
 
   for (int n_char = 0; n_char < char_list.size(); n_char++)
   {
-    if (char_list.at(n_char).name == real_char)
+    if (char_list.at(n_char).name == p_item->text())
       f_cid = n_char;
   }
 
   if (f_cid < 0 || f_cid >= char_list.size())
   {
-    qDebug() << "W: " << real_char << " not present in char_list";
+    qDebug() << "W: " << p_item->text() << " not present in char_list";
     return;
   }
 
-  if (mute_map.value(f_cid))
-  {
-    mute_map.insert(f_cid, false);
-    f_item->setText(real_char);
-  }
-  else
+  if (Qt::CheckState::Checked == p_item->checkState())
   {
     mute_map.insert(f_cid, true);
-    f_item->setText(real_char + " [x]");
-  }
-
-  /*
-  if (f_char.endsWith(" [x]"))
-  {
-    real_char = f_char.left(f_char.size() - 4);
-    mute_map.remove(real_char);
-    mute_map.insert(real_char, false);
-    f_item->setText(real_char);
   }
   else
   {
-    real_char = f_char;
-    mute_map.remove(real_char);
-    mute_map.insert(real_char, true);
-    f_item->setText(real_char + " [x]");
+    mute_map.insert(f_cid, false);
   }
-  */
 }
 
 void Courtroom::on_music_list_clicked()

--- a/courtroom.h
+++ b/courtroom.h
@@ -656,7 +656,7 @@ private slots:
 
   void chat_tick();
 
-  void on_mute_list_clicked(QModelIndex p_index);
+  void on_mute_list_item_changed(QListWidgetItem *p_item);
 
   void on_chat_return_pressed();
   void on_chat_config_changed();

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -273,8 +273,8 @@ void Courtroom::connect_widgets()
   connect(ui_pos_dropdown, SIGNAL(activated(int)), this,
           SLOT(on_pos_dropdown_changed(int)));
 
-  connect(ui_mute_list, SIGNAL(clicked(QModelIndex)), this,
-          SLOT(on_mute_list_clicked(QModelIndex)));
+  connect(ui_mute_list, SIGNAL(itemChanged(QListWidgetItem *)), this,
+          SLOT(on_mute_list_item_changed(QListWidgetItem *)));
 
   connect(ui_ic_chat_message, SIGNAL(returnPressed()), this,
           SLOT(on_chat_return_pressed()));
@@ -1590,9 +1590,11 @@ void Courtroom::set_mute_list()
 
   sorted_mute_list.sort();
 
-  for (QString i_name : sorted_mute_list)
+  for (int i = 0; i < sorted_mute_list.size(); ++i)
   {
-    // mute_map.insert(i_name, false);
-    ui_mute_list->addItem(i_name);
+    ui_mute_list->addItem(sorted_mute_list[i]);
+    ui_mute_list->item(i)->setFlags(ui_mute_list->item(i)->flags() |
+                                    Qt::ItemFlag::ItemIsUserCheckable);
+    ui_mute_list->item(i)->setCheckState(Qt::CheckState::Unchecked);
   }
 }

--- a/courtroom_widgets.cpp
+++ b/courtroom_widgets.cpp
@@ -1590,11 +1590,10 @@ void Courtroom::set_mute_list()
 
   sorted_mute_list.sort();
 
-  for (int i = 0; i < sorted_mute_list.size(); ++i)
+  for (QString i_chr_name : sorted_mute_list)
   {
-    ui_mute_list->addItem(sorted_mute_list[i]);
-    ui_mute_list->item(i)->setFlags(ui_mute_list->item(i)->flags() |
-                                    Qt::ItemFlag::ItemIsUserCheckable);
-    ui_mute_list->item(i)->setCheckState(Qt::CheckState::Unchecked);
+    QListWidgetItem *i_item = new QListWidgetItem(i_chr_name, ui_mute_list);
+    i_item->setFlags(i_item->flags() | Qt::ItemFlag::ItemIsUserCheckable);
+    i_item->setCheckState(Qt::Unchecked);
   }
 }


### PR DESCRIPTION
This PR makes it so that instead of dynamically doing string wizardly to add a manual checkbox to the entries in the mute list, it uses Qt's built-in support for checkbox items in QListWidgets.

The functionality is otherwise the same.