### PR TITLE
Timer improvements

### DIFF
--- a/include/aotimer.h
+++ b/include/aotimer.h
@@ -56,6 +56,8 @@ private:
   int firing_timer_length = 12;
   int time_spent_in_timestep = 0;
 
+  bool paused;
+
 public slots:
   void update_time();
   void set();

--- a/include/aotimer.h
+++ b/include/aotimer.h
@@ -50,7 +50,7 @@ private:
   ManualTimer manual_timer;
   QTimer firing_timer;
 
-  QTime start_time = QTime(0, 5);
+  QTime start_time = QTime(0, 0);
   // All of this is in miliseconds
   int manual_timer_timestep_length = -12;
   int firing_timer_length = 12;

--- a/src/aotimer.cpp
+++ b/src/aotimer.cpp
@@ -11,6 +11,7 @@ AOTimer::AOTimer(QWidget *p_parent) : QTextEdit(p_parent)
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setReadOnly(true);
 
+  firing_timer.setTimerType(Qt::PreciseTimer);
   connect(&firing_timer, SIGNAL(timeout()), this, SLOT(update_time()));
 
   set_time(start_time);
@@ -57,7 +58,16 @@ void AOTimer::update_time()
   // current timer Redraw and return
   old_manual_timer.perform_timestep();
   redraw();
-  firing_timer.start(firing_timer_length);
+  // As the firing timer is not single shot, it will restart automatically once
+  // expired. However, it will do so with its firing interval, whatever it was
+  // (which could be less than firing_timer_length if, say, the timer was
+  // paused midstep).
+  // The next firing_timer should take firing_timer_length miliseconds no
+  // matter what. However, to avoid needless computation, we only explicitly
+  // restart firing_timer if its length was not firing_timer_length already
+  // (see example above).
+  if (firing_timer.interval() != firing_timer_length)
+    firing_timer.start(firing_timer_length);
 }
 
 void AOTimer::set()


### PR DESCRIPTION
* Optimize timer restarts to take advantage of QT's better automatic restarts. Manual restarts now only occur if the firing interval changed or does not match the firing timer's interval (which can happen if the timer is paused midstep).

* Prevent the timer from abnormally starting if it receives an order to update its firing interval while it is paused.

* Make the default time be 00:00
