### PR TITLE
Add ability to close notes through deselecting and deleting

### DIFF
--- a/aonotepicker.cpp
+++ b/aonotepicker.cpp
@@ -1,6 +1,7 @@
 #include "aonotepicker.h"
 
 #include "courtroom.h"
+#include "debug_functions.h"
 
 #include <QDebug>
 #include <QFileDialog>
@@ -23,6 +24,12 @@ void Courtroom::on_file_selected()
   AOButton *f_button = static_cast<AOButton *>(sender());
   AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
 
+  if (f_notepicker->real_file.isEmpty())
+  {
+    call_notice("You must give a filepath to load a note from!");
+    return;
+  }
+
   if (current_file != f_notepicker->real_file)
   {
     current_file = f_notepicker->real_file;
@@ -39,7 +46,9 @@ void Courtroom::on_set_file_button_clicked()
 {
   AOButton *f_button = static_cast<AOButton *>(sender());
   AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
-  QString f_filename = QFileDialog::getOpenFileName(this, "Open File");
+  QString f_filename = QFileDialog::getOpenFileName(
+      this, "Open File", QDir::currentPath(), "Text files (*.txt)");
+
   if (f_filename != "")
   {
     f_notepicker->m_line->setText(f_filename);

--- a/aonotepicker.cpp
+++ b/aonotepicker.cpp
@@ -22,9 +22,17 @@ void Courtroom::on_file_selected()
 
   AOButton *f_button = static_cast<AOButton *>(sender());
   AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
-  current_file = f_notepicker->real_file;
-  load_note();
-  f_button->set_image("note_select_selected.png");
+
+  if (current_file != f_notepicker->real_file)
+  {
+    current_file = f_notepicker->real_file;
+    load_note();
+    f_button->set_image("note_select_selected.png");
+  }
+  else
+  {
+    current_file = "";
+  }
 }
 
 void Courtroom::on_set_file_button_clicked()
@@ -45,6 +53,12 @@ void Courtroom::on_delete_button_clicked()
 {
   AOButton *f_button = static_cast<AOButton *>(sender());
   AONotePicker *f_notepicker = static_cast<AONotePicker *>(f_button->parent());
+
+  if (current_file == f_notepicker->real_file)
+  {
+    current_file = "";
+  }
+
   ui_note_area->m_layout->removeWidget(f_notepicker);
   delete f_notepicker;
   set_note_files();

--- a/aonotepicker.cpp
+++ b/aonotepicker.cpp
@@ -34,7 +34,7 @@ void Courtroom::on_file_selected()
   {
     current_file = f_notepicker->real_file;
     load_note();
-    f_button->set_image("note_select_selected.png");
+    f_notepicker->m_hover->set_image("note_select_selected.png");
   }
   else
   {
@@ -52,6 +52,15 @@ void Courtroom::on_set_file_button_clicked()
   if (f_filename != "")
   {
     f_notepicker->m_line->setText(f_filename);
+
+    // If this notepicker is the currently selected slot, update the notepad as
+    // the file given changes.
+    if (f_notepicker->real_file == current_file)
+    {
+      current_file = f_filename;
+      load_note();
+    }
+
     f_notepicker->real_file = f_filename;
 
     set_note_files();


### PR DESCRIPTION
Adds the ability to close notes by clicking the note selection button again, and fixes a bug where you could still edit notes after deleting them off the list, if you had them selected.

This feature keeps the "ephemeral storage" function for the notepad if there is no selected note at the moment.
So you could open a note, edit it, close it, keep the text from it, edit the text (without editing the note), and then reopen the note, discarding your previous edits while no note was open.

Closes #46 .