### PR TITLE
Update file and show clock only if file exists. Hide clock by if give…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 3rd/
+3rdparty/
 base/
 docs/
 .qmake.conf

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -344,11 +344,27 @@ void Courtroom::handle_music_anim()
 
 void Courtroom::handle_clock(QString time)
 {
+  qDebug() << time;
   current_clock = time.toInt();
 
   QString string = "hours\\" + time; // expected to be 0, 1, 2...
-  qDebug() << "hours:" << string;
-  ui_vp_clock->play(string);
+  qDebug() << current_clock << string
+           << ao_app->find_theme_asset_path(string,
+                                            animated_or_static_extensions());
+  // If the new hour file exists, use it and show the clock
+  if (!ao_app->find_theme_asset_path(string, animated_or_static_extensions())
+           .isEmpty())
+  {
+    ui_vp_clock->show();
+    ui_vp_clock->play(string);
+  }
+  // Otherwise, keep showing whatever was last shown...
+  // except if time is now -1. If so, that means the time is unknown, and there
+  // are no files for it. In that case, hide the clock and stop the movie
+  else if (current_clock == -1)
+  {
+    ui_vp_clock->hide();
+  }
 }
 
 void Courtroom::handle_gamemode(QString gamemode)
@@ -574,7 +590,8 @@ void Courtroom::save_textlog(QString p_text)
 {
   QString f_file = ao_app->get_base_path() + icchatlogsfilename;
 
-  ao_app->append_note("[" + QTime::currentTime().toString() + "]" + p_text, f_file);
+  ao_app->append_note("[" + QTime::currentTime().toString() + "]" + p_text,
+                      f_file);
 }
 
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -344,27 +344,29 @@ void Courtroom::handle_music_anim()
 
 void Courtroom::handle_clock(QString time)
 {
-  qDebug() << time;
   current_clock = time.toInt();
+  if (current_clock < 0 || current_clock > 23)
+    current_clock = -1;
+  qInfo() << QString("Clock time changed to %1").arg(current_clock);
 
-  QString string = "hours\\" + time; // expected to be 0, 1, 2...
-  qDebug() << current_clock << string
-           << ao_app->find_theme_asset_path(string,
-                                            animated_or_static_extensions());
-  // If the new hour file exists, use it and show the clock
-  if (!ao_app->find_theme_asset_path(string, animated_or_static_extensions())
-           .isEmpty())
+  ui_vp_clock->hide();
+
+  if (current_clock == -1)
   {
-    ui_vp_clock->show();
-    ui_vp_clock->play(string);
+    qInfo() << "Unknown time; no asset to be used.";
+    return;
   }
-  // Otherwise, keep showing whatever was last shown...
-  // except if time is now -1. If so, that means the time is unknown, and there
-  // are no files for it. In that case, hide the clock and stop the movie
-  else if (current_clock == -1)
+
+  qDebug() << "Displaying clock asset...";
+  const QString asset_path = ao_app->find_theme_asset_path("hours/" + QString::number(current_clock), animated_or_static_extensions());
+  if (asset_path.isEmpty())
   {
-    ui_vp_clock->hide();
+    qDebug() << "Asset not found; aborting.";
+    return;
   }
+
+  ui_vp_clock->play(asset_path);
+  ui_vp_clock->show();
 }
 
 void Courtroom::handle_gamemode(QString gamemode)

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -682,7 +682,7 @@ void Courtroom::set_widgets()
   ui_vp_music_display_b->show();
 
   set_size_and_pos(ui_vp_clock, "clock");
-  ui_vp_clock->show();
+  ui_vp_clock->hide();
 
   ui_ic_chat_message->setStyleSheet(
       "QLineEdit{background-color: rgba(100, 100, 100, 255);}");

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -678,6 +678,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   }
   else if (header == "CL")
   {
+    qDebug() << f_contents;
     w_courtroom->handle_clock(f_contents.at(1));
   }
   else if (header == "GM")


### PR DESCRIPTION
* Start showing the clock only if it receives a CL packet where the file exists in the theme folder.
* If the clock is currently shown and the clock fails to load an image for an hour between 0 and 23, it will show the last shown image.
* If the clock is currently shown and the clock fails to load an image for hour -1 (for unknown/invalid time), it will hide the clock.