### PR TITLE
Resolves #119, added audio-device system

### DIFF
--- a/dronline-client.pro
+++ b/dronline-client.pro
@@ -12,6 +12,7 @@ INCLUDEPATH += $$PWD/include $$PWD/3rd $$PWD/3rd/include
 DEPENDPATH += $$PWD/include
 
 DEFINES += DRO_ACKMS
+CONFIG(debug, debug|release):DEFINES += DR_DEV
 
 HEADERS += \
   include/aoapplication.h \
@@ -48,7 +49,9 @@ HEADERS += \
   include/debug_functions.h \
   include/discord_rich_presence.h \
   include/draudio.h \
+  include/draudiodevice.h \
   include/draudioengine.h \
+  include/draudioengine_p.h \
   include/draudioerror.h \
   include/draudiostream.h \
   include/draudiostreamfamily.h \
@@ -96,7 +99,9 @@ SOURCES += \
   src/debug_functions.cpp \
   src/discord_rich_presence.cpp \
   src/draudio.cpp \
+  src/draudiodevice.cpp \
   src/draudioengine.cpp \
+  src/draudioengine_p.cpp \
   src/draudioerror.cpp \
   src/draudiostream.cpp \
   src/draudiostreamfamily.cpp \

--- a/include/aoconfig.h
+++ b/include/aoconfig.h
@@ -36,6 +36,7 @@ public:
   bool log_is_recording_enabled();
 
   // audio
+  std::optional<QString> favorite_device_driver();
   int master_volume();
   bool mute_background_audio();
   int system_volume();
@@ -68,6 +69,9 @@ public slots:
   void set_log_music(bool p_enabled);
   void set_log_is_recording(bool p_enabled);
   void set_mute_background_audio(bool p_enabled);
+
+  // audio
+  void set_favorite_device_driver(QString p_device_driver);
   void set_master_volume(int p_number);
   void set_system_volume(int p_number);
   void set_effect_volume(int p_number);
@@ -94,6 +98,9 @@ signals:
   void log_uses_newline_changed(bool);
   void log_music_changed(bool);
   void log_is_recording_changed(bool);
+
+  // audio
+  void favorite_device_changed(QString);
   void master_volume_changed(int);
   void mute_background_audio_changed(bool);
   void system_volume_changed(int);

--- a/include/aoconfigpanel.h
+++ b/include/aoconfigpanel.h
@@ -1,7 +1,10 @@
 #ifndef AOCONFIGPANEL_H
 #define AOCONFIGPANEL_H
 
-// qt
+#include "aoconfig.h"
+#include "aoguiloader.h"
+#include "draudioengine.h"
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -12,10 +15,6 @@
 #include <QSpinBox>
 #include <QTabWidget>
 #include <QWidget>
-
-// src
-#include "aoconfig.h"
-#include "aoguiloader.h"
 
 class AOApplication;
 
@@ -39,12 +38,17 @@ private:
   void refresh_theme_list();
   void refresh_gamemode_list();
   void refresh_timeofday_list();
+  void update_audio_device_list();
 
 private slots:
   void on_reload_theme_clicked();
   void on_gamemode_index_changed(QString p_text);
   void on_timeofday_index_changed(QString p_text);
   void on_log_is_topdown_changed(bool p_enabled);
+  void on_device_current_index_changed(int p_index);
+  void on_audio_device_changed(DRAudioDevice p_device);
+  void on_favorite_audio_device_changed(DRAudioDevice p_device);
+  void on_audio_device_list_changed(QList<DRAudioDevice> p_device_list);
   void on_master_value_changed(int p_num);
   void on_system_value_changed(int p_num);
   void on_effect_value_changed(int p_num);
@@ -57,6 +61,7 @@ private:
 
   // driver
   AOConfig *m_config = nullptr;
+  DRAudioEngine *m_engine = nullptr;
 
   // behaviour
   QPushButton *w_save = nullptr;
@@ -87,6 +92,8 @@ private:
   QCheckBox *w_log_is_recording = nullptr;
 
   // audio
+  QComboBox *w_device = nullptr;
+  QCheckBox *w_favorite_device = nullptr;
   QSlider *w_master = nullptr;
   QLabel *w_master_value = nullptr;
   QCheckBox *w_mute_background_audio = nullptr;

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -92,7 +92,7 @@ struct pos_size_type
   int height = 0;
 };
 
