### PR TITLE
Improve 'base not found' launch error to account for missing theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 3rd/
+3rdparty/
 base/
 docs/
 .qmake.conf

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -210,8 +210,12 @@ public slots:
     username = cfg.value("username").toString();
     callwords = cfg.value("callwords").toString();
     server_alerts = cfg.value("server_alerts", true).toBool();
-    theme = cfg.value("theme", "default").toString();
-    gamemode = cfg.value("gamemode", "").toString();
+
+    theme = cfg.value("theme").toString();
+    if (theme.trimmed().isEmpty())
+      theme = "default";
+
+    gamemode = cfg.value("gamemode").toString();
     manual_gamemode = cfg.value("manual_gamemode", false).toBool();
     timeofday = cfg.value("timeofday", "").toString();
     manual_timeofday = cfg.value("manual_timeofday", false).toBool();

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -82,13 +82,20 @@ void Lobby::set_widgets()
   {
     qDebug() << "W: did not find lobby width or height in " << filename;
 
-    // Most common symptom of bad config files and missing assets.
-    call_notice("It doesn't look like your client is set up correctly "
-                "at " +
-                QDir::currentPath() +
-                "\n"
-                "Did you download all resources correctly from the DRO Discord "
-                "including the large 'base' folder?");
+    // Most common symptom of bad config files, missing assets, or misnamed
+    // theme folder
+    call_notice(
+        "It doesn't look like your client is set up correctly. This can be "
+        "due to the following reasons: \n"
+        "1. Check you downloaded and extracted the resources correctly from "
+        "the DRO Discord including the large 'base' folder.\n"
+        "2. If you did, check that the base folder is in the same folder "
+        "where you launched Danganronpa Online from: " +
+        QDir::currentPath() +
+        "\n"
+        "3. If it is there, check that your current theme folder exists in "
+        "base/themes. According to base/config.ini, your current theme is " +
+        ao_app->get_theme());
 
     this->resize(517, 666);
   }


### PR DESCRIPTION
It is possible to trigger the DRO 'base not found' error if the current theme folder does not exist, which can be tricky to decide has happened with an error message that does not describe it. This PR changes the wording to include the current theme