### PR TITLE
Clean up build warnings

### DIFF
--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -79,20 +79,6 @@ void AOEvidenceButton::mouseDoubleClickEvent(QMouseEvent *e)
   evidence_double_clicked(m_id);
 }
 
-void AOEvidenceButton::dragLeaveEvent(QMouseEvent *e)
-{
-  // QWidget::dragLeaveEvent(e);
-
-  qDebug() << "drag leave event";
-}
-
-void AOEvidenceButton::dragEnterEvent(QMouseEvent *e)
-{
-  // QWidget::dragEnterEvent(e);
-
-  qDebug() << "drag enter event";
-}
-
 void AOEvidenceButton::enterEvent(QEvent *e)
 {
   ui_selector->show();

--- a/aoevidencebutton.h
+++ b/aoevidencebutton.h
@@ -37,8 +37,6 @@ protected:
   void enterEvent(QEvent *e);
   void leaveEvent(QEvent *e);
   void mouseDoubleClickEvent(QMouseEvent *e);
-  void dragLeaveEvent(QMouseEvent *e);
-  void dragEnterEvent(QMouseEvent *e);
 
 signals:
   void evidence_clicked(int p_id);


### PR DESCRIPTION
Removed the two functions that blast the entire compilation process with warnings.
They not only used the wrong parameter types (should have been `QDragEnterEvent` and `QDragLeaveEvent` instead of `QMouseEvent` in both places), they also did nothing, so why keep them around.