-enum ChatMessage : std::int32_t
+enum ChatMessage : int32_t
 {
   CMDeskModifier = 0,
   CMPreAnim,
@@ -114,7 +114,7 @@ enum ChatMessage : std::int32_t
 
 namespace dr
 {
-enum Color : std::int32_t
+enum Color : int32_t
 {
   CDefault,
   CGreen,

--- a/include/draudio.h
+++ b/include/draudio.h
@@ -17,10 +17,17 @@ enum Option
 {
   OSuppressed = 0x1,
   OIgnoreSuppression = 0x2,
+
+  // engine
+
+  /**
+   * If enabled, the engine will suppress all audio when the application is inactive.
+   */
+  OEngineMuteBackgroundAudio = 0x4,
 };
 Q_DECLARE_FLAGS(Options, Option)
 
-QString get_bass_error(int p_error_code);
+QString get_bass_error(const int32_t p_error_code);
 QString get_last_bass_error();
 } // namespace DRAudio
 Q_DECLARE_METATYPE(DRAudio::Options)

--- a/include/draudiodevice.h
+++ b/include/draudiodevice.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <bass.h>
+
+#include <QFlags>
+#include <QMetaType>
+#include <QString>
+
+class DRAudioEngine;
+class DRAudioEnginePrivate;
+
+class DRAudioDevice
+{
+public:
+  enum State : DWORD
+  {
+    SEnabled = BASS_DEVICE_ENABLED,
+    SDefault = BASS_DEVICE_DEFAULT,
+    SInit = BASS_DEVICE_INIT,
+  };
+  Q_DECLARE_FLAGS(States, State)
+
+  DRAudioDevice();
+  DRAudioDevice(DWORD p_device, BASS_DEVICEINFO p_device_info);
+
+  std::optional<DWORD> get_id() const;
+  QString get_name() const;
+  QString get_driver() const;
+  States get_states() const;
+  // condition check
+  bool is_state(State p_state) const;
+  bool is_enabled() const;
+  bool is_default() const;
+  bool is_init() const;
+
+private:
+  friend class DRAudioEngine;
+  friend class DRAudioEnginePrivate;
+
+  std::optional<DWORD> m_id;
+  QString m_name;
+  QString m_driver;
+  States m_states;
+
+  bool merge(DRAudioDevice &p_device);
+};
+Q_DECLARE_METATYPE(DRAudioDevice)

--- a/include/draudioengine.h
+++ b/include/draudioengine.h
@@ -10,24 +10,38 @@ public:
   DRAudioEngine(QObject *p_parent = nullptr);
   ~DRAudioEngine();
 
+  static std::optional<DRAudioDevice> get_device();
+  static std::optional<DRAudioDevice> get_favorite_device();
+  static QList<DRAudioDevice> get_device_list();
   static DRAudioStreamFamily::ptr get_family(DRAudio::Family p_family);
   static QList<DRAudioStreamFamily::ptr> get_family_list();
-  static std::int32_t get_volume();
+  static int32_t get_volume();
   static DRAudio::Options get_options();
-  // option getter
+  // option get
+  static bool is_option(DRAudio::Option p_option);
   static bool is_suppressed();
+  static bool is_mute_background_audio();
 
 public slots:
-  void set_volume(std::int32_t p_volume);
+  void set_device(DRAudioDevice p_device);
+  void set_favorite_device(DRAudioDevice p_device);
+  void set_favorite_device_by_driver(QString p_device_driver);
+  void set_volume(int32_t p_volume);
   void set_options(DRAudio::Options p_options);
-  // option setter
+  // option set
+  void set_option(DRAudio::Option p_option, bool p_enabled);
   void set_suppressed(bool p_enabled);
+  void set_mute_background_audio(bool p_enabled);
 
 signals:
-  void volume_changed(std::int32_t);
+  void device_changed(DRAudioDevice);
+  void favorite_device_changed(DRAudioDevice);
+  void device_list_changed(QList<DRAudioDevice>);
+  void volume_changed(int32_t);
   void options_changed(DRAudio::Options);
 
 private:
-  void adjust_options();
-  void adjust_volume();
+  friend class DRAudioStream;
+
+  static void check_stream_error();
 };

--- a/include/draudioengine_p.h
+++ b/include/draudioengine_p.h
@@ -11,8 +11,6 @@
 
 #include <optional>
 
-void print_device_list(const QList<DRAudioDevice> &device_list);
-
 class DRAudioEngine;
 class DRAudioEngineData;
 

--- a/include/draudioengine_p.h
+++ b/include/draudioengine_p.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "draudio.h"
+#include "draudiostreamfamily.h"
+
+#include <QFlags>
+#include <QMap>
+#include <QObject>
+#include <QPointer>
+#include <QTimer>
+
+#include <optional>
+
+void print_device_list(const QList<DRAudioDevice> &device_list);
+
+class DRAudioEngine;
+class DRAudioEngineData;
+
+class DRAudioEnginePrivate : public QObject
+{
+  Q_OBJECT
+
+public:
+  using ptr = QPointer<DRAudioEnginePrivate>;
+
+  DRAudioEnginePrivate();
+  ~DRAudioEnginePrivate();
+
+  void invoke_signal(QString p_method_name, QGenericArgument p_arg1 = QGenericArgument(nullptr));
+
+private:
+  friend class DRAudioEngine;
+  friend class DRAudioEngineData;
+
+  void update_device();
+  void update_device_list();
+  void update_options();
+  void update_volume();
+
+  void check_stream_error();
+
+  QObjectList children;
+  QPointer<DRAudioEngine> engine;
+
+  QPointer<QTimer> event_timer;
+  bool check_device = false;
+
+  std::optional<DRAudioDevice> device;
+  std::optional<DRAudioDevice> previous_device;
+  std::optional<DRAudioDevice> favorite_device;
+
+  int32_t volume = 0;
+  DRAudio::Options options;
+
+  QMap<QString, DRAudioDevice> device_map;
+  QMap<DRAudio::Family, DRAudioStreamFamily::ptr> family_map;
+
+private slots:
+  void on_event_tick();
+};

--- a/include/draudioerror.h
+++ b/include/draudioerror.h
@@ -8,7 +8,7 @@ public:
   DRAudioError();
   DRAudioError(QString p_error);
 
-  QString get_error();
+  QString what();
 
 private:
   QString m_error;

--- a/include/draudiostream.h
+++ b/include/draudiostream.h
@@ -1,57 +1,80 @@
 #pragma once
 
 #include "draudio.h"
+#include "draudiodevice.h"
 #include "draudioerror.h"
 
 #include <bass.h>
 
 #include <QObject>
+#include <QStack>
 
 #include <memory>
 #include <optional>
-#include <stack>
 
+class DRAudioEngine;
+class DRAudioEnginePrivate;
 class DRAudioStreamFamily;
+
+class DRAudioStreamSync
+{
+public:
+  HSYNC sync;
+  DWORD type;
+};
 
 class DRAudioStream : public QObject
 {
   Q_OBJECT
+
+  DRAudioStream(DRAudio::Family p_family);
 
 public:
   using ptr = QSharedPointer<DRAudioStream>;
 
   ~DRAudioStream();
 
-  DRAudio::Family get_family();
-  std::optional<QString> get_file();
+  DRAudio::Family get_family() const;
+  std::optional<QString> get_file() const;
 
   // state
-  bool is_playing();
+  bool is_playing() const;
 
 public slots:
-  void play();
-  void stop();
-
   std::optional<DRAudioError> set_file(QString m_file);
   void set_volume(float p_volume);
+
+  void play();
+  void stop();
 
 signals:
   void file_changed(QString p_file);
   void finished();
 
 public:
-  static void CALLBACK sync_on_end(HSYNC hsync, DWORD ch, DWORD data, void *userdata);
+  static void CALLBACK on_sync_callback(HSYNC hsync, DWORD ch, DWORD data, void *userdata);
 
 private:
+  friend class DRAudioEngine;
+  friend class DRAudioEnginePrivate;
   friend class DRAudioStreamFamily;
 
-  DRAudioStream(DRAudio::Family p_family);
+  void cache_position();
+  void update_device();
 
   // static method
   DRAudio::Family m_family;
   std::optional<QString> m_file;
+  float m_volume;
 
   // bass
   std::optional<HSTREAM> m_hstream;
-  std::stack<HSYNC> m_hsync_stack;
+  QStack<DRAudioStreamSync> m_hsync_stack;
+  std::optional<DWORD> m_position;
+
+private slots:
+  void on_device_error();
+
+signals:
+  void device_error(QPrivateSignal);
 };

--- a/include/draudiostreamfamily.h
+++ b/include/draudiostreamfamily.h
@@ -10,6 +10,7 @@
 #include <optional>
 
 class DRAudioEngine;
+class DRAudioEngineData;
 
 class DRAudioStreamFamily : public QObject
 {
@@ -20,49 +21,50 @@ public:
 
   std::optional<DRAudioStream::ptr> create_stream(QString p_file);
   std::optional<DRAudioStream::ptr> play_stream(QString p_file);
-  QVector<DRAudioStream::ptr> get_stream_list();
 
-  std::int32_t get_volume();
-  std::int32_t get_capacity();
-  DRAudio::Options get_options();
-  // options getter
-  bool is_suppressed();
-  bool is_ignore_suppression();
+  // get
+  QVector<DRAudioStream::ptr> get_stream_list() const;
+  int32_t get_volume() const;
+  int32_t get_capacity() const;
+  DRAudio::Options get_options() const;
 
-  using iterator = QVector<DRAudioStream::ptr>::iterator;
-  iterator begin();
-  iterator end();
+  // options get
+  bool is_suppressed() const;
+  bool is_ignore_suppression() const;
 
 public slots:
-  void set_volume(std::int32_t p_volume);
-  void set_capacity(std::int32_t p_capacity);
+  void set_volume(int32_t p_volume);
+  void set_capacity(int32_t p_capacity);
   void set_options(DRAudio::Options p_options);
   // options setter
   void set_suppressed(bool p_enabled);
   void set_ignore_suppression(bool p_enabled);
 
 signals:
-  void volume_changed(std::int32_t);
-  void capacity_changed(std::int32_t);
+  void volume_changed(int32_t);
+  void capacity_changed(int32_t);
   void options_changed(DRAudio::Options);
 
 private:
   friend class DRAudioEngine;
+  friend class DRAudioEngineData;
+  friend class DRAudioEnginePrivate;
 
   DRAudioStreamFamily(DRAudio::Family p_family);
 
   float calculate_volume();
 
-  void adjust_capacity();
-  void adjust_options();
-  void adjust_volume();
+  void update_device();
+  void update_capacity();
+  void update_options();
+  void update_volume();
 
   DRAudio::Family m_family;
-  std::int32_t m_volume = 0;
-  std::int32_t m_capacity = 0;
+  int32_t m_volume = 0;
+  int32_t m_capacity = 0;
   DRAudio::Options m_options;
   QVector<QSharedPointer<DRAudioStream>> m_stream_list;
 
 private slots:
-  void on_stream_stopped();
+  void on_stream_finished();
 };

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -448,6 +448,9 @@
         </widget>
        </item>
        <item row="0" column="1">
+        <widget class="QComboBox" name="device"/>
+       </item>
+       <item row="1" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QSlider" name="master">
@@ -495,7 +498,7 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QCheckBox" name="mute_background_audio">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, audio will be temporarily muted when the client is not in focus.&lt;br/&gt;&lt;br/&gt;This does not apply to system sounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -505,14 +508,21 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="1">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <widget class="QLabel" name="system_label">
          <property name="text">
           <string>System:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
           <widget class="QSlider" name="system">
@@ -560,14 +570,14 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="music_label">
          <property name="text">
           <string>Music:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QSlider" name="music">
@@ -615,14 +625,14 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="effect_label">
          <property name="text">
           <string>Effects:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QSlider" name="effect">
@@ -664,14 +674,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="blip_label">
          <property name="text">
           <string>Blips:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QSlider" name="blip">
@@ -713,14 +723,14 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="blip_rate_label">
          <property name="text">
           <string>Blip rate:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QSpinBox" name="blip_rate">
          <property name="minimum">
           <number>1</number>
@@ -733,14 +743,14 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="blank_blips_label">
          <property name="text">
           <string>Blank blips:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QCheckBox" name="blank_blips">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -750,7 +760,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -762,13 +772,6 @@
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="2" column="1">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -20,11 +20,28 @@ class AOConfigPrivate : public QObject
 {
   Q_OBJECT
 
-  friend AOConfig;
+public:
+  AOConfigPrivate(QObject *p_parent = nullptr);
+  ~AOConfigPrivate();
+
+  // setters
+public slots:
+  void read_file();
+  void save_file();
+
+private:
+  void invoke_signal(QString p_method_name, QGenericArgument p_arg1 = QGenericArgument(nullptr));
+  void update_favorite_device();
+
+private slots:
+  void on_application_state_changed(Qt::ApplicationState p_state);
+
+private:
+  friend class AOConfig;
 
   QSettings cfg;
   // hate me more
-  QVector<QObject *> parents;
+  QVector<QObject *> children;
 
   // data
   bool autosave;
@@ -44,6 +61,8 @@ class AOConfigPrivate : public QObject
   bool log_music;
   bool log_is_recording;
 
+  // audio
+  std::optional<QString> favorite_device_driver;
   int master_volume;
   bool mute_background_audio;
   int effect_volume;
@@ -55,284 +74,128 @@ class AOConfigPrivate : public QObject
 
   // audio sync
   DRAudioEngine *audio_engine = nullptr;
-
-public:
-  AOConfigPrivate(QObject *p_parent = nullptr)
-      : QObject(p_parent), cfg(QDir::currentPath() + "/base/config.ini", QSettings::IniFormat),
-        audio_engine(new DRAudioEngine(this))
-  {
-    Q_ASSERT_X(qApp, "initialization", "QGuiApplication is required");
-    connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)), this,
-            SLOT(on_application_state_changed(Qt::ApplicationState)));
-
-    read_file();
-  }
-  ~AOConfigPrivate()
-  {
-    if (autosave)
-    {
-      save_file();
-    }
-  }
-
-  // setters
-public slots:
-  void set_autosave(bool p_enabled)
-  {
-    if (autosave == p_enabled)
-      return;
-    autosave = p_enabled;
-    invoke_parents("autosave_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_username(QString p_string)
-  {
-    if (username == p_string)
-      return;
-    username = p_string;
-    invoke_parents("username_changed", Q_ARG(QString, p_string));
-  }
-  void set_callwords(QString p_string)
-  {
-    if (callwords == p_string)
-      return;
-    callwords = p_string;
-    invoke_parents("callwords_changed", Q_ARG(QString, p_string));
-  }
-  void set_server_alerts(bool p_enabled)
-  {
-    if (server_alerts == p_enabled)
-      return;
-    server_alerts = p_enabled;
-    invoke_parents("server_alerts_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_theme(QString p_string)
-  {
-    if (theme == p_string)
-      return;
-    theme = p_string;
-    invoke_parents("theme_changed", Q_ARG(QString, p_string));
-  }
-  void set_gamemode(QString p_string)
-  {
-    if (gamemode == p_string)
-      return;
-    gamemode = p_string;
-    invoke_parents("gamemode_changed", Q_ARG(QString, p_string));
-  }
-  void set_manual_gamemode(bool p_enabled)
-  {
-    if (manual_gamemode == p_enabled)
-      return;
-    manual_gamemode = p_enabled;
-    invoke_parents("manual_gamemode_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_timeofday(QString p_string)
-  {
-    if (timeofday == p_string)
-      return;
-    timeofday = p_string;
-    invoke_parents("timeofday_changed", Q_ARG(QString, p_string));
-  }
-  void set_manual_timeofday(bool p_enabled)
-  {
-    if (manual_timeofday == p_enabled)
-      return;
-    manual_timeofday = p_enabled;
-    invoke_parents("manual_timeofday_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_always_pre(bool p_enabled)
-  {
-    if (always_pre == p_enabled)
-      return;
-    always_pre = p_enabled;
-    invoke_parents("always_pre_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_chat_tick_interval(int p_number)
-  {
-    if (chat_tick_interval == p_number)
-      return;
-    chat_tick_interval = p_number;
-    invoke_parents("chat_tick_interval_changed", Q_ARG(int, p_number));
-  }
-  void set_log_max_lines(int p_number)
-  {
-    if (log_max_lines == p_number)
-      return;
-    log_max_lines = p_number;
-    invoke_parents("log_max_lines_changed", Q_ARG(int, p_number));
-  }
-  void set_log_is_topdown(bool p_enabled)
-  {
-    if (log_is_topdown == p_enabled)
-      return;
-    log_is_topdown = p_enabled;
-    invoke_parents("log_is_topdown_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_log_uses_newline(bool p_enabled)
-  {
-    if (log_uses_newline == p_enabled)
-      return;
-    log_uses_newline = p_enabled;
-    invoke_parents("log_uses_newline_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_log_music(bool p_enabled)
-  {
-    if (log_music == p_enabled)
-      return;
-    log_music = p_enabled;
-    invoke_parents("log_music_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_log_is_recording(bool p_enabled)
-  {
-    if (log_is_recording == p_enabled)
-      return;
-    log_is_recording = p_enabled;
-    invoke_parents("log_is_recording_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_master_volume(int p_number)
-  {
-    if (master_volume == p_number)
-      return;
-    master_volume = p_number;
-    audio_engine->set_volume(p_number);
-    invoke_parents("master_volume_changed", Q_ARG(int, p_number));
-  }
-  void set_mute_background_audio(bool p_enabled)
-  {
-    if (mute_background_audio == p_enabled)
-      return;
-    mute_background_audio = p_enabled;
-    invoke_parents("mute_background_audio_changed", Q_ARG(bool, p_enabled));
-  }
-  void set_system_volume(int p_number)
-  {
-    if (system_volume == p_number)
-      return;
-    system_volume = p_number;
-    audio_engine->get_family(DRAudio::Family::FSystem)->set_volume(p_number);
-    invoke_parents("system_volume_changed", Q_ARG(int, p_number));
-  }
-  void set_effects_volume(int p_number)
-  {
-    if (effect_volume == p_number)
-      return;
-    effect_volume = p_number;
-    audio_engine->get_family(DRAudio::Family::FEffect)->set_volume(p_number);
-    invoke_parents("effect_volume_changed", Q_ARG(int, p_number));
-  }
-  void set_music_volume(int p_number)
-  {
-    if (music_volume == p_number)
-      return;
-    music_volume = p_number;
-    audio_engine->get_family(DRAudio::Family::FMusic)->set_volume(p_number);
-    invoke_parents("music_volume_changed", Q_ARG(int, p_number));
-  }
-  void set_blips_volume(int p_number)
-  {
-    if (blip_volume == p_number)
-      return;
-    blip_volume = p_number;
-    audio_engine->get_family(DRAudio::Family::FBlip)->set_volume(p_number);
-    invoke_parents("blip_volume_changed", Q_ARG(int, p_number));
-  }
-  void set_blip_rate(int p_number)
-  {
-    if (blip_rate == p_number)
-      return;
-    blip_rate = p_number;
-    invoke_parents("blip_rate_changed", Q_ARG(int, p_number));
-  }
-  void set_blank_blips(bool p_enabled)
-  {
-    if (blank_blips == p_enabled)
-      return;
-    blank_blips = p_enabled;
-    invoke_parents("blank_blips_changed", Q_ARG(bool, p_enabled));
-  }
-  void read_file()
-  {
-    autosave = cfg.value("autosave", true).toBool();
-    username = cfg.value("username").toString();
-    callwords = cfg.value("callwords").toString();
-    server_alerts = cfg.value("server_alerts", true).toBool();
-
-    theme = cfg.value("theme").toString();
-    if (theme.trimmed().isEmpty())
-      theme = "default";
-
-    gamemode = cfg.value("gamemode").toString();
-    manual_gamemode = cfg.value("manual_gamemode", false).toBool();
-    timeofday = cfg.value("timeofday", "").toString();
-    manual_timeofday = cfg.value("manual_timeofday", false).toBool();
-    always_pre = cfg.value("always_pre", true).toBool();
-    chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
-    log_max_lines = cfg.value("chatlog_limit", 200).toInt();
-    log_is_topdown = cfg.value("chatlog_scrolldown", true).toBool();
-    log_uses_newline = cfg.value("chatlog_newline", false).toBool();
-    log_music = cfg.value("music_change_log", true).toBool();
-    log_is_recording = cfg.value("enable_logging", true).toBool();
-
-    mute_background_audio = cfg.value("mute_background_audio").toBool();
-    master_volume = cfg.value("default_master", 50).toInt();
-    system_volume = cfg.value("default_system", 50).toInt();
-    effect_volume = cfg.value("default_sfx", 50).toInt();
-    music_volume = cfg.value("default_music", 50).toInt();
-    blip_volume = cfg.value("default_blip", 50).toInt();
-    blip_rate = cfg.value("blip_rate", 1000000000).toInt();
-    blank_blips = cfg.value("blank_blips").toBool();
-
-    // audio update
-    audio_engine->set_volume(master_volume);
-    audio_engine->get_family(DRAudio::Family::FSystem)->set_volume(system_volume);
-    audio_engine->get_family(DRAudio::Family::FEffect)->set_volume(effect_volume);
-    audio_engine->get_family(DRAudio::Family::FMusic)->set_volume(music_volume);
-    audio_engine->get_family(DRAudio::Family::FBlip)->set_volume(blip_volume);
-  }
-  void save_file()
-  {
-    cfg.setValue("autosave", autosave);
-    cfg.setValue("username", username);
-    cfg.setValue("callwords", callwords);
-    cfg.setValue("server_alerts", server_alerts);
-    cfg.setValue("theme", theme);
-    cfg.setValue("gamemode", gamemode);
-    cfg.setValue("manual_gamemode", manual_gamemode);
-    cfg.setValue("timeofday", timeofday);
-    cfg.setValue("manual_timeofday", manual_timeofday);
-    cfg.setValue("always_pre", always_pre);
-    cfg.setValue("chat_tick_interval", chat_tick_interval);
-    cfg.setValue("chatlog_limit", log_max_lines);
-    cfg.setValue("chatlog_scrolldown", log_is_topdown);
-    cfg.setValue("chatlog_newline", log_uses_newline);
-    cfg.setValue("music_change_log", log_music);
-    cfg.setValue("enable_logging", log_is_recording);
-    cfg.setValue("default_master", master_volume);
-    cfg.setValue("mute_background_audio", mute_background_audio);
-    cfg.setValue("default_sfx", effect_volume);
-    cfg.setValue("default_system", system_volume);
-    cfg.setValue("default_music", music_volume);
-    cfg.setValue("default_blip", blip_volume);
-    cfg.setValue("blip_rate", blip_rate);
-    cfg.setValue("blank_blips", blank_blips);
-    cfg.sync();
-  }
-
-private:
-  void invoke_parents(QString p_method_name, QGenericArgument p_arg1 = QGenericArgument(nullptr))
-  {
-    for (QObject *i_parent : parents)
-    {
-      QMetaObject::invokeMethod(i_parent, p_method_name.toStdString().c_str(), p_arg1);
-    }
-  }
-
-private slots:
-  void on_application_state_changed(Qt::ApplicationState p_state)
-  {
-    audio_engine->set_suppressed(mute_background_audio && p_state != Qt::ApplicationActive);
-  }
 };
+
+AOConfigPrivate::AOConfigPrivate(QObject *p_parent)
+    : QObject(p_parent), cfg(QDir::currentPath() + "/base/config.ini", QSettings::IniFormat),
+      audio_engine(new DRAudioEngine(this))
+{
+  Q_ASSERT_X(qApp, "initialization", "QGuiApplication is required");
+  connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)), this,
+          SLOT(on_application_state_changed(Qt::ApplicationState)));
+
+  read_file();
+}
+
+AOConfigPrivate::~AOConfigPrivate()
+{
+  if (autosave)
+  {
+    save_file();
+  }
+}
+
+void AOConfigPrivate::read_file()
+{
+  autosave = cfg.value("autosave", true).toBool();
+  username = cfg.value("username").toString();
+  callwords = cfg.value("callwords").toString();
+  server_alerts = cfg.value("server_alerts", true).toBool();
+
+  theme = cfg.value("theme").toString();
+  if (theme.trimmed().isEmpty())
+    theme = "default";
+
+  gamemode = cfg.value("gamemode").toString();
+  manual_gamemode = cfg.value("manual_gamemode", false).toBool();
+  timeofday = cfg.value("timeofday", "").toString();
+  manual_timeofday = cfg.value("manual_timeofday", false).toBool();
+  always_pre = cfg.value("always_pre", true).toBool();
+  chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
+  log_max_lines = cfg.value("chatlog_limit", 200).toInt();
+  log_is_topdown = cfg.value("chatlog_scrolldown", true).toBool();
+  log_uses_newline = cfg.value("chatlog_newline", false).toBool();
+  log_music = cfg.value("music_change_log", true).toBool();
+  log_is_recording = cfg.value("enable_logging", true).toBool();
+
+  if (cfg.contains("favorite_device_driver"))
+    favorite_device_driver = cfg.value("favorite_device_driver").toString();
+
+  mute_background_audio = cfg.value("mute_background_audio").toBool();
+  master_volume = cfg.value("default_master", 50).toInt();
+  system_volume = cfg.value("default_system", 50).toInt();
+  effect_volume = cfg.value("default_sfx", 50).toInt();
+  music_volume = cfg.value("default_music", 50).toInt();
+  blip_volume = cfg.value("default_blip", 50).toInt();
+  blip_rate = cfg.value("blip_rate", 1000000000).toInt();
+  blank_blips = cfg.value("blank_blips").toBool();
+
+  // audio update
+  audio_engine->set_volume(master_volume);
+  audio_engine->get_family(DRAudio::Family::FSystem)->set_volume(system_volume);
+  audio_engine->get_family(DRAudio::Family::FEffect)->set_volume(effect_volume);
+  audio_engine->get_family(DRAudio::Family::FMusic)->set_volume(music_volume);
+  audio_engine->get_family(DRAudio::Family::FBlip)->set_volume(blip_volume);
+
+  // audio device
+  update_favorite_device();
+}
+
+void AOConfigPrivate::save_file()
+{
+  cfg.setValue("autosave", autosave);
+  cfg.setValue("username", username);
+  cfg.setValue("callwords", callwords);
+  cfg.setValue("server_alerts", server_alerts);
+  cfg.setValue("theme", theme);
+  cfg.setValue("gamemode", gamemode);
+  cfg.setValue("manual_gamemode", manual_gamemode);
+  cfg.setValue("timeofday", timeofday);
+  cfg.setValue("manual_timeofday", manual_timeofday);
+  cfg.setValue("always_pre", always_pre);
+  cfg.setValue("chat_tick_interval", chat_tick_interval);
+  cfg.setValue("chatlog_limit", log_max_lines);
+  cfg.setValue("chatlog_scrolldown", log_is_topdown);
+  cfg.setValue("chatlog_newline", log_uses_newline);
+  cfg.setValue("music_change_log", log_music);
+  cfg.setValue("enable_logging", log_is_recording);
+
+  // audio
+  if (favorite_device_driver.has_value())
+    cfg.setValue("favorite_device_driver", favorite_device_driver.value());
+
+  cfg.setValue("mute_background_audio", mute_background_audio);
+  cfg.setValue("default_master", master_volume);
+  cfg.setValue("default_sfx", effect_volume);
+  cfg.setValue("default_system", system_volume);
+  cfg.setValue("default_music", music_volume);
+  cfg.setValue("default_blip", blip_volume);
+  cfg.setValue("blip_rate", blip_rate);
+  cfg.setValue("blank_blips", blank_blips);
+  cfg.sync();
+}
+
+void AOConfigPrivate::invoke_signal(QString p_method_name, QGenericArgument p_arg1)
+{
+  for (QObject *i_child : children)
+  {
+    QMetaObject::invokeMethod(i_child, p_method_name.toStdString().c_str(), p_arg1);
+  }
+}
+
+void AOConfigPrivate::update_favorite_device()
+{
+  if (!favorite_device_driver.has_value())
+    return;
+  audio_engine->set_favorite_device_by_driver(favorite_device_driver.value());
+}
+
+void AOConfigPrivate::on_application_state_changed(Qt::ApplicationState p_state)
+{
+  audio_engine->set_suppressed(mute_background_audio && p_state != Qt::ApplicationActive);
+}
+
+// AOConfig ////////////////////////////////////////////////////////////////////
 
 /*!
  * private classes are cool
@@ -352,13 +215,13 @@ AOConfig::AOConfig(QObject *p_parent) : QObject(p_parent)
   }
 
   // ao2 is the pinnacle of thread security
-  d->parents.append(this);
+  d->children.append(this);
 }
 
 AOConfig::~AOConfig()
 {
   // totally safe!
-  d->parents.removeAll(this);
+  d->children.removeAll(this);
 }
 
 QString AOConfig::get_string(QString p_name, QString p_default)
@@ -454,6 +317,12 @@ bool AOConfig::log_is_recording_enabled()
 {
   return d->log_is_recording;
 }
+
+std::optional<QString> AOConfig::favorite_device_driver()
+{
+  return d->favorite_device_driver;
+}
+
 int AOConfig::master_volume()
 {
   return d->master_volume;
@@ -493,129 +362,215 @@ bool AOConfig::blank_blips_enabled()
   return d->blank_blips;
 }
 
+void AOConfig::save_file()
+{
+  d->save_file();
+}
+
 void AOConfig::set_autosave(bool p_enabled)
 {
-  d->set_autosave(p_enabled);
+  if (d->autosave == p_enabled)
+    return;
+  d->autosave = p_enabled;
+  d->invoke_signal("autosave_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_username(QString p_string)
 {
-  d->set_username(p_string);
+  if (d->username == p_string)
+    return;
+  d->username = p_string;
+  d->invoke_signal("username_changed", Q_ARG(QString, p_string));
 }
 
 void AOConfig::set_callwords(QString p_string)
 {
-  d->set_callwords(p_string);
-}
-
-void AOConfig::set_theme(QString p_string)
-{
-  d->set_theme(p_string);
-}
-
-void AOConfig::set_gamemode(QString p_string)
-{
-  d->set_gamemode(p_string);
-}
-
-void AOConfig::set_manual_gamemode(bool p_enabled)
-{
-  d->set_manual_gamemode(p_enabled);
-}
-
-void AOConfig::set_timeofday(QString p_string)
-{
-  d->set_timeofday(p_string);
-}
-
-void AOConfig::set_manual_timeofday(bool p_enabled)
-{
-  d->set_manual_timeofday(p_enabled);
+  if (d->callwords == p_string)
+    return;
+  d->callwords = p_string;
+  d->invoke_signal("callwords_changed", Q_ARG(QString, p_string));
 }
 
 void AOConfig::set_server_alerts(bool p_enabled)
 {
-  d->set_server_alerts(p_enabled);
+  if (d->server_alerts == p_enabled)
+    return;
+  d->server_alerts = p_enabled;
+  d->invoke_signal("server_alerts_changed", Q_ARG(bool, p_enabled));
+}
+
+void AOConfig::set_theme(QString p_string)
+{
+  if (d->theme == p_string)
+    return;
+  d->theme = p_string;
+  d->invoke_signal("theme_changed", Q_ARG(QString, p_string));
+}
+
+void AOConfig::set_gamemode(QString p_string)
+{
+  if (d->gamemode == p_string)
+    return;
+  d->gamemode = p_string;
+  d->invoke_signal("gamemode_changed", Q_ARG(QString, p_string));
+}
+
+void AOConfig::set_manual_gamemode(bool p_enabled)
+{
+  if (d->manual_gamemode == p_enabled)
+    return;
+  d->manual_gamemode = p_enabled;
+  d->invoke_signal("manual_gamemode_changed", Q_ARG(bool, p_enabled));
+}
+
+void AOConfig::set_timeofday(QString p_string)
+{
+  if (d->timeofday == p_string)
+    return;
+  d->timeofday = p_string;
+  d->invoke_signal("timeofday_changed", Q_ARG(QString, p_string));
+}
+
+void AOConfig::set_manual_timeofday(bool p_enabled)
+{
+  if (d->manual_timeofday == p_enabled)
+    return;
+  d->manual_timeofday = p_enabled;
+  d->invoke_signal("manual_timeofday_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_always_pre(bool p_enabled)
 {
-  d->set_always_pre(p_enabled);
+  if (d->always_pre == p_enabled)
+    return;
+  d->always_pre = p_enabled;
+  d->invoke_signal("always_pre_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_chat_tick_interval(int p_number)
 {
-  d->set_chat_tick_interval(p_number);
+  if (d->chat_tick_interval == p_number)
+    return;
+  d->chat_tick_interval = p_number;
+  d->invoke_signal("chat_tick_interval_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_log_max_lines(int p_number)
 {
-  d->set_log_max_lines(p_number);
+  if (d->log_max_lines == p_number)
+    return;
+  d->log_max_lines = p_number;
+  d->invoke_signal("log_max_lines_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_log_is_topdown(bool p_enabled)
 {
-  d->set_log_is_topdown(p_enabled);
+  if (d->log_is_topdown == p_enabled)
+    return;
+  d->log_is_topdown = p_enabled;
+  d->invoke_signal("log_is_topdown_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_log_uses_newline(bool p_enabled)
 {
-  d->set_log_uses_newline(p_enabled);
+  if (d->log_uses_newline == p_enabled)
+    return;
+  d->log_uses_newline = p_enabled;
+  d->invoke_signal("log_uses_newline_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_log_music(bool p_enabled)
 {
-  d->set_log_music(p_enabled);
+  if (d->log_music == p_enabled)
+    return;
+  d->log_music = p_enabled;
+  d->invoke_signal("log_music_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_log_is_recording(bool p_enabled)
 {
-  d->set_log_is_recording(p_enabled);
-}
-
-void AOConfig::set_mute_background_audio(bool p_enabled)
-{
-  d->set_mute_background_audio(p_enabled);
+  if (d->log_is_recording == p_enabled)
+    return;
+  d->log_is_recording = p_enabled;
+  d->invoke_signal("log_is_recording_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_master_volume(int p_number)
 {
-  d->set_master_volume(p_number);
+  if (d->master_volume == p_number)
+    return;
+  d->master_volume = p_number;
+  d->audio_engine->set_volume(p_number);
+  d->invoke_signal("master_volume_changed", Q_ARG(int, p_number));
+}
+
+void AOConfig::set_mute_background_audio(bool p_enabled)
+{
+  if (d->mute_background_audio == p_enabled)
+    return;
+  d->mute_background_audio = p_enabled;
+  d->invoke_signal("mute_background_audio_changed", Q_ARG(bool, p_enabled));
+}
+
+void AOConfig::set_favorite_device_driver(QString p_device_driver)
+{
+  if (d->favorite_device_driver.has_value() && d->favorite_device_driver.value() == p_device_driver)
+    return;
+  d->favorite_device_driver = p_device_driver;
+  d->update_favorite_device();
+  d->invoke_signal("favorite_device_changed", Q_ARG(QString, p_device_driver));
 }
 
 void AOConfig::set_system_volume(int p_number)
 {
-  d->set_system_volume(p_number);
+  if (d->system_volume == p_number)
+    return;
+  d->system_volume = p_number;
+  d->audio_engine->get_family(DRAudio::Family::FSystem)->set_volume(p_number);
+  d->invoke_signal("system_volume_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_effect_volume(int p_number)
 {
-  d->set_effects_volume(p_number);
+  if (d->effect_volume == p_number)
+    return;
+  d->effect_volume = p_number;
+  d->audio_engine->get_family(DRAudio::Family::FEffect)->set_volume(p_number);
+  d->invoke_signal("effect_volume_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_music_volume(int p_number)
 {
-  d->set_music_volume(p_number);
+  if (d->music_volume == p_number)
+    return;
+  d->music_volume = p_number;
+  d->audio_engine->get_family(DRAudio::Family::FMusic)->set_volume(p_number);
+  d->invoke_signal("music_volume_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_blip_volume(int p_number)
 {
-  d->set_blips_volume(p_number);
+  if (d->blip_volume == p_number)
+    return;
+  d->blip_volume = p_number;
+  d->audio_engine->get_family(DRAudio::Family::FBlip)->set_volume(p_number);
+  d->invoke_signal("blip_volume_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_blip_rate(int p_number)
 {
-  d->set_blip_rate(p_number);
+  if (d->blip_rate == p_number)
+    return;
+  d->blip_rate = p_number;
+  d->invoke_signal("blip_rate_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_blank_blips(bool p_enabled)
 {
-  d->set_blank_blips(p_enabled);
-}
-
-void AOConfig::save_file()
-{
-  d->save_file();
+  if (d->blank_blips == p_enabled)
+    return;
+  d->blank_blips = p_enabled;
+  d->invoke_signal("blank_blips_changed", Q_ARG(bool, p_enabled));
 }
 
 // moc

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -8,7 +8,7 @@
 #include "aoapplication.h" // ruined
 
 AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
-    : QWidget(p_parent), m_config(new AOConfig(this))
+    : QWidget(p_parent), m_config(new AOConfig(this)), m_engine(new DRAudioEngine(this))
 {
   ao_app = p_ao_app;
 
@@ -50,6 +50,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   w_log_is_recording = AO_GUI_WIDGET(QCheckBox, "log_recording");
 
   // audio
+  w_device = AO_GUI_WIDGET(QComboBox, "device");
+  w_favorite_device = AO_GUI_WIDGET(QCheckBox, "favorite_device");
   w_master = AO_GUI_WIDGET(QSlider, "master");
   w_master_value = AO_GUI_WIDGET(QLabel, "master_value");
   w_mute_background_audio = AO_GUI_WIDGET(QCheckBox, "mute_background_audio");
@@ -95,6 +97,12 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(m_config, SIGNAL(blip_rate_changed(int)), w_blip_rate, SLOT(setValue(int)));
   connect(m_config, SIGNAL(blank_blips_changed(bool)), w_blank_blips, SLOT(setChecked(bool)));
 
+  connect(m_engine, SIGNAL(device_changed(DRAudioDevice)), this, SLOT(on_audio_device_changed(DRAudioDevice)));
+  connect(m_engine, SIGNAL(device_list_changed(QList<DRAudioDevice>)), this,
+          SLOT(on_audio_device_list_changed(QList<DRAudioDevice>)));
+  connect(m_engine, SIGNAL(favorite_device_changed(DRAudioDevice)), this,
+          SLOT(on_favorite_audio_device_changed(DRAudioDevice)));
+
   // output
   connect(w_close, SIGNAL(clicked()), this, SLOT(close()));
   connect(w_save, SIGNAL(clicked()), m_config, SLOT(save_file()));
@@ -116,6 +124,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(w_log_music, SIGNAL(toggled(bool)), m_config, SLOT(set_log_music(bool)));
   connect(w_log_is_recording, SIGNAL(toggled(bool)), m_config, SLOT(set_log_is_recording(bool)));
   connect(w_mute_background_audio, SIGNAL(toggled(bool)), m_config, SLOT(set_mute_background_audio(bool)));
+  connect(w_device, SIGNAL(currentIndexChanged(int)), this, SLOT(on_device_current_index_changed(int)));
   connect(w_master, SIGNAL(valueChanged(int)), m_config, SLOT(set_master_volume(int)));
   connect(w_master, SIGNAL(valueChanged(int)), this, SLOT(on_master_value_changed(int)));
   connect(w_system, SIGNAL(valueChanged(int)), m_config, SLOT(set_system_volume(int)));
@@ -155,6 +164,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   w_log_uses_newline->setChecked(m_config->log_uses_newline_enabled());
   w_log_music->setChecked(m_config->log_music_enabled());
   w_log_is_recording->setChecked(m_config->log_is_recording_enabled());
+
+  // audio
+  update_audio_device_list();
   w_master->setValue(m_config->master_volume());
   w_mute_background_audio->setChecked(m_config->mute_background_audio());
   w_system->setValue(m_config->system_volume());
@@ -270,6 +282,40 @@ void AOConfigPanel::refresh_timeofday_list()
   w_timeofday->blockSignals(false);
 }
 
+void AOConfigPanel::update_audio_device_list()
+{
+  const auto current_device = m_engine->get_device();
+  const auto favorite_device = m_engine->get_favorite_device();
+
+  QSignalBlocker device_blocker(w_device);
+  w_device->clear();
+
+  std::optional<int> current_device_index;
+  {
+    for (DRAudioDevice &i_device : m_engine->get_device_list())
+    {
+      if (!i_device.is_enabled())
+        continue;
+      w_device->addItem(i_device.get_name(), i_device.get_driver());
+      int item_index = w_device->count() - 1;
+
+      if (current_device.has_value() && current_device.value().get_driver() == i_device.get_driver())
+        current_device_index = item_index;
+
+      if (favorite_device.has_value() && favorite_device.value().get_driver() == i_device.get_driver())
+        w_device->setItemData(item_index, QColor(Qt::green), Qt::BackgroundRole);
+    }
+
+    const bool has_items(w_device->count());
+    if (!has_items)
+      w_device->addItem(tr("<no sound>"));
+    w_device->setEnabled(has_items);
+  }
+
+  if (current_device_index.has_value())
+    w_device->setCurrentIndex(current_device_index.value());
+}
+
 void AOConfigPanel::on_reload_theme_clicked()
 {
   qDebug() << "reload theme clicked";
@@ -292,6 +338,40 @@ void AOConfigPanel::on_log_is_topdown_changed(bool p_enabled)
 {
   w_log_orientation_top_down->setChecked(p_enabled);
   w_log_orientation_bottom_up->setChecked(!p_enabled);
+}
+
+void AOConfigPanel::on_device_current_index_changed(int p_index)
+{
+  if (p_index == -1 || p_index >= w_device->count())
+    return;
+
+  const QString target_device_driver = w_device->itemData(p_index).toString();
+  for (DRAudioDevice &i_device : m_engine->get_device_list())
+    if (target_device_driver == i_device.get_driver())
+    {
+      m_engine->set_device(i_device);
+      m_engine->set_favorite_device(i_device);
+      m_config->set_favorite_device_driver(i_device.get_driver());
+      break;
+    }
+}
+
+void AOConfigPanel::on_audio_device_changed(DRAudioDevice p_device)
+{
+  Q_UNUSED(p_device)
+  update_audio_device_list();
+}
+
+void AOConfigPanel::on_favorite_audio_device_changed(DRAudioDevice p_device)
+{
+  Q_UNUSED(p_device)
+  update_audio_device_list();
+}
+
+void AOConfigPanel::on_audio_device_list_changed(QList<DRAudioDevice> p_device_list)
+{
+  Q_UNUSED(p_device_list);
+  update_audio_device_list();
 }
 
 void AOConfigPanel::on_master_value_changed(int p_num)

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -19,7 +19,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   loader.load_from_file(":res/ui/config_panel.ui", this);
 
   // tab
-  setFocusProxy(AO_GUI_WIDGET(QTabWidget, "tab_widget"));
+  QTabWidget *tab_widget = AO_GUI_WIDGET(QTabWidget, "tab_widget");
+  setFocusProxy(tab_widget);
+  tab_widget->setCurrentIndex(0);
 
   // behaviour
   w_save = AO_GUI_WIDGET(QPushButton, "save");

--- a/src/draudio.cpp
+++ b/src/draudio.cpp
@@ -2,7 +2,7 @@
 
 #include <bass.h>
 
-QString DRAudio::get_bass_error(int32_t p_error_code)
+QString DRAudio::get_bass_error(const int32_t p_error_code)
 {
   switch (p_error_code)
   {

--- a/src/draudiodevice.cpp
+++ b/src/draudiodevice.cpp
@@ -1,0 +1,64 @@
+#include "draudiodevice.h"
+
+DRAudioDevice::DRAudioDevice() : m_name("<unknown>")
+{}
+
+DRAudioDevice::DRAudioDevice(DWORD p_device, BASS_DEVICEINFO p_device_info)
+    : m_id(p_device), m_name(p_device_info.name), m_driver(p_device_info.driver), m_states(State(p_device_info.flags))
+{}
+
+std::optional<DWORD> DRAudioDevice::get_id() const
+{
+  return m_id;
+}
+
+QString DRAudioDevice::get_name() const
+{
+  return m_name;
+}
+
+QString DRAudioDevice::get_driver() const
+{
+  return m_driver;
+}
+
+DRAudioDevice::States DRAudioDevice::get_states() const
+{
+  return m_states;
+}
+
+bool DRAudioDevice::is_state(DRAudioDevice::State p_state) const
+{
+  return m_states.testFlag(p_state);
+}
+
+bool DRAudioDevice::is_enabled() const
+{
+  return is_state(SEnabled);
+}
+
+bool DRAudioDevice::is_default() const
+{
+  return is_state(SDefault);
+}
+
+bool DRAudioDevice::is_init() const
+{
+  return is_state(SInit);
+}
+
+bool DRAudioDevice::merge(DRAudioDevice &p_device)
+{
+  bool is_changed = false;
+  auto check_and_set = [&](auto &a, auto &b) {
+    if (a == b)
+      return;
+    is_changed = true;
+    a = b;
+  };
+
+  check_and_set(m_name, p_device.m_name);
+  check_and_set(m_driver, p_device.m_driver);
+  check_and_set(m_states, p_device.m_states);
+  return is_changed;
+}

--- a/src/draudioengine.cpp
+++ b/src/draudioengine.cpp
@@ -1,71 +1,81 @@
 #include "draudioengine.h"
 
+#include "draudioengine_p.h"
+
 #include <QCoreApplication>
 #include <QDebug>
-#include <QMap>
-#include <QPointer>
+#include <QScopedPointer>
 
-class DRAudioEnginePrivate : public QObject
+static const int EVENT_TIMER_INTERVAL_DEFAULT = 100;
+
+static class DRAudioEngineData
 {
-  Q_OBJECT
-
 public:
-  using ptr = std::unique_ptr<DRAudioEnginePrivate>;
+  using ptr = DRAudioEnginePrivate::ptr;
 
-  DRAudioEnginePrivate(QObject *parent = nullptr) : QObject(parent)
-  {}
-
-  void invoke_signal(QString p_method_name, QGenericArgument p_arg1 = QGenericArgument(nullptr))
+  ptr &operator->()
   {
-    for (QObject *i_parent : parents)
+    if (d == nullptr)
     {
-      QMetaObject::invokeMethod(i_parent, p_method_name.toStdString().c_str(), p_arg1);
+      d = ptr(new DRAudioEnginePrivate);
+
+      // create engine shortcut
+      d->engine = new DRAudioEngine;
+
+      // create families
+      d->family_map.insert(DRAudio::Family::FSystem,
+                           DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FSystem)));
+      d->family_map.insert(DRAudio::Family::FEffect,
+                           DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FEffect)));
+      d->family_map.insert(DRAudio::Family::FMusic,
+                           DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FMusic)));
+      d->family_map.insert(DRAudio::Family::FBlip,
+                           DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FBlip)));
+
+      // set family-specific options
+      d->family_map.value(DRAudio::Family::FSystem)->set_ignore_suppression(true);
+
+      // create and init event loop
+      d->event_timer->setInterval(EVENT_TIMER_INTERVAL_DEFAULT);
+      d->event_timer->setSingleShot(false);
+
+      QObject::connect(d->event_timer, SIGNAL(timeout()), d, SLOT(on_event_tick()));
+
+      d->event_timer->start();
+
+      d->on_event_tick();
     }
+
+    return d;
   }
 
-  QObjectList parents;
-  std::int32_t volume = 0;
-  DRAudio::Options options;
-  QMap<DRAudio::Family, DRAudioStreamFamily::ptr> family_map;
-};
-
-namespace
-{
-static QPointer<DRAudioEnginePrivate> d;
-}
+private:
+  ptr d;
+} d;
 
 DRAudioEngine::DRAudioEngine(QObject *p_parent) : QObject(p_parent)
 {
-  if (BOOL r = BASS_Init(-1, 48000, BASS_DEVICE_LATENCY, 0, NULL); r == FALSE)
-    qWarning() << DRAudioError(QString("failed to init: %1").arg(DRAudio::get_last_bass_error())).get_error();
-
-  if (d == nullptr)
-  {
-    Q_ASSERT_X(qApp, "initialization", "QApplication is required");
-    d = new DRAudioEnginePrivate(qApp);
-
-    // there's plenty of way of optimizing this
-    d->family_map.insert(DRAudio::Family::FSystem,
-                         DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FSystem)));
-    d->family_map.insert(DRAudio::Family::FEffect,
-                         DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FEffect)));
-    d->family_map.insert(DRAudio::Family::FMusic,
-                         DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FMusic)));
-    d->family_map.insert(DRAudio::Family::FBlip,
-                         DRAudioStreamFamily::ptr(new DRAudioStreamFamily(DRAudio::Family::FBlip)));
-
-    // family-specific options
-    get_family(DRAudio::Family::FSystem)->set_ignore_suppression(true);
-  }
-
-  d->parents.append(this);
+  d->children.append(this);
 }
 
 DRAudioEngine::~DRAudioEngine()
 {
-  d->parents.removeAll(this);
+  d->children.removeAll(this);
+}
 
-  BASS_Free();
+std::optional<DRAudioDevice> DRAudioEngine::get_device()
+{
+  return d->device;
+}
+
+std::optional<DRAudioDevice> DRAudioEngine::get_favorite_device()
+{
+  return d->favorite_device;
+}
+
+QList<DRAudioDevice> DRAudioEngine::get_device_list()
+{
+  return d->device_map.values();
 }
 
 DRAudioStreamFamily::ptr DRAudioEngine::get_family(DRAudio::Family p_family)
@@ -88,50 +98,85 @@ DRAudio::Options DRAudioEngine::get_options()
   return d->options;
 }
 
+bool DRAudioEngine::is_option(DRAudio::Option p_option)
+{
+  return d->options.testFlag(p_option);
+}
+
 bool DRAudioEngine::is_suppressed()
 {
   return d->options.testFlag(DRAudio::OSuppressed);
 }
 
+bool DRAudioEngine::is_mute_background_audio()
+{
+  return is_option(DRAudio::OEngineMuteBackgroundAudio);
+}
+void DRAudioEngine::set_device(DRAudioDevice p_device)
+{
+  if (!d->device_map.contains(p_device.get_driver()))
+    return;
+  if (d->device.has_value() && d->device->get_driver() == p_device.get_driver())
+    return;
+  d->previous_device = d->device;
+  d->device = d->device_map.value(p_device.get_driver());
+  d->update_device();
+  Q_EMIT d->invoke_signal("device_changed", Q_ARG(DRAudioDevice, d->device.value()));
+}
+
+void DRAudioEngine::set_favorite_device(DRAudioDevice p_device)
+{
+  if (d->favorite_device.has_value() && d->favorite_device.value().get_driver() == p_device.get_driver())
+    return;
+  d->favorite_device = p_device;
+  Q_EMIT d->invoke_signal("favorite_device_changed", Q_ARG(DRAudioDevice, d->favorite_device.value()));
+}
+
+void DRAudioEngine::set_favorite_device_by_driver(QString p_device_driver)
+{
+  DRAudioDevice favorite_device;
+  favorite_device.m_driver = p_device_driver;
+  d->check_device = true;
+  set_favorite_device(favorite_device);
+}
+
 void DRAudioEngine::set_volume(int32_t p_volume)
 {
   p_volume = std::clamp(p_volume, 0, 100);
-
   if (d->volume == p_volume)
     return;
-
   d->volume = p_volume;
-  adjust_volume();
-  Q_EMIT d->invoke_signal("volume_changed", Q_ARG(std::int32_t, d->volume));
+  d->update_volume();
+  Q_EMIT d->invoke_signal("volume_changed", Q_ARG(int32_t, d->volume));
 }
 
 void DRAudioEngine::set_options(DRAudio::Options p_options)
 {
   if (d->options == p_options)
     return;
-
   d->options = p_options;
-  adjust_options();
+  d->update_options();
   Q_EMIT d->invoke_signal("options_changed", Q_ARG(DRAudio::Options, d->options));
+}
+
+void DRAudioEngine::set_option(DRAudio::Option p_option, bool p_enabled)
+{
+  DRAudio::Options new_options = d->options;
+  new_options.setFlag(p_option, p_enabled);
+  set_options(new_options);
 }
 
 void DRAudioEngine::set_suppressed(bool p_enabled)
 {
-  DRAudio::Options options = d->options;
-  options.setFlag(DRAudio::OSuppressed, p_enabled);
-  set_options(options);
+  set_option(DRAudio::OSuppressed, p_enabled);
 }
 
-void DRAudioEngine::adjust_options()
+void DRAudioEngine::set_mute_background_audio(bool p_enabled)
 {
-  adjust_volume();
+  set_option(DRAudio::OEngineMuteBackgroundAudio, p_enabled);
 }
 
-void DRAudioEngine::adjust_volume()
+void DRAudioEngine::check_stream_error()
 {
-  for (auto &i_group : d->family_map.values())
-    i_group->adjust_volume();
+  d->check_stream_error();
 }
-
-// needed by moc
-#include "draudioengine.moc"

--- a/src/draudioengine_p.cpp
+++ b/src/draudioengine_p.cpp
@@ -1,0 +1,153 @@
+#include "draudioengine_p.h"
+
+/*!
+    I could've avoided making this necessary but I didn't
+    want to make the code extra complex.
+
+    So here, instead have this very convuloted workaround
+    instead.
+*/
+#include "draudioengine.h"
+
+#include <QDebug>
+#include <QGuiApplication>
+
+static const int EVENT_TIMER_INTERVAL_DEFAULT = 100;
+
+DRAudioEnginePrivate::DRAudioEnginePrivate() : QObject(nullptr), event_timer(new QTimer)
+{}
+
+DRAudioEnginePrivate::~DRAudioEnginePrivate()
+{
+  event_timer->stop();
+
+  BASS_Free();
+}
+
+void DRAudioEnginePrivate::invoke_signal(QString p_method_name, QGenericArgument p_arg1)
+{
+  for (QObject *i_child : children)
+  {
+    QMetaObject::invokeMethod(i_child, p_method_name.toStdString().c_str(), p_arg1);
+  }
+}
+
+void DRAudioEnginePrivate::update_device()
+{
+  // cache the stream's position before we make the switch
+  for (DRAudioStreamFamily::ptr &i_family : family_map.values())
+    for (DRAudioStream::ptr &i_stream : i_family->get_stream_list())
+      i_stream->cache_position();
+
+  if (previous_device.has_value())
+  {
+    qInfo().noquote() << QString("Shutting down current device: %1").arg(previous_device->get_name());
+    if (BASS_Free() == FALSE)
+      qCritical() << DRAudioError(QString("Failed to free: %1").arg(DRAudio::get_last_bass_error())).what();
+    previous_device.reset();
+  }
+
+  if (!device.has_value())
+    qCritical() << DRAudioError("Failed to initialize, device not set!").what();
+
+  qInfo().noquote() << QString("Initializing device: %1").arg(device->get_name());
+  if (BASS_Init(device->get_id().value_or(0), 48000, BASS_DEVICE_LATENCY, 0, NULL) == FALSE)
+    qCritical() << DRAudioError(QString("Failed to initialize: %1").arg(DRAudio::get_last_bass_error())).what();
+
+  qInfo() << "Switching to initiliazed device";
+  if (BASS_SetDevice(device->get_id().value_or(0)) == FALSE)
+    qCritical() << DRAudioError(QString("Failed to set device: %1").arg(DRAudio::get_last_bass_error())).what();
+
+  for (DRAudioStreamFamily::ptr &i_family : family_map.values())
+    i_family->update_device();
+}
+
+void DRAudioEnginePrivate::update_device_list()
+{
+  QVector<DRAudioDevice> updated_device_list;
+
+  {
+    BASS_DEVICEINFO device_info;
+    for (int device = 1; BASS_GetDeviceInfo(device, &device_info); ++device)
+      updated_device_list.append(DRAudioDevice(device, device_info));
+  }
+
+  bool is_changed = false;
+  for (DRAudioDevice &device : updated_device_list)
+  {
+    if (device_map.contains(device.get_driver()))
+    {
+      if (device_map[device.get_driver()].merge(device))
+        is_changed = true;
+      continue;
+    }
+
+    device_map.insert(device.get_driver(), device);
+    is_changed = true;
+  }
+
+  if (!is_changed)
+    return;
+  check_device = true;
+  Q_EMIT invoke_signal("device_list_changed", Q_ARG(QList<DRAudioDevice>, device_map.values()));
+}
+
+void DRAudioEnginePrivate::update_options()
+{
+  update_volume();
+}
+
+void DRAudioEnginePrivate::update_volume()
+{
+  for (auto &i_group : family_map.values())
+    i_group->update_volume();
+}
+
+void DRAudioEnginePrivate::check_stream_error()
+{
+  event_timer->start(EVENT_TIMER_INTERVAL_DEFAULT);
+  check_device = true;
+}
+
+void DRAudioEnginePrivate::on_event_tick()
+{
+  update_device_list();
+
+  if (device.has_value() && !check_device)
+    return;
+  check_device = false;
+
+  std::optional<DRAudioDevice> target_device;
+  for (DRAudioDevice &i_device : device_map.values())
+  {
+    if (!i_device.is_enabled())
+      continue;
+
+    if (favorite_device && favorite_device.value().get_driver() == i_device.get_driver())
+    {
+      // if our favorite device doesn't have an id then
+      // it was most likely set through the driver
+      // in which case we need to update it
+      if (!favorite_device->get_id().has_value())
+      {
+        favorite_device.reset();
+        engine->set_favorite_device(i_device);
+      }
+
+      target_device = i_device;
+      break;
+    }
+
+    if (!target_device.has_value() || i_device.is_default())
+      target_device = i_device;
+  }
+
+  if (!target_device.has_value())
+  {
+#ifdef QT_DEBUG
+    qWarning().noquote() << DRAudioError(QString("NO DEVICE AVAILABLE!")).what();
+#endif
+    return;
+  }
+  engine->set_device(target_device.value());
+}

--- a/src/draudioerror.cpp
+++ b/src/draudioerror.cpp
@@ -3,10 +3,10 @@
 DRAudioError::DRAudioError()
 {}
 
-DRAudioError::DRAudioError(QString p_error) : m_error(QString("[bass]%1").arg(p_error))
+DRAudioError::DRAudioError(QString p_error) : m_error(QString("[bass] %1").arg(p_error))
 {}
 
-QString DRAudioError::get_error()
+QString DRAudioError::what()
 {
   return m_error;
 }

--- a/src/draudiostream.cpp
+++ b/src/draudiostream.cpp
@@ -73,7 +73,7 @@ std::optional<DRAudioError> DRAudioStream::set_file(QString p_file)
 
   const QFileInfo file(p_file);
   if (!file.exists())
-    return DRAudioError("file does not exist");
+    return DRAudioError(QString("file does not exist: %1").arg(p_file.isEmpty() ? "<empty>" : p_file));
 
   if (m_file == p_file)
     return std::nullopt;
@@ -135,12 +135,10 @@ void DRAudioStream::on_sync_callback(HSYNC hsync, DWORD ch, DWORD data, void *us
     switch (v.type)
     {
     case BASS_SYNC_END:
-      qDebug().noquote() << QString("[%1] %2 has been triggered!").arg(filePath).arg("BASS_SYNC_END");
       Q_EMIT self->finished();
       break;
 
     case BASS_SYNC_DEV_FAIL:
-      qDebug().noquote() << QString("[%1] %2 has been triggered!").arg(filePath).arg("BASS_SYNC_DEV_FAIL");
       Q_EMIT self->device_error(QPrivateSignal());
       break;
     }

--- a/src/draudiostream.cpp
+++ b/src/draudiostream.cpp
@@ -7,7 +7,9 @@
 #include <QFileInfo>
 
 DRAudioStream::DRAudioStream(DRAudio::Family p_family) : m_family(p_family)
-{}
+{
+  connect(this, &DRAudioStream::device_error, this, &DRAudioStream::on_device_error, Qt::QueuedConnection);
+}
 
 DRAudioStream::~DRAudioStream()
 {
@@ -17,7 +19,7 @@ DRAudioStream::~DRAudioStream()
 
     while (!m_hsync_stack.empty())
     {
-      BASS_ChannelRemoveSync(hstream, m_hsync_stack.top());
+      BASS_ChannelRemoveSync(hstream, m_hsync_stack.top().sync);
       m_hsync_stack.pop();
     }
 
@@ -25,17 +27,17 @@ DRAudioStream::~DRAudioStream()
   }
 }
 
-DRAudio::Family DRAudioStream::get_family()
+DRAudio::Family DRAudioStream::get_family() const
 {
   return m_family;
 }
 
-std::optional<QString> DRAudioStream::get_file()
+std::optional<QString> DRAudioStream::get_file() const
 {
   return m_file;
 }
 
-bool DRAudioStream::is_playing()
+bool DRAudioStream::is_playing() const
 {
   if (!m_hstream)
     return false;
@@ -51,7 +53,7 @@ void DRAudioStream::play()
   {
     qWarning() << DRAudioError(
                       QString("failed to play file %1: %2").arg(m_file.value()).arg(DRAudio::get_last_bass_error()))
-                      .get_error();
+                      .what();
     Q_EMIT finished();
   }
 }
@@ -85,10 +87,17 @@ std::optional<DRAudioError> DRAudioStream::set_file(QString p_file)
   m_hstream = stream_handle;
 
   // bass events
-  HSYNC sync_handle = BASS_ChannelSetSync(stream_handle, BASS_SYNC_END, 0, &DRAudioStream::sync_on_end, this);
-  if (sync_handle == 0)
-    return DRAudioError(
-        QString("failed to create sync for file %1: %2").arg(p_file).arg(DRAudio::get_last_bass_error()));
+  for (const DWORD type : {BASS_SYNC_END, BASS_SYNC_DEV_FAIL})
+  {
+    HSYNC sync_handle =
+        BASS_ChannelSetSync(stream_handle, type | BASS_SYNC_MIXTIME, 0, &DRAudioStream::on_sync_callback, this);
+    if (sync_handle == 0)
+      return DRAudioError(QString("failed to create sync %1 for file %2: %3")
+                              .arg(type)
+                              .arg(p_file)
+                              .arg(DRAudio::get_last_bass_error()));
+    m_hsync_stack.push(DRAudioStreamSync{sync_handle, type});
+  }
 
   Q_EMIT file_changed(p_file);
   return std::nullopt;
@@ -98,10 +107,13 @@ void DRAudioStream::set_volume(float p_volume)
 {
   if (!m_hstream)
     return;
+  m_volume = p_volume;
   BASS_ChannelSetAttribute(m_hstream.value(), BASS_ATTRIB_VOL, float(p_volume) * 0.01f);
 }
 
-void DRAudioStream::sync_on_end(HSYNC hsync, DWORD ch, DWORD data, void *userdata)
+#include <QTimer>
+
+void DRAudioStream::on_sync_callback(HSYNC hsync, DWORD ch, DWORD data, void *userdata)
 {
   Q_UNUSED(hsync)
   Q_UNUSED(ch)
@@ -112,5 +124,68 @@ void DRAudioStream::sync_on_end(HSYNC hsync, DWORD ch, DWORD data, void *userdat
    * the pointer we provided get deleted mid-way through the program lifetime
    */
   DRAudioStream *self = static_cast<DRAudioStream *>(userdata);
-  Q_EMIT self->finished();
+
+  for (auto &v : self->m_hsync_stack)
+  {
+    if (v.sync != hsync)
+      continue;
+
+    const QString filePath = self->get_file().value();
+
+    switch (v.type)
+    {
+    case BASS_SYNC_END:
+      qDebug().noquote() << QString("[%1] %2 has been triggered!").arg(filePath).arg("BASS_SYNC_END");
+      Q_EMIT self->finished();
+      break;
+
+    case BASS_SYNC_DEV_FAIL:
+      qDebug().noquote() << QString("[%1] %2 has been triggered!").arg(filePath).arg("BASS_SYNC_DEV_FAIL");
+      Q_EMIT self->device_error(QPrivateSignal());
+      break;
+    }
+  }
+}
+
+void DRAudioStream::cache_position()
+{
+  if (!m_hstream.has_value())
+    return;
+  if (m_position.has_value())
+    return;
+  m_position = BASS_ChannelGetPosition(m_hstream.value(), BASS_POS_BYTE);
+  BASS_ChannelStop(m_hstream.value());
+}
+
+void DRAudioStream::on_device_error()
+{
+  cache_position();
+  DRAudioEngine::check_stream_error();
+}
+
+void DRAudioStream::update_device()
+{
+  if (is_playing())
+    return;
+  const QString file = m_file.value();
+
+  m_file.reset();
+  m_hstream.reset();
+  m_hsync_stack.clear();
+
+  blockSignals(true);
+  set_file(file);
+  set_volume(m_volume);
+  blockSignals(false);
+
+  if (m_position.has_value())
+  {
+    if (BASS_ChannelSetPosition(m_hstream.value(), m_position.value(), BASS_POS_BYTE) == FALSE)
+      qWarning() << DRAudioError(
+                        QString("failed to set position for %1: %2").arg(file).arg(DRAudio::get_last_bass_error()))
+                        .what();
+    m_position.reset();
+  }
+
+  play();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,12 +5,6 @@
 #include "lobby.h"
 #include "networkmanager.h"
 
-#include <QDebug>
-#include <QDir>
-#include <QFileInfo>
-#include <QPluginLoader>
-#include <cstdio>
-
 int main(int argc, char *argv[])
 {
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)


### PR DESCRIPTION
DRAudioEngine has been updated to automatically pick a device and can be provided a favorite device.

If a favorite device has been designed, DRAudioEngine will attempt to transfert all currently playing sounds to the favorite device of choice.

Otherwise, it will attempt to pick the designated audio device chosen by the OS.

Finally, If there is no designated audio device, it will pick the first one available.

Finally, if there are no devices available the client will simply prevent audio from playing and will report the issue in the console.

DRAudioEngine will always attempt to have an audio device active. As long as one is enabled within the OS, it will attempt its best to use it. Failing this, sounds will simply be disabled and won't be able to play until an appropriate device is available.

**Favorite Device**
* To select a favorite device simply switch to the wanted device in the dropdown menu in AOConfigPanel
**NOTE: The dropdown will always reflect the currently used device. If clicked on the dropdown, the favorite device will be highlighted in green to indicate it's the favorite device.**

If clicking outside of the dropdown, it will simply close the dropdown list of choices and will continue showing the current device.