### PR TITLE
Add DRO devs to about window

### DIFF
--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -7,6 +7,8 @@
 
 #include <QDebug>
 #include <QDir>
+#include <QImageReader>
+#include <QMessageBox>
 #include <QScrollBar>
 #include <QTextEdit>
 
@@ -365,21 +367,24 @@ void Lobby::on_connect_released()
 
 void Lobby::on_about_clicked()
 {
-  call_notice("Attorney Online 2 is built using Qt.\n\n"
-              "Lead development:\n"
-              "OmniTroid\n\n"
-              "stonedDiscord\n"
-              "longbyte1\n"
-              "Supporting development:\n"
-              "Fiercy\n\n"
-              "UI design:\n"
-              "Ruekasu\n"
-              "Draxirch\n\n"
-              "Special thanks:\n"
-              "Unishred\n"
-              "Argoneus\n"
-              "Noevain\n"
-              "Cronnicossy");
+  const bool hasApng = QImageReader::supportedImageFormats().contains("apng");
+
+  QString msg = tr("<h2>Danganronpa Online</h2>"
+                   "version: %1"
+                   "<p><b>Source code:</b> "
+                   "<a href='https://github.com/Chrezm/DRO-Client'>"
+                   "https://github.com/Chrezm/DRO-Client</a>"
+                   "<p><b>Development:</b><br>"
+                   "Cerapter, Elf, Iuvee, Tricky Leifa"
+                   "<p>Running on Qt version %2 with the BASS audio engine.<br>"
+                   "APNG plugin loaded: %3"
+                   "<p>Built on %4")
+                    .arg(ao_app->get_version_string())
+                    .arg(QLatin1String(QT_VERSION_STR))
+                    .arg(hasApng ? tr("Yes") : tr("No"))
+                    .arg(QLatin1String(__DATE__));
+
+  QMessageBox::about(this, tr("About"), msg);
 }
 
 void Lobby::on_server_list_clicked(QModelIndex p_model)

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -375,7 +375,10 @@ void Lobby::on_about_clicked()
                    "<a href='https://github.com/Chrezm/DRO-Client'>"
                    "https://github.com/Chrezm/DRO-Client</a>"
                    "<p><b>Development:</b><br>"
-                   "Cerapter, Elf, Iuvee, Tricky Leifa"
+                   "Cerapter, Elf, Iuvee, Tricky Leifa, Ziella"
+                   "<p>Based on Attorney Online 2:<br>"
+                   "<a href='https://github.com/AttorneyOnline/AO2-Client'>"
+                   "https://github.com/AttorneyOnline/AO2-Client</a>"
                    "<p>Running on Qt version %2 with the BASS audio engine.<br>"
                    "APNG plugin loaded: %3"
                    "<p>Built on %4")


### PR DESCRIPTION
Adds the current DRO developers to the about window.

Also modifies the About window to be more like Vanilla's, and to actually use the Qt-given About window default.

The translation strings are left in the messages purposefully, in case we want to supply translations later (and because being able to add arguments this way was convenient).

Closes #48 .