### PR TITLE
Fix missing case sensitive path getting in places

### DIFF
--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -40,7 +40,7 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString p_emote_prefix,
     bool found = false;
     for (auto &ext : QStringList{".webp", ".apng", ".gif", ".png"})
     {
-      QString fullPath = f_file + ext;
+      QString fullPath = ao_app->get_case_sensitive_path(f_file + ext);
       found = file_exists(fullPath);
       if (found)
       {
@@ -83,7 +83,8 @@ bool AOCharMovie::play_pre(QString p_char, QString p_emote, bool show)
     QString f_source_path = ao_app->get_character_path(p_char, p_emote);
     for (QString &i_ext : QStringList{".webp", ".apng", ".gif", ".png"})
     {
-      QString f_target_path = f_source_path + i_ext;
+      QString f_target_path =
+          ao_app->get_case_sensitive_path(f_source_path + i_ext);
       if (file_exists(f_target_path))
       {
         f_file_path = f_target_path;

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -60,7 +60,7 @@ void AOMovie::play(QString p_file, QString p_char, QString p_custom_theme)
     bool found = false;
     for (auto &ext : decltype(f_vec){".webp", ".apng", ".gif", ".png"})
     {
-      QString fullPath = f_file + ext;
+      QString fullPath = ao_app->get_case_sensitive_path(f_file + ext);
       found = file_exists(fullPath);
       if (found)
       {

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -22,7 +22,8 @@ void AOScene::set_image(QString p_image)
 
   for (auto &ext : QVector<QString>{".webp", ".apng", ".gif", ".png"})
   {
-    QString full_background_path = background_path + ext;
+    QString full_background_path =
+        ao_app->get_case_sensitive_path(background_path + ext);
 
     if (file_exists(full_background_path))
     {

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1013,7 +1013,7 @@ void Courtroom::handle_chatmessage_3()
     ext = ao_app->get_file_extension(directory, exts);
     if (!ext.isEmpty())
     {
-      path = directory + ext;
+      path = ao_app->get_case_sensitive_path(directory + ext);
       break;
     }
   }


### PR DESCRIPTION
There were a select few places where the case sensitive path version wasn't grabbed, resulting in always missed path lookups on Linux.

Good example is `base/characters/Tenko_HD/disappointed.png`.
The client looks for a case-insensitive `Disappointed`, without extension and with capitalisation, fails, then case-sensitively looks it up with various extensions -- which all fail, because the file itself is uncapitalised.