### PR TITLE
Implement ackMS packet recognition to reset UI after server acknowledges client sent IC message

### DIFF
--- a/dronline-client.pro
+++ b/dronline-client.pro
@@ -11,6 +11,8 @@ RC_ICONS = icon.ico
 INCLUDEPATH += $$PWD/include $$PWD/3rd $$PWD/3rd/include
 DEPENDPATH += $$PWD/include
 
+DEFINES += DRO_ACKMS
+
 HEADERS += \
   include/aoabstractplayer.h \
   include/aoapplication.h \

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -45,6 +45,10 @@ public:
   void send_ms_packet(AOPacket *p_packet);
   void send_server_packet(AOPacket *p_packet, bool encoded = true);
 
+  ///////////////server metadata////////////////
+
+  bool ackMS_enabled = false;
+
   ///////////////loading info///////////////////
 
   // player number, it's hardly used but might be needed for some old servers

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -45,9 +45,11 @@ public:
   void send_ms_packet(AOPacket *p_packet);
   void send_server_packet(AOPacket *p_packet, bool encoded = true);
 
+#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
   ///////////////server metadata////////////////
 
   bool ackMS_enabled = false;
+#endif
 
   ///////////////loading info///////////////////
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -209,6 +209,9 @@ public:
   // these are for OOC chat
   void append_server_chatmessage(QString p_name, QString p_message);
 
+  // handles resetting the UI after the server acknowledged the client sent an
+  // message.
+  void handle_acknowledged_ms();
   // these functions handle chatmessages sequentially.
   // The process itself is very convoluted and merits separate documentation
   // But the general idea is objection animation->pre animation->talking->idle
@@ -597,8 +600,8 @@ private:
   QVector<QCheckBox *> ui_checks; // 0 = pre, 1 = flip, 2 = hidden
   QVector<AOLabel *> ui_labels;   // 0 = music, 1 = sfx, 2 = blip
   QVector<AOImageDisplay *> ui_label_images;
-  QVector<QString> label_images = {"Pre", "Flip", "Hidden",
-                                   "Music", "SFX", "Blip"};
+  QVector<QString> label_images = {"Pre",   "Flip", "Hidden",
+                                   "Music", "SFX",  "Blip"};
 
   AOButton *ui_effect_flash = nullptr;
   AOButton *ui_effect_gloom = nullptr;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -21,7 +21,8 @@
 #include <QTextCharFormat>
 #include <QTime>
 
-Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
+Courtroom::Courtroom(AOApplication *p_ao_app)
+    : QMainWindow()
 {
   ao_app = p_ao_app;
   ao_config = new AOConfig(this);
@@ -796,6 +797,7 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   // reset our ui state if client just spoke
   if (m_cid == f_char_id && is_system_speaking == false)
   {
+#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
     // If the server does not have the feature of acknowledging our MS
     // messages, assume in this if that the message is proof the server
     // acknowledged our message. It is not quite the same, as it is
@@ -803,13 +805,16 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
     // as the client, but the client did not send that message, but it is
     // the best we can do.
     if (!ao_app->ackMS_enabled)
+    {
       handle_acknowledged_ms();
+    }
 
     // If the server does have the feature of acknowledging our MS messages,
     // it will have sent an ackMS packet prior to the MS one, so chat would
     // have been cleared and thus we need not do anything else.
+#endif
 
-    // Also update first person mode status
+    // update first person mode status
     m_msg_is_first_person = ao_app->get_first_person_enabled();
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -739,6 +739,29 @@ void Courtroom::on_chat_return_pressed()
   ao_app->send_server_packet(new AOPacket("MS", packet_contents));
 }
 
+void Courtroom::handle_acknowledged_ms()
+{
+  ui_ic_chat_message->clear();
+
+  // reset states
+  ui_pre->setChecked(ao_config->always_pre_enabled());
+  list_sfx();
+  ui_sfx_list->setCurrentItem(
+      ui_sfx_list->item(0)); // prevents undefined errors
+
+  m_shout_state = 0;
+  draw_shout_buttons();
+
+  m_effect_state = 0;
+  draw_effect_buttons();
+
+  m_wtce_current = 0;
+  draw_judge_wtce_buttons();
+
+  is_presenting_evidence = false;
+  ui_evidence_present->set_image("present_disabled.png");
+}
+
 void Courtroom::handle_chatmessage(QStringList p_contents)
 {
   if (p_contents.size() < 15)
@@ -773,26 +796,20 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   // reset our ui state if client just spoke
   if (m_cid == f_char_id && is_system_speaking == false)
   {
-    ui_ic_chat_message->clear();
+    // If the server does not have the feature of acknowledging our MS
+    // messages, assume in this if that the message is proof the server
+    // acknowledged our message. It is not quite the same, as it is
+    // possible the server crafted a message with the same char_id
+    // as the client, but the client did not send that message, but it is
+    // the best we can do.
+    if (!ao_app->ackMS_enabled)
+      handle_acknowledged_ms();
 
-    // reset states
-    ui_pre->setChecked(ao_config->always_pre_enabled());
-    list_sfx();
-    ui_sfx_list->setCurrentItem(
-        ui_sfx_list->item(0)); // prevents undefined errors
+    // If the server does have the feature of acknowledging our MS messages,
+    // it will have sent an ackMS packet prior to the MS one, so chat would
+    // have been cleared and thus we need not do anything else.
 
-    m_shout_state = 0;
-    draw_shout_buttons();
-
-    m_effect_state = 0;
-    draw_effect_buttons();
-
-    m_wtce_current = 0;
-    draw_judge_wtce_buttons();
-
-    is_presenting_evidence = false;
-    ui_evidence_present->set_image("present_disabled.png");
-
+    // Also update first person mode status
     m_msg_is_first_person = ao_app->get_first_person_enabled();
   }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -139,7 +139,9 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     QString f_hdid;
     f_hdid = get_hdid();
 
+#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
     ackMS_enabled = false;
+#endif
 
     AOPacket *hi_packet = new AOPacket("HI#" + f_hdid + "#%");
     send_server_packet(hi_packet);
@@ -165,8 +167,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   }
   else if (header == "FL")
   {
+#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
     if (f_packet.contains("ackMS", Qt::CaseInsensitive))
       ackMS_enabled = true;
+#endif
   }
   else if (header == "PN")
   {

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -139,6 +139,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     QString f_hdid;
     f_hdid = get_hdid();
 
+    ackMS_enabled = false;
+
     AOPacket *hi_packet = new AOPacket("HI#" + f_hdid + "#%");
     send_server_packet(hi_packet);
   }
@@ -161,10 +163,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_courtroom->append_server_chatmessage(f_contents.at(0),
                                              f_contents.at(1));
   }
-  // FIXME Should the FL packet acknowledgement removed?
   else if (header == "FL")
   {
-    // The packet is acknowledged but is of no use to the client
+    if (f_packet.contains("ackMS", Qt::CaseInsensitive))
+      ackMS_enabled = true;
   }
   else if (header == "PN")
   {
@@ -552,6 +554,11 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   {
     if (courtroom_constructed && courtroom_loaded)
       w_courtroom->handle_chatmessage(p_packet->get_contents());
+  }
+  else if (header == "ackMS")
+  {
+    if (courtroom_constructed && courtroom_loaded)
+      w_courtroom->handle_acknowledged_ms();
   }
   else if (header == "MC")
   {


### PR DESCRIPTION
This PR is done in cooperation with some additional server changes. A server that sends "ackMS" as part of the FL packet promises it will send an "ackMS" packet to a client as soon as it acknowledges it has properly received an IC message from the client and that it will do something (server won't reject the message because, for example, client sent the same message twice), but *before* it sends an MS packet. That way, a client that recognizes the ackMS can use such a packet as an instruction to reset UI after having successfully sent an IC message. If the server does not send "ackMS", behavior is the same as before (reset UI if IC message's char_id matches the client's).

The reason why we need to perform this extra step is to allow the server to send messages with the same character as the client without forcing the client to reset their UI. The most obvious use case is in nonstop debate looping in TSDR 4.3.0, where the server may resend previously sent messages automatically. If a player happened to be typing something and the server as part of the loop sent one of the messages that player had previously sent as part of the loop, the player's UI would be frivolously reset. With this PR, the player's UI will not be reset in this case as the server would not send an ackMS packet, as the client did not send an IC message themselves.

This PR also gives acknowledging the FL packet some use again, so it needs not be removed.