### PR TITLE
Optimize alignment changes and rendering of IC messages

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -332,6 +332,10 @@ public:
    */
   QString read_theme_ini(QString p_identifier, QString p_file);
 
+  bool read_theme_ini_bool(QString p_identifier, QString p_file);
+
+  int read_theme_ini_int(QString p_identifier, QString p_file);
+
   // Returns the coordinates of widget with p_identifier from p_file
   QPoint get_button_spacing(QString p_identifier, QString p_file);
 

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -114,6 +114,16 @@ public:
   QString get_background_path(QString p_file);
   QString get_default_background_path(QString p_file);
   QString get_evidence_path(QString p_file);
+
+  /**
+   * @brief Check the path for various known exploits.
+   *
+   * In order:
+   * - Directory traversal (most commonly: "../" jumps)
+   * @param p_file The path to check.
+   * @return A sanitized path. If any check fails, the path returned is an empty string. The sanitized path does not
+   * necessarily exist.
+   */
   QString sanitize_path(QString p_file);
 
   /**

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -383,9 +383,6 @@ public:
   // Returns the value of chat from the specific p_char's ini file
   QString get_chat(QString p_char);
 
-  // Not in use
-  int get_text_delay(QString p_char, QString p_emote);
-
   // Returns the name of p_char
   QString get_char_name(QString p_char);
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -766,12 +766,13 @@ private slots:
    * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_shout_buttons();
+  void reset_shout_buttons();
 
   /**
    * @brief a general purpose function to toggle button selection
    */
-  void on_shout_clicked();
+  void on_shout_button_clicked(const bool);
+  void on_shout_button_toggled(const bool);
 
   /**
    * @brief Set the sprites of the effect buttons, and mark the currently
@@ -780,8 +781,9 @@ private slots:
    * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_effect_buttons();
-  void on_effect_button_clicked();
+  void reset_effect_buttons();
+  void on_effect_button_clicked(const bool);
+  void on_effect_button_toggled(const bool);
 
   void on_mute_clicked();
 
@@ -800,7 +802,7 @@ private slots:
    * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_judge_wtce_buttons();
+  void reset_wtce_buttons();
   void on_wtce_clicked();
 
   void on_change_character_clicked();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -331,9 +331,6 @@ private:
   //////////////
   QScrollArea *note_scroll_area = nullptr;
 
-  // delay before chat messages starts ticking
-  QTimer *text_delay_timer = nullptr;
-
   // delay before sfx plays
   QTimer *sfx_delay_timer = nullptr;
 
@@ -693,7 +690,7 @@ public slots:
   void mod_called(QString p_ip);
 
 private slots:
-  void start_chat_ticking();
+  void setup_chat();
   void play_sfx();
 
   void chat_tick();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -171,7 +171,10 @@ public:
 
   void list_areas();
 
-  void list_sfx();
+  QString current_sfx_file();
+  void update_sfx_list();
+  void update_sfx_widget_list();
+  void clear_sfx_widget_list_selection();
 
   void list_note_files();
 
@@ -303,7 +306,6 @@ private:
   QVector<evi_type> evidence_list;
   QVector<QString> music_list;
   QVector<QString> area_list;
-  QVector<QString> sfx_names;
   QVector<QString> area_names;
   QVector<QString> note_list;
 
@@ -447,7 +449,6 @@ private:
 
   int current_clock = -1;
   int timer_number = 0;
-  int current_sfx_id = -1;
 
   QString current_background = "gs4";
 
@@ -500,7 +501,11 @@ private:
   QListWidget *ui_mute_list = nullptr;
   QListWidget *ui_area_list = nullptr;
   QListWidget *ui_music_list = nullptr;
+
   QListWidget *ui_sfx_list = nullptr;
+  QVector<DR::SFX> m_sfx_list;
+  QColor m_sfx_color_found;
+  QColor m_sfx_color_missing;
 
   QLineEdit *ui_ic_chat_message = nullptr;
 
@@ -697,13 +702,14 @@ private slots:
 
   void on_ooc_return_pressed();
 
-  void on_music_search_edited(QString p_text);
+  void on_music_search_edited();
   void on_music_list_clicked();
   void on_area_list_clicked();
   void on_music_list_double_clicked(QModelIndex p_model);
   void on_area_list_double_clicked(QModelIndex p_model);
 
-  void on_sfx_search_edited(QString p_text);
+  void on_sfx_search_edited();
+  void on_sfx_widget_list_row_changed();
 
   void select_emote(int p_id);
 
@@ -821,8 +827,6 @@ private slots:
   void on_pre_clicked();
   void on_flip_clicked();
   void on_hidden_clicked();
-
-  void on_sfx_list_clicked(QModelIndex p_index);
 
   void on_evidence_button_clicked();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -403,6 +403,11 @@ private:
   // if enabled, disable showing our own sprites when we talk in ic
   bool m_msg_is_first_person = false;
 
+  // Cached values for chat_tick
+  bool chatbox_message_outline = false;
+  bool chatbox_message_enable_highlighting = false;
+  QVector<QStringList> chatbox_message_highlight_colors;
+
   // cid and this may differ in cases of ini-editing
   QString current_char;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -96,13 +96,8 @@ public:
   void set_widgets();
   // sets font properties based on theme ini files
   void set_font(QWidget *widget, QString p_identifier);
-  // same as above, but use override color as color if it is not an empty
-  // string, otherwise use normal logic for color of set_font
-  void set_font(QWidget *widget, QString p_identifier, QString override_color);
-  // sets font properties for DRTextEdit (same as above but also text outline)
+  // sets font properties for DRTextEdit (same as above but also text outline, and alignments)
   void set_drtextedit_font(DRTextEdit *widget, QString p_identifier);
-  // same as second set_font but for drtextedit
-  void set_drtextedit_font(DRTextEdit *widget, QString p_identifier, QString override_color);
   // helper function that calls above function on the relevant widgets
   void set_fonts();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -171,10 +171,7 @@ public:
 
   void list_areas();
 
-  QString current_sfx_file();
-  void update_sfx_list();
-  void update_sfx_widget_list();
-  void clear_sfx_widget_list_selection();
+  void list_sfx();
 
   void list_note_files();
 
@@ -306,6 +303,7 @@ private:
   QVector<evi_type> evidence_list;
   QVector<QString> music_list;
   QVector<QString> area_list;
+  QVector<QString> sfx_names;
   QVector<QString> area_names;
   QVector<QString> note_list;
 
@@ -449,6 +447,7 @@ private:
 
   int current_clock = -1;
   int timer_number = 0;
+  int current_sfx_id = -1;
 
   QString current_background = "gs4";
 
@@ -501,11 +500,7 @@ private:
   QListWidget *ui_mute_list = nullptr;
   QListWidget *ui_area_list = nullptr;
   QListWidget *ui_music_list = nullptr;
-
   QListWidget *ui_sfx_list = nullptr;
-  QVector<DR::SFX> m_sfx_list;
-  QColor m_sfx_color_found;
-  QColor m_sfx_color_missing;
 
   QLineEdit *ui_ic_chat_message = nullptr;
 
@@ -702,14 +697,13 @@ private slots:
 
   void on_ooc_return_pressed();
 
-  void on_music_search_edited();
+  void on_music_search_edited(QString p_text);
   void on_music_list_clicked();
   void on_area_list_clicked();
   void on_music_list_double_clicked(QModelIndex p_model);
   void on_area_list_double_clicked(QModelIndex p_model);
 
-  void on_sfx_search_edited();
-  void on_sfx_widget_list_row_changed();
+  void on_sfx_search_edited(QString p_text);
 
   void select_emote(int p_id);
 
@@ -827,6 +821,8 @@ private slots:
   void on_pre_clicked();
   void on_flip_clicked();
   void on_hidden_clicked();
+
+  void on_sfx_list_clicked(QModelIndex p_index);
 
   void on_evidence_button_clicked();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -401,9 +401,9 @@ private:
   bool m_msg_is_first_person = false;
 
   // Cached values for chat_tick
-  bool chatbox_message_outline = false;
-  bool chatbox_message_enable_highlighting = false;
-  QVector<QStringList> chatbox_message_highlight_colors;
+  bool m_chatbox_message_outline = false;
+  bool m_chatbox_message_enable_highlighting = false;
+  QVector<QStringList> m_chatbox_message_highlight_colors;
 
   // cid and this may differ in cases of ini-editing
   QString current_char;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -171,7 +171,11 @@ public:
 
   void list_areas();
 
-  void list_sfx();
+  QString current_sfx_file();
+  void update_sfx_list();
+  void update_sfx_widget_list();
+  void select_default_sfx();
+  void clear_sfx_selection();
 
   void list_note_files();
 
@@ -303,7 +307,6 @@ private:
   QVector<evi_type> evidence_list;
   QVector<QString> music_list;
   QVector<QString> area_list;
-  QVector<QString> sfx_names;
   QVector<QString> area_names;
   QVector<QString> note_list;
 
@@ -447,7 +450,6 @@ private:
 
   int current_clock = -1;
   int timer_number = 0;
-  int current_sfx_id = -1;
 
   QString current_background = "gs4";
 
@@ -500,7 +502,12 @@ private:
   QListWidget *ui_mute_list = nullptr;
   QListWidget *ui_area_list = nullptr;
   QListWidget *ui_music_list = nullptr;
+
   QListWidget *ui_sfx_list = nullptr;
+  QVector<DR::SFX> m_sfx_list;
+  const QString m_sfx_default_file = "__DEFAULT__";
+  QColor m_sfx_color_found;
+  QColor m_sfx_color_missing;
 
   QLineEdit *ui_ic_chat_message = nullptr;
 
@@ -697,13 +704,14 @@ private slots:
 
   void on_ooc_return_pressed();
 
-  void on_music_search_edited(QString p_text);
+  void on_music_search_edited();
   void on_music_list_clicked();
   void on_area_list_clicked();
   void on_music_list_double_clicked(QModelIndex p_model);
   void on_area_list_double_clicked(QModelIndex p_model);
 
-  void on_sfx_search_edited(QString p_text);
+  void on_sfx_search_editing_finished();
+  void on_sfx_widget_list_row_changed();
 
   void select_emote(int p_id);
 
@@ -821,8 +829,6 @@ private slots:
   void on_pre_clicked();
   void on_flip_clicked();
   void on_hidden_clicked();
-
-  void on_sfx_list_clicked(QModelIndex p_index);
 
   void on_evidence_button_clicked();
 

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -60,6 +60,19 @@ private:
   bool system = false;
   bool music = false;
 };
+
+struct SFX
+{
+public:
+  SFX() = default;
+  SFX(QString p_name, QString p_file, bool p_is_found = false)
+      : name(p_name.trimmed()), file(p_file.trimmed()), is_found(p_is_found)
+  {}
+
+  QString name;
+  QString file;
+  bool is_found;
+};
 } // namespace DR
 
 struct server_type

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -60,19 +60,6 @@ private:
   bool system = false;
   bool music = false;
 };
-
-struct SFX
-{
-public:
-  SFX() = default;
-  SFX(QString p_name, QString p_file, bool p_is_found = false)
-      : name(p_name.trimmed()), file(p_file.trimmed()), is_found(p_is_found)
-  {}
-
-  QString name;
-  QString file;
-  bool is_found;
-};
 } // namespace DR
 
 struct server_type

--- a/include/drtextedit.h
+++ b/include/drtextedit.h
@@ -12,10 +12,12 @@ public:
   DRTextEdit(QWidget *p_parent);
 
   bool get_outline();
+  bool get_auto_align();
   Qt::Alignment get_vertical_alignment();
   Qt::Alignment get_horizontal_alignment();
 
   void set_outline(bool p_outline);
+  void set_auto_align(bool new_auto_align);
   void set_vertical_alignment(Qt::Alignment p_align);
   void set_horizontal_alignment(Qt::Alignment p_align);
 
@@ -30,6 +32,7 @@ private:
     InProgress,
   };
   Status m_status = Status::Done;
+  bool m_auto_align = true;
 
   int current_document_blocks = 0;
   int current_document_height = 0;

--- a/include/drtextedit.h
+++ b/include/drtextedit.h
@@ -34,8 +34,8 @@ private:
   Status m_status = Status::Done;
   bool m_auto_align = true;
 
-  int current_document_blocks = 0;
-  int current_document_height = 0;
+  int m_current_document_blocks = 0;
+  int m_current_document_height = 0;
 
   void refresh_horizontal_alignment();
   void refresh_vertical_alignment();

--- a/include/drtextedit.h
+++ b/include/drtextedit.h
@@ -31,6 +31,7 @@ private:
   };
   Status m_status = Status::Done;
 
+  int current_document_blocks = 0;
   int current_document_height = 0;
 
   void refresh_horizontal_alignment();

--- a/include/drtextedit.h
+++ b/include/drtextedit.h
@@ -31,6 +31,11 @@ private:
   };
   Status m_status = Status::Done;
 
+  int current_document_height = 0;
+
+  void refresh_horizontal_alignment();
+  void refresh_vertical_alignment();
+
 private slots:
   void on_text_changed();
 };

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -185,19 +185,14 @@ QString AOApplication::get_current_char()
 
 QString AOApplication::sanitize_path(QString p_file)
 {
-  // We want to avoid allowing directories with \..\ or /../, as those allow us to jump
-  // We first check if there are any .. at all
   if (!p_file.contains(".."))
-  {
-    // Don't do expensive check if there are no .. to begin with.
     return p_file;
-  }
-  // Otherwise, there are ..
-  // Check if they are actually referring to a directory, as it is possible
+
   QStringList list = p_file.split(QRegularExpression("[\\/]"));
   while (!list.isEmpty())
     if (list.takeFirst().contains(QRegularExpression("\\.{2,}")))
       return nullptr;
+
   return p_file;
 }
 

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -185,6 +185,15 @@ QString AOApplication::get_current_char()
 
 QString AOApplication::sanitize_path(QString p_file)
 {
+  // We want to avoid allowing directories with \..\ or /../, as those allow us to jump
+  // We first check if there are any .. at all
+  if (!p_file.contains(".."))
+  {
+    // Don't do expensive check if there are no .. to begin with.
+    return p_file;
+  }
+  // Otherwise, there are ..
+  // Check if they are actually referring to a directory, as it is possible
   QStringList list = p_file.split(QRegularExpression("[\\/]"));
   while (!list.isEmpty())
     if (list.takeFirst().contains(QRegularExpression("\\.{2,}")))

--- a/src/aocharmovie.cpp
+++ b/src/aocharmovie.cpp
@@ -84,13 +84,11 @@ bool AOCharMovie::play_pre(QString p_chr, QString p_emote)
 
 void AOCharMovie::play_talking(QString p_chr, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_chr, "(b)" + p_emote);
   play(p_chr, p_emote, "(b)", false);
 }
 
 void AOCharMovie::play_idle(QString p_chr, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_chr, "(a)" + p_emote);
   play(p_chr, p_emote, "(a)", false);
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -309,7 +309,7 @@ void Courtroom::handle_music_anim()
   QFont f_font = ui_vp_music_name->font();
   QFontMetrics fm(f_font);
   int dist;
-  if (ao_app->read_theme_ini("enable_const_music_speed", cc_config_ini) == "true")
+  if (ao_app->read_theme_ini_bool("enable_const_music_speed", cc_config_ini))
     dist = res_b.width;
   else
     dist = fm.horizontalAdvance(ui_vp_music_name->toPlainText());
@@ -979,7 +979,7 @@ void Courtroom::handle_chatmessage_3()
   const bool l_hide_emote = (f_emote == "../../misc/blank");
 
   QString path;
-  if (!chatmessage_is_empty && ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
+  if (!chatmessage_is_empty && ao_app->read_theme_ini_bool("enable_showname_image", cc_config_ini))
   {
     // Asset lookup order
     // 1. In the theme folder (gamemode-timeofday/main/default), in the character
@@ -1367,7 +1367,7 @@ void Courtroom::setup_chat()
 
   // Cache these so chat_tick performs better
   chatbox_message_outline = (ao_app->get_font_property("message_outline", fonts_ini) == 1);
-  chatbox_message_enable_highlighting = (ao_app->read_theme_ini("enable_highlighting", cc_config_ini) == "true");
+  chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", cc_config_ini));
   chatbox_message_highlight_colors = ao_app->get_highlight_colors();
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CMChrName]);
@@ -2011,7 +2011,7 @@ void Courtroom::on_cycle_clicked()
     break;
   }
 
-  if (ao_app->read_theme_ini("enable_cycle_ding", cc_config_ini) == "true")
+  if (ao_app->read_theme_ini_bool("enable_cycle_ding", cc_config_ini))
     m_system_player->play(ao_app->get_sfx("cycle"));
 
   set_shouts();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -936,7 +936,8 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
 void Courtroom::handle_chatmessage_3()
 {
-  qDebug() << "handle_chatmessage_3";
+  qDebug() << "3 start" << QTime::currentTime();
+  // qDebug() << "handle_chatmessage_3";
 
   setup_chat();
 
@@ -1106,6 +1107,7 @@ void Courtroom::handle_chatmessage_3()
   }
 
   chat_tick_timer->start(ao_app->get_chat_tick_interval());
+  // qDebug() << "3 end" << QTime::currentTime();
 }
 
 void Courtroom::on_chat_config_changed()
@@ -1572,7 +1574,7 @@ void Courtroom::hide_testimony()
 void Courtroom::play_sfx()
 {
   QString sfx_name = m_chatmessage[CMSoundName];
-  if (sfx_name == "1")
+  if (sfx_name == "1" || sfx_name == "0")
     return;
 
   m_effects_player->play(sfx_name);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -720,7 +720,10 @@ void Courtroom::handle_acknowledged_ms()
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
   m_shout_state = 0;
+
+  qDebug() << "Shout start" << QTime::currentTime();
   draw_shout_buttons();
+  qDebug() << "Shout end" << QTime::currentTime();
 
   m_effect_state = 0;
   draw_effect_buttons();
@@ -729,6 +732,7 @@ void Courtroom::handle_acknowledged_ms()
   draw_judge_wtce_buttons();
 
   is_presenting_evidence = false;
+
   ui_evidence_present->set_image("present_disabled.png");
 }
 
@@ -803,12 +807,6 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   }
 
   QString f_message = f_showname + ": " + m_chatmessage[CMMessage] + "\n";
-
-  /*
-  if (f_message == previous_ic_message && is_system_speaking == false)
-    return;
-  previous_ic_message = f_message;
-    */
 
   m_effects_player->stop_all();
 
@@ -936,11 +934,9 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
 void Courtroom::handle_chatmessage_3()
 {
-  qDebug() << "3 start" << QTime::currentTime();
-  // qDebug() << "handle_chatmessage_3";
+  qDebug() << "handle_chatmessage_3";
 
   setup_chat();
-
   int f_evi_id = m_chatmessage[CMEvidenceId].toInt();
   QString f_side = m_chatmessage[CMPosition];
 
@@ -1046,30 +1042,7 @@ void Courtroom::handle_chatmessage_3()
   QString overlay_name = overlay.at(0);
   QString overlay_sfx = overlay.at(1);
 
-  bool do_it = ao_app->read_theme_ini("non_vanilla_effects", cc_config_ini) == "true";
-
-  if (effect == 1 && !do_it)
-  {
-    if (overlay_sfx == "")
-      overlay_sfx = ao_app->get_sfx("effect_flash");
-    m_effects_player->play(overlay_sfx);
-    ui_vp_effect->set_play_once(true);
-    if (overlay_name == "")
-      overlay_name = "effect_flash";
-    ui_vp_effect->play(overlay_name, f_char);
-    realization_timer->start(60);
-  }
-  //  else if (effect == 2)
-  //  {
-  //    if (overlay_sfx == "")
-  //      overlay_sfx = ao_app->get_sfx("effect_gloom");
-  //    m_sfx_player->play(overlay_sfx);
-  //    ui_vp_effect->set_play_once(false);
-  //    if (overlay_name == "")
-  //      overlay_name = "effect_gloom";
-  //    ui_vp_effect->play(overlay_name, f_char);
-  //  }
-  else if (do_it && effect > 0 && effect <= ui_effects.size() && effect_names.size() > 0) // check to prevent crashing
+  if (effect > 0 && effect <= ui_effects.size() && effect_names.size() > 0) // check to prevent crashing
   {
     QString s_eff = effect_names.at(effect - 1);
     QStringList f_eff = ao_app->get_effect(effect);
@@ -1107,7 +1080,6 @@ void Courtroom::handle_chatmessage_3()
   }
 
   chat_tick_timer->start(ao_app->get_chat_tick_interval());
-  // qDebug() << "3 end" << QTime::currentTime();
 }
 
 void Courtroom::on_chat_config_changed()
@@ -1982,8 +1954,10 @@ void Courtroom::draw_shout_buttons()
 {
   for (int i = 0; i < ui_shouts.size(); ++i)
   {
+    // qDebug() << "Shout start" << QTime::currentTime();
     QString shout_file = shout_names.at(i) + ".png";
     ui_shouts[i]->set_image(shout_file);
+    // qDebug() << "Shout after set_image" << QTime::currentTime();
     if (ao_app->find_theme_asset_path(shout_file).isEmpty())
       ui_shouts[i]->setText(shout_names.at(i));
     else

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -803,8 +803,6 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
     f_showname = m_chatmessage[CMShowName];
   }
 
-  QString f_message = f_showname + ": " + m_chatmessage[CMMessage] + "\n";
-
   m_effects_player->stop_all();
 
   text_state = 0;
@@ -879,11 +877,6 @@ void Courtroom::handle_chatmessage_2() // handles IC
   {
     f_showname = m_chatmessage[CMShowName];
   }
-
-  // Check if char.ini has color property, which overrides the theme's default
-  // showname color
-  QString f_color = ao_app->read_char_ini(real_name, "color", "[Options]", "[Time]");
-  set_drtextedit_font(ui_vp_showname, "showname", f_color);
 
   ui_vp_showname->setText(f_showname);
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -911,8 +911,6 @@ void Courtroom::handle_chatmessage_2() // handles IC
     set_scene();
   }
 
-  set_text_color();
-
   int emote_mod = m_chatmessage[CMEmoteModifier].toInt();
 
   if (m_chatmessage[CMFlipState].toInt() == 1)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -938,8 +938,6 @@ void Courtroom::handle_chatmessage_3()
 {
   qDebug() << "handle_chatmessage_3";
 
-  start_chat_ticking();
-
   int f_evi_id = m_chatmessage[CMEvidenceId].toInt();
   QString f_side = m_chatmessage[CMPosition];
 
@@ -1099,6 +1097,8 @@ void Courtroom::handle_chatmessage_3()
       break;
     }
   }
+
+  start_chat_ticking();
 }
 
 void Courtroom::on_chat_config_changed()
@@ -1318,7 +1318,7 @@ void Courtroom::play_preanim()
 {
   QString f_preanim = m_chatmessage[CMPreAnim];
 
-  if (f_preanim == "-")
+  if (f_preanim.trimmed() == "-")
   {
     // no animation, continue
     preanim_done();
@@ -1405,12 +1405,14 @@ void Courtroom::start_chat_ticking()
 
   // means text is currently ticking
   text_state = 1;
+  chat_tick();
 }
 
 void Courtroom::chat_tick()
 {
   // note: this is called fairly often(every 60 ms when char is talking)
   // do not perform heavy operations here
+  qDebug() << QTime::currentTime();
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
   if (chatbox_message_outline)
     vp_message_format.setTextOutline(QPen(Qt::black, 1));
@@ -1538,7 +1540,9 @@ void Courtroom::chat_tick()
         blip_pos = 0;
 
         // play blip
+        qDebug() << "START" << QTime::currentTime();
         m_blips_player->blip_tick();
+        qDebug() << "END" << QTime::currentTime();
       }
 
       ++blip_pos;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -127,7 +127,7 @@ void Courtroom::enter_courtroom(int p_cid)
 
   list_music();
   list_areas();
-  update_sfx_list();
+  list_sfx();
 
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
@@ -437,96 +437,68 @@ void Courtroom::list_areas()
   }
 }
 
-QString Courtroom::current_sfx_file()
+void Courtroom::list_sfx()
 {
-  QListWidgetItem *l_item = ui_sfx_list->currentItem();
-  if (l_item == nullptr)
-    return "0";
-  const QString l_file = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
-  return l_file.isEmpty() ? "0" : l_file;
-}
-
-void Courtroom::update_sfx_list()
-{
-  // colors
-  m_sfx_color_found = ao_app->get_color("found_song_color", design_ini);
-  m_sfx_color_missing = ao_app->get_color("missing_song_color", design_ini);
-
-  // items
-  m_sfx_list.clear();
-  m_sfx_list.append(DR::SFX("Default", nullptr));
-  m_sfx_list.append(DR::SFX("Silence", nullptr));
-
-  const QStringList l_sfx_list = ao_app->get_sfx_list();
-  for (const QString &i_sfx_line : l_sfx_list)
-  {
-    const QStringList l_sfx_entry = i_sfx_line.split("=", DR::SkipEmptyParts);
-
-    const QString l_name = l_sfx_entry.at(l_sfx_entry.size() - 1).trimmed();
-    const QString l_file = QString(l_sfx_entry.size() >= 2 ? l_sfx_entry.at(0) : nullptr).trimmed();
-    const bool l_is_found = !ao_app->find_asset_path({ao_app->get_sounds_path(l_file)}, audio_extensions()).isEmpty();
-    m_sfx_list.append(DR::SFX(l_name, l_file, l_is_found));
-  }
-
-  update_sfx_widget_list();
-}
-
-void Courtroom::update_sfx_widget_list()
-{
-  QSignalBlocker l_blocker(ui_sfx_list);
   ui_sfx_list->clear();
+  sfx_names.clear();
+  current_sfx_id = -1; // Restart current SFX, because it may no longer be valid
 
-  const QString l_name_filter = ui_sfx_search->text();
-  for (int i = 0; i < m_sfx_list.length(); ++i)
+  QString f_file = design_ini;
+
+  QStringList sfx_list = ao_app->get_sfx_list();
+
+  QBrush found_brush(ao_app->get_color("found_song_color", f_file));
+  QBrush missing_brush(ao_app->get_color("missing_song_color", f_file));
+
+  // Add hardcoded items
+  // FIXME: Rewrite
+  ui_sfx_list->addItem("Default");
+  ui_sfx_list->addItem("Silence");
+
+  sfx_names.append("1"); // Default
+  sfx_names.append("1"); // Silence
+
+  QString default_sfx_root = ao_app->get_sounds_path("1");
+  QString default_sfx_path = ao_app->find_asset_path({default_sfx_root}, audio_extensions());
+  if (!default_sfx_path.isEmpty())
   {
-    const DR::SFX &i_sfx = m_sfx_list.at(i);
-    if (!i_sfx.name.contains(l_name_filter, Qt::CaseInsensitive))
-      continue;
-    QListWidgetItem *l_item = new QListWidgetItem;
-    l_item->setText(i_sfx.name);
-    l_item->setData(Qt::UserRole, i);
-    ui_sfx_list->addItem(l_item);
+    ui_sfx_list->item(0)->setBackground(found_brush);
+    ui_sfx_list->item(1)->setBackground(found_brush);
+  }
+  else
+  {
+    ui_sfx_list->item(0)->setBackground(missing_brush);
+    ui_sfx_list->item(1)->setBackground(missing_brush);
   }
 
-  on_sfx_widget_list_row_changed();
-}
-
-void Courtroom::clear_sfx_widget_list_selection()
-{
-  ui_sfx_list->setCurrentRow(-1);
-}
-
-void Courtroom::on_sfx_search_edited()
-{
-  update_sfx_list();
-}
-
-void Courtroom::on_sfx_widget_list_row_changed()
-{
-  const int p_current_row = ui_sfx_list->currentRow();
-  ui_pre->setChecked(p_current_row != -1);
-
-  for (int i = 0; i < ui_sfx_list->count(); ++i)
+  // Now add the other SFXs given by the character's sound.ini
+  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
   {
-    QListWidgetItem *l_item = ui_sfx_list->item(i);
-    const bool l_is_found = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).is_found;
+    QStringList sfx = sfx_list.at(n_sfx).split("=");
+    QString i_sfx = sfx.at(0).trimmed();
+    QString d_sfx = "";
+    sfx_names.append(i_sfx);
+    if (sfx_list.at(n_sfx).split("=").size() < 2)
+      d_sfx = i_sfx;
+    else
+      d_sfx = sfx.at(1).trimmed();
 
-    QColor i_color = l_is_found ? m_sfx_color_found : m_sfx_color_missing;
-    if (i == p_current_row)
+    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
     {
-      // Calculate the amount of lightness it would take to light up the row. We
-      // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
-      // nothing. +0.4 is just an arbitrarily chosen number.
-      const double l_final_lightness = qMin(1.0, i_color.lightnessF() + 0.4);
+      ui_sfx_list->addItem(d_sfx);
+      int last_index = ui_sfx_list->count() - 1;
+      ui_sfx_list->item(last_index)->setStatusTip(QString::number(n_sfx + 2));
 
-      // This is just the reverse of the above, basically. We set the colour, and we
-      // set the brush to have that colour.
-      i_color.setHslF(i_color.hueF(), i_color.saturationF(), l_final_lightness);
+      // Apply appropriate color whether SFX exists or not
+      QString sfx_root = ao_app->get_sounds_path(i_sfx);
+      QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
+
+      if (!sfx_path.isEmpty())
+        ui_sfx_list->item(last_index)->setBackground(found_brush);
+      else
+        ui_sfx_list->item(last_index)->setBackground(missing_brush);
     }
-
-    l_item->setBackground(i_color);
   }
-  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::list_note_files()
@@ -659,8 +631,20 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(f_side);
 
-  // sfx file
-  packet_contents.append(current_sfx_file());
+  //  packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
+  //  packet_contents.append(ui_sfx_search->text());
+
+  int row = ui_sfx_list->currentRow();
+  if (row == -1 || row == 0) // default
+    packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
+  else if (QListWidgetItem *item = ui_sfx_list->item(row)) // selection
+  {
+    double d_ind = item->statusTip().toDouble();
+    int ind = int(d_ind);
+    qDebug() << ind;
+    packet_contents.append(sfx_names.at(ind));
+    //    packet_contents.append(sfx_names.at(row));
+  }
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
@@ -732,11 +716,12 @@ void Courtroom::handle_acknowledged_ms()
 
   // reset states
   ui_pre->setChecked(ao_config->always_pre_enabled());
+  list_sfx();
+  ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
   reset_shout_buttons();
   reset_effect_buttons();
   reset_wtce_buttons();
-  clear_sfx_widget_list_selection();
 
   is_presenting_evidence = false;
   ui_evidence_present->set_image("present_disabled.png");
@@ -1835,10 +1820,19 @@ void Courtroom::on_ooc_return_pressed()
   ui_ooc_chat_message->setFocus();
 }
 
-void Courtroom::on_music_search_edited()
+void Courtroom::on_music_search_edited(QString p_text)
 {
+  // preventing compiler warnings
+  p_text += "a";
   list_music();
   list_areas();
+}
+
+void Courtroom::on_sfx_search_edited(QString p_text)
+{
+  // preventing compiler warnings
+  p_text += "a";
+  list_sfx();
 }
 
 void Courtroom::on_pos_dropdown_changed(int p_index)
@@ -1967,6 +1961,7 @@ void Courtroom::on_shout_button_clicked(const bool p_checked)
       continue;
     i_button->setChecked(false);
   }
+
   m_shout_state = p_checked ? l_id : 0;
 
   ui_ic_chat_message->setFocus();
@@ -2365,6 +2360,52 @@ void Courtroom::closeEvent(QCloseEvent *event)
 {
   Q_EMIT closing();
   QMainWindow::closeEvent(event);
+}
+
+void Courtroom::on_sfx_list_clicked(QModelIndex p_index)
+{
+  if (p_index.isValid())
+    ui_pre->setChecked(p_index.isValid());
+
+  QListWidgetItem *new_sfx = ui_sfx_list->currentItem();
+
+  QBrush found_brush(ao_app->get_color("found_song_color", design_ini));
+  QBrush missing_brush(ao_app->get_color("missing_song_color", design_ini));
+
+  if (current_sfx_id != -1)
+  {
+    QListWidgetItem *old_sfx = ui_sfx_list->item(current_sfx_id);
+
+    // Apply appropriate color whether SFX exists or not
+    QString sfx_root = ao_app->get_sounds_path(sfx_names.at(current_sfx_id));
+    QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
+
+    if (!sfx_path.isEmpty())
+      old_sfx->setBackground(found_brush);
+    else
+      old_sfx->setBackground(missing_brush);
+  }
+
+  // Grab the colour of the selected row's brush.
+  QBrush selected_brush = new_sfx->background();
+  QColor selected_col = selected_brush.color();
+
+  // Calculate the amount of lightness it would take to light up the row. We
+  // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
+  // nothing. +0.4 is just an arbitrarily chosen number.
+  double final_lightness = qMin(1.0, selected_col.lightnessF() + 0.4);
+
+  // This is just the reverse of the above, basically. We set the colour, and we
+  // set the brush to have that colour.
+  selected_col.setHslF(selected_col.hueF(), selected_col.saturationF(), final_lightness);
+  selected_brush.setColor(selected_col);
+
+  // Finally, we set the selected SFX's background to be the lightened-up brush.
+  new_sfx->setBackground(selected_brush);
+
+  current_sfx_id = ui_sfx_list->currentRow();
+
+  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -720,10 +720,7 @@ void Courtroom::handle_acknowledged_ms()
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
   m_shout_state = 0;
-
-  qDebug() << "Shout start" << QTime::currentTime();
   draw_shout_buttons();
-  qDebug() << "Shout end" << QTime::currentTime();
 
   m_effect_state = 0;
   draw_effect_buttons();
@@ -1521,6 +1518,8 @@ void Courtroom::chat_tick()
 
     ++tick_pos;
   }
+
+  ui_vp_message->repaint();
 }
 
 void Courtroom::show_testimony()
@@ -1954,10 +1953,8 @@ void Courtroom::draw_shout_buttons()
 {
   for (int i = 0; i < ui_shouts.size(); ++i)
   {
-    // qDebug() << "Shout start" << QTime::currentTime();
     QString shout_file = shout_names.at(i) + ".png";
     ui_shouts[i]->set_image(shout_file);
-    // qDebug() << "Shout after set_image" << QTime::currentTime();
     if (ao_app->find_theme_asset_path(shout_file).isEmpty())
       ui_shouts[i]->setText(shout_names.at(i));
     else

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -984,20 +984,25 @@ void Courtroom::handle_chatmessage_3()
   const QString f_emote = m_chatmessage[CMEmote];
   const bool l_hide_emote = (f_emote == "../../misc/blank");
 
-  ui_vp_showname_image->show();
+  QString path;
+  if (!chatmessage_is_empty && ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
+  {
+    // Asset lookup order
+    // 1. In the theme folder (gamemode-timeofday/main/default), in the character
+    // folder, look for "showname" + extensions in `exts` in order
+    // 2. In the character folder, look for
+    // "showname" + extensions in `exts` in order
 
-  // Asset lookup order
-  // 1. In the theme folder (gamemode-timeofday/main/default), in the character
-  // folder, look for "showname" + extensions in `exts` in order
-  // 2. In the character folder, look for
-  // "showname" + extensions in `exts` in order
+    path = ao_app->find_theme_asset_path("characters/" + f_char + "/showname", {".png"});
+    if (path.isEmpty())
+      path = ao_app->find_asset_path({ao_app->get_character_path(f_char, "showname")}, {".png"});
+  }
 
-  QString path = ao_app->find_theme_asset_path("characters/" + f_char + "/showname", {".png"});
-  if (path.isEmpty())
-    path = ao_app->find_asset_path({ao_app->get_character_path(f_char, "showname")}, {".png"});
-
-  if (!path.isEmpty() && !chatmessage_is_empty &&
-      ao_app->read_theme_ini("enable_showname_image", cc_config_ini) == "true")
+  // Path may be empty if
+  // 1. Chat message was empty
+  // 2. Enable showname images was false
+  // 3. No valid showname image was found
+  if (!path.isEmpty())
   {
     ui_vp_showname->hide();
     ui_vp_showname_image->set_image_from_path(path);
@@ -1101,7 +1106,6 @@ void Courtroom::handle_chatmessage_3()
   }
 
   chat_tick_timer->start(ao_app->get_chat_tick_interval());
-  chat_tick();
 }
 
 void Courtroom::on_chat_config_changed()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1115,6 +1115,9 @@ void Courtroom::update_ic_log(bool p_reset_log)
 
   if (p_reset_log)
   {
+    // Turn off auto align. That is because we are going to be performing a lot of text change operations
+    // but we don't necessarily care the intermediate states are not aligned
+    ui_ic_chatlog->set_auto_align(false);
     // we need all recordings
     QQueue<DR::ChatRecord> new_queue;
     while (!m_ic_record_list.isEmpty())
@@ -1279,6 +1282,12 @@ void Courtroom::update_ic_log(bool p_reset_log)
   {
     ui_ic_chatlog->moveCursor(move_type);
     vscrollbar->setValue(chatlog_scrolldown ? vscrollbar->maximum() : vscrollbar->minimum());
+  }
+
+  if (p_reset_log)
+  {
+    // We are done updating the IC chat log, now do all alignment computations
+    ui_ic_chatlog->set_auto_align(true);
   }
 }
 
@@ -1522,7 +1531,6 @@ void Courtroom::chat_tick()
         blip_pos = 0;
 
         // play blip
-        //        m_blip_player->play();
         m_blips_player->blip_tick();
       }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -127,7 +127,7 @@ void Courtroom::enter_courtroom(int p_cid)
 
   list_music();
   list_areas();
-  list_sfx();
+  update_sfx_list();
 
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
@@ -437,68 +437,96 @@ void Courtroom::list_areas()
   }
 }
 
-void Courtroom::list_sfx()
+QString Courtroom::current_sfx_file()
 {
+  QListWidgetItem *l_item = ui_sfx_list->currentItem();
+  if (l_item == nullptr)
+    return "0";
+  const QString l_file = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
+  return l_file.isEmpty() ? "0" : l_file;
+}
+
+void Courtroom::update_sfx_list()
+{
+  // colors
+  m_sfx_color_found = ao_app->get_color("found_song_color", design_ini);
+  m_sfx_color_missing = ao_app->get_color("missing_song_color", design_ini);
+
+  // items
+  m_sfx_list.clear();
+  m_sfx_list.append(DR::SFX("Default", nullptr));
+  m_sfx_list.append(DR::SFX("Silence", nullptr));
+
+  const QStringList l_sfx_list = ao_app->get_sfx_list();
+  for (const QString &i_sfx_line : l_sfx_list)
+  {
+    const QStringList l_sfx_entry = i_sfx_line.split("=", DR::SkipEmptyParts);
+
+    const QString l_name = l_sfx_entry.at(l_sfx_entry.size() - 1).trimmed();
+    const QString l_file = QString(l_sfx_entry.size() >= 2 ? l_sfx_entry.at(0) : nullptr).trimmed();
+    const bool l_is_found = !ao_app->find_asset_path({ao_app->get_sounds_path(l_file)}, audio_extensions()).isEmpty();
+    m_sfx_list.append(DR::SFX(l_name, l_file, l_is_found));
+  }
+
+  update_sfx_widget_list();
+}
+
+void Courtroom::update_sfx_widget_list()
+{
+  QSignalBlocker l_blocker(ui_sfx_list);
   ui_sfx_list->clear();
-  sfx_names.clear();
-  current_sfx_id = -1; // Restart current SFX, because it may no longer be valid
 
-  QString f_file = design_ini;
-
-  QStringList sfx_list = ao_app->get_sfx_list();
-
-  QBrush found_brush(ao_app->get_color("found_song_color", f_file));
-  QBrush missing_brush(ao_app->get_color("missing_song_color", f_file));
-
-  // Add hardcoded items
-  // FIXME: Rewrite
-  ui_sfx_list->addItem("Default");
-  ui_sfx_list->addItem("Silence");
-
-  sfx_names.append("1"); // Default
-  sfx_names.append("1"); // Silence
-
-  QString default_sfx_root = ao_app->get_sounds_path("1");
-  QString default_sfx_path = ao_app->find_asset_path({default_sfx_root}, audio_extensions());
-  if (!default_sfx_path.isEmpty())
+  const QString l_name_filter = ui_sfx_search->text();
+  for (int i = 0; i < m_sfx_list.length(); ++i)
   {
-    ui_sfx_list->item(0)->setBackground(found_brush);
-    ui_sfx_list->item(1)->setBackground(found_brush);
-  }
-  else
-  {
-    ui_sfx_list->item(0)->setBackground(missing_brush);
-    ui_sfx_list->item(1)->setBackground(missing_brush);
+    const DR::SFX &i_sfx = m_sfx_list.at(i);
+    if (!i_sfx.name.contains(l_name_filter, Qt::CaseInsensitive))
+      continue;
+    QListWidgetItem *l_item = new QListWidgetItem;
+    l_item->setText(i_sfx.name);
+    l_item->setData(Qt::UserRole, i);
+    ui_sfx_list->addItem(l_item);
   }
 
-  // Now add the other SFXs given by the character's sound.ini
-  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
-  {
-    QStringList sfx = sfx_list.at(n_sfx).split("=");
-    QString i_sfx = sfx.at(0).trimmed();
-    QString d_sfx = "";
-    sfx_names.append(i_sfx);
-    if (sfx_list.at(n_sfx).split("=").size() < 2)
-      d_sfx = i_sfx;
-    else
-      d_sfx = sfx.at(1).trimmed();
+  on_sfx_widget_list_row_changed();
+}
 
-    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
+void Courtroom::clear_sfx_widget_list_selection()
+{
+  ui_sfx_list->setCurrentRow(-1);
+}
+
+void Courtroom::on_sfx_search_edited()
+{
+  update_sfx_list();
+}
+
+void Courtroom::on_sfx_widget_list_row_changed()
+{
+  const int p_current_row = ui_sfx_list->currentRow();
+  ui_pre->setChecked(p_current_row != -1);
+
+  for (int i = 0; i < ui_sfx_list->count(); ++i)
+  {
+    QListWidgetItem *l_item = ui_sfx_list->item(i);
+    const bool l_is_found = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).is_found;
+
+    QColor i_color = l_is_found ? m_sfx_color_found : m_sfx_color_missing;
+    if (i == p_current_row)
     {
-      ui_sfx_list->addItem(d_sfx);
-      int last_index = ui_sfx_list->count() - 1;
-      ui_sfx_list->item(last_index)->setStatusTip(QString::number(n_sfx + 2));
+      // Calculate the amount of lightness it would take to light up the row. We
+      // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
+      // nothing. +0.4 is just an arbitrarily chosen number.
+      const double l_final_lightness = qMin(1.0, i_color.lightnessF() + 0.4);
 
-      // Apply appropriate color whether SFX exists or not
-      QString sfx_root = ao_app->get_sounds_path(i_sfx);
-      QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
-
-      if (!sfx_path.isEmpty())
-        ui_sfx_list->item(last_index)->setBackground(found_brush);
-      else
-        ui_sfx_list->item(last_index)->setBackground(missing_brush);
+      // This is just the reverse of the above, basically. We set the colour, and we
+      // set the brush to have that colour.
+      i_color.setHslF(i_color.hueF(), i_color.saturationF(), l_final_lightness);
     }
+
+    l_item->setBackground(i_color);
   }
+  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::list_note_files()
@@ -631,20 +659,8 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(f_side);
 
-  //  packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
-  //  packet_contents.append(ui_sfx_search->text());
-
-  int row = ui_sfx_list->currentRow();
-  if (row == -1 || row == 0) // default
-    packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
-  else if (QListWidgetItem *item = ui_sfx_list->item(row)) // selection
-  {
-    double d_ind = item->statusTip().toDouble();
-    int ind = int(d_ind);
-    qDebug() << ind;
-    packet_contents.append(sfx_names.at(ind));
-    //    packet_contents.append(sfx_names.at(row));
-  }
+  // sfx file
+  packet_contents.append(current_sfx_file());
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
@@ -716,12 +732,11 @@ void Courtroom::handle_acknowledged_ms()
 
   // reset states
   ui_pre->setChecked(ao_config->always_pre_enabled());
-  list_sfx();
-  ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
   reset_shout_buttons();
   reset_effect_buttons();
   reset_wtce_buttons();
+  clear_sfx_widget_list_selection();
 
   is_presenting_evidence = false;
   ui_evidence_present->set_image("present_disabled.png");
@@ -1820,19 +1835,10 @@ void Courtroom::on_ooc_return_pressed()
   ui_ooc_chat_message->setFocus();
 }
 
-void Courtroom::on_music_search_edited(QString p_text)
+void Courtroom::on_music_search_edited()
 {
-  // preventing compiler warnings
-  p_text += "a";
   list_music();
   list_areas();
-}
-
-void Courtroom::on_sfx_search_edited(QString p_text)
-{
-  // preventing compiler warnings
-  p_text += "a";
-  list_sfx();
 }
 
 void Courtroom::on_pos_dropdown_changed(int p_index)
@@ -1961,7 +1967,6 @@ void Courtroom::on_shout_button_clicked(const bool p_checked)
       continue;
     i_button->setChecked(false);
   }
-
   m_shout_state = p_checked ? l_id : 0;
 
   ui_ic_chat_message->setFocus();
@@ -2360,52 +2365,6 @@ void Courtroom::closeEvent(QCloseEvent *event)
 {
   Q_EMIT closing();
   QMainWindow::closeEvent(event);
-}
-
-void Courtroom::on_sfx_list_clicked(QModelIndex p_index)
-{
-  if (p_index.isValid())
-    ui_pre->setChecked(p_index.isValid());
-
-  QListWidgetItem *new_sfx = ui_sfx_list->currentItem();
-
-  QBrush found_brush(ao_app->get_color("found_song_color", design_ini));
-  QBrush missing_brush(ao_app->get_color("missing_song_color", design_ini));
-
-  if (current_sfx_id != -1)
-  {
-    QListWidgetItem *old_sfx = ui_sfx_list->item(current_sfx_id);
-
-    // Apply appropriate color whether SFX exists or not
-    QString sfx_root = ao_app->get_sounds_path(sfx_names.at(current_sfx_id));
-    QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
-
-    if (!sfx_path.isEmpty())
-      old_sfx->setBackground(found_brush);
-    else
-      old_sfx->setBackground(missing_brush);
-  }
-
-  // Grab the colour of the selected row's brush.
-  QBrush selected_brush = new_sfx->background();
-  QColor selected_col = selected_brush.color();
-
-  // Calculate the amount of lightness it would take to light up the row. We
-  // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
-  // nothing. +0.4 is just an arbitrarily chosen number.
-  double final_lightness = qMin(1.0, selected_col.lightnessF() + 0.4);
-
-  // This is just the reverse of the above, basically. We set the colour, and we
-  // set the brush to have that colour.
-  selected_col.setHslF(selected_col.hueF(), selected_col.saturationF(), final_lightness);
-  selected_brush.setColor(selected_col);
-
-  // Finally, we set the selected SFX's background to be the lightened-up brush.
-  new_sfx->setBackground(selected_brush);
-
-  current_sfx_id = ui_sfx_list->currentRow();
-
-  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1366,9 +1366,9 @@ void Courtroom::setup_chat()
   blip_pos = 0;
 
   // Cache these so chat_tick performs better
-  chatbox_message_outline = (ao_app->get_font_property("message_outline", fonts_ini) == 1);
-  chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", cc_config_ini));
-  chatbox_message_highlight_colors = ao_app->get_highlight_colors();
+  m_chatbox_message_outline = (ao_app->get_font_property("message_outline", fonts_ini) == 1);
+  m_chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", cc_config_ini));
+  m_chatbox_message_highlight_colors = ao_app->get_highlight_colors();
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CMChrName]);
 
@@ -1384,7 +1384,7 @@ void Courtroom::chat_tick()
   // note: this is called fairly often(every 60 ms when char is talking)
   // do not perform heavy operations here
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
-  if (chatbox_message_outline)
+  if (m_chatbox_message_outline)
     vp_message_format.setTextOutline(QPen(Qt::black, 1));
   else
     vp_message_format.setTextOutline(Qt::NoPen);
@@ -1443,7 +1443,7 @@ void Courtroom::chat_tick()
 
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
     }
-    else if (chatbox_message_enable_highlighting)
+    else if (m_chatbox_message_enable_highlighting)
     {
       bool highlight_found = false;
       bool render_character = true;
@@ -1453,7 +1453,7 @@ void Courtroom::chat_tick()
       if (m_color_stack.isEmpty())
         m_color_stack.push("");
 
-      for (const auto &col : chatbox_message_highlight_colors)
+      for (const auto &col : m_chatbox_message_highlight_colors)
       {
         if (f_character == col[0][0] && m_string_color != col[1])
         {
@@ -1477,7 +1477,7 @@ void Courtroom::chat_tick()
 
       QString m_future_string_color = m_string_color;
 
-      for (const auto &col : chatbox_message_highlight_colors)
+      for (const auto &col : m_chatbox_message_highlight_colors)
       {
         if (f_character == col[0][1] && !highlight_found)
         {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1316,9 +1316,16 @@ void Courtroom::append_system_text(QString p_showname, QString p_line)
 
 void Courtroom::play_preanim()
 {
-  QString f_char = m_chatmessage[CMChrName];
   QString f_preanim = m_chatmessage[CMPreAnim];
 
+  if (f_preanim == "-")
+  {
+    // no animation, continue
+    preanim_done();
+    return;
+  }
+
+  QString f_char = m_chatmessage[CMChrName];
   // all time values in char.inis are multiplied by a constant(time_mod) to get
   // the actual time
   int text_delay = ao_app->get_text_delay(f_char, f_preanim) * time_mod;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1319,6 +1319,11 @@ void Courtroom::append_system_text(QString p_showname, QString p_line)
 
 void Courtroom::play_preanim()
 {
+  // all time values in char.inis are multiplied by a constant(time_mod) to get
+  // the actual time
+  int sfx_delay = m_chatmessage[CMSoundDelay].toInt() * 60;
+  sfx_delay_timer->start(sfx_delay);
+
   QString f_preanim = m_chatmessage[CMPreAnim];
 
   if (f_preanim.trimmed() == "-")
@@ -1329,12 +1334,6 @@ void Courtroom::play_preanim()
   }
 
   QString f_char = m_chatmessage[CMChrName];
-  // all time values in char.inis are multiplied by a constant(time_mod) to get
-  // the actual time
-  int sfx_delay = m_chatmessage[CMSoundDelay].toInt() * 60;
-
-  sfx_delay_timer->start(sfx_delay);
-
   // set state
   anim_state = 1;
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -288,7 +288,7 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(log_is_topdown_changed(bool)), this, SLOT(on_chat_config_changed()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited()));
+  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited(QString)));
 
   connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));
@@ -304,7 +304,7 @@ void Courtroom::connect_widgets()
   connect(ui_flip, SIGNAL(clicked()), this, SLOT(on_flip_clicked()));
   connect(ui_hidden, SIGNAL(clicked()), this, SLOT(on_hidden_clicked()));
 
-  connect(ui_sfx_list, SIGNAL(currentRowChanged(int)), this, SLOT(on_sfx_widget_list_row_changed()));
+  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_sfx_list_clicked(QModelIndex)));
 
   connect(ui_evidence_button, SIGNAL(clicked()), this, SLOT(on_evidence_button_clicked()));
 
@@ -1247,7 +1247,7 @@ void Courtroom::load_shouts()
     l_button->stackUnder(ui_shout_up);
     l_button->stackUnder(ui_shout_down);
 
-    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked(bool)));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked()));
     connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_shout_button_toggled(bool)));
   }
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -688,7 +688,7 @@ void Courtroom::set_widgets()
   //  ui_shouts[0]->show();
   //  ui_shouts[1]->show();
   //  ui_shouts[2]->show();
-  draw_shout_buttons();
+  reset_shout_buttons();
 
   set_size_and_pos(ui_shout_up, "shout_up");
   ui_shout_up->set_image("shoutup.png");
@@ -717,7 +717,7 @@ void Courtroom::set_widgets()
   {
     set_size_and_pos(ui_effects[i], effect_names[i]);
   }
-  draw_effect_buttons();
+  reset_effect_buttons();
 
   set_size_and_pos(ui_effect_up, "effect_up");
   ui_effect_up->set_image("effectup.png");
@@ -757,7 +757,7 @@ void Courtroom::set_widgets()
     qDebug() << "AA: single wtce";
   }
   set_judge_wtce();
-  draw_judge_wtce_buttons();
+  reset_wtce_buttons();
 
   for (int i = 0; i < free_block_names.size(); ++i)
   {
@@ -1169,15 +1169,16 @@ void Courtroom::load_effects()
 
   for (int i = 0; i < ui_effects.size(); ++i)
   {
-    ui_effects[i] = new AOButton(this, ao_app);
-    ui_effects[i]->setProperty("effect_id", i + 1);
-    ui_effects[i]->stackUnder(ui_effect_up);
-    ui_effects[i]->stackUnder(ui_effect_down);
-  }
+    AOButton *l_button = new AOButton(this, ao_app);
+    ui_effects.replace(i, l_button);
+    l_button->setCheckable(true);
+    l_button->setProperty("effect_id", i + 1);
+    l_button->stackUnder(ui_effect_up);
+    l_button->stackUnder(ui_effect_down);
 
-  // And connect their actions
-  for (auto &effect : ui_effects)
-    connect(effect, SIGNAL(clicked(bool)), this, SLOT(on_effect_button_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_effect_button_clicked(bool)));
+    connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_effect_button_toggled(bool)));
+  }
 
   // And add names
   effect_names.clear();
@@ -1186,8 +1187,11 @@ void Courtroom::load_effects()
     QStringList names = ao_app->get_effect(i);
     if (!names.isEmpty())
     {
-      QString name = names.at(0).trimmed();
-      effect_names.append(name);
+      const QString l_name = names.at(0).trimmed();
+      effect_names.append(l_name);
+      AOButton *l_button = ui_effects.at(i - 1);
+      l_button->setProperty("effect_name", l_name);
+      Q_EMIT l_button->toggled(l_button->isChecked());
     }
   }
 }
@@ -1236,15 +1240,16 @@ void Courtroom::load_shouts()
 
   for (int i = 0; i < ui_shouts.size(); ++i)
   {
-    ui_shouts[i] = new AOButton(this, ao_app);
-    ui_shouts[i]->setProperty("shout_id", i + 1);
-    ui_shouts[i]->stackUnder(ui_shout_up);
-    ui_shouts[i]->stackUnder(ui_shout_down);
-  }
+    AOButton *l_button = new AOButton(this, ao_app);
+    ui_shouts.replace(i, l_button);
+    l_button->setCheckable(true);
+    l_button->setProperty("shout_id", i + 1);
+    l_button->stackUnder(ui_shout_up);
+    l_button->stackUnder(ui_shout_down);
 
-  // And connect their actions
-  for (auto &shout : ui_shouts)
-    connect(shout, SIGNAL(clicked(bool)), this, SLOT(on_shout_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked()));
+    connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_shout_button_toggled(bool)));
+  }
 
   // And add names
   shout_names.clear();
@@ -1255,8 +1260,11 @@ void Courtroom::load_shouts()
     {
       qDebug() << "SHOUT " << name << " " << ui_shouts[i - 1];
       shout_names.append(name);
-      widget_names[name] = ui_shouts[i - 1];
-      ui_shouts[i - 1]->setObjectName(name);
+      AOButton *l_button = ui_shouts.at(i - 1);
+      widget_names.insert(name, l_button);
+      l_button->setObjectName(name);
+      l_button->setProperty("shout_name", name);
+      Q_EMIT l_button->toggled(l_button->isChecked());
     }
   }
   qDebug() << widget_names;

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -288,7 +288,7 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(log_is_topdown_changed(bool)), this, SLOT(on_chat_config_changed()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited(QString)));
+  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited()));
 
   connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));
@@ -304,7 +304,7 @@ void Courtroom::connect_widgets()
   connect(ui_flip, SIGNAL(clicked()), this, SLOT(on_flip_clicked()));
   connect(ui_hidden, SIGNAL(clicked()), this, SLOT(on_hidden_clicked()));
 
-  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_sfx_list_clicked(QModelIndex)));
+  connect(ui_sfx_list, SIGNAL(currentRowChanged(int)), this, SLOT(on_sfx_widget_list_row_changed()));
 
   connect(ui_evidence_button, SIGNAL(clicked()), this, SLOT(on_evidence_button_clicked()));
 
@@ -1247,7 +1247,7 @@ void Courtroom::load_shouts()
     l_button->stackUnder(ui_shout_up);
     l_button->stackUnder(ui_shout_down);
 
-    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked(bool)));
     connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_shout_button_toggled(bool)));
   }
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -28,9 +28,6 @@ void Courtroom::create_widgets()
   chat_tick_timer = new QTimer(this);
   chat_tick_timer->setTimerType(Qt::PreciseTimer); // Prevents drift
 
-  text_delay_timer = new QTimer(this);
-  text_delay_timer->setSingleShot(true);
-
   sfx_delay_timer = new QTimer(this);
   sfx_delay_timer->setSingleShot(true);
 
@@ -234,7 +231,6 @@ void Courtroom::connect_widgets()
   connect(ui_vp_objection, SIGNAL(done()), this, SLOT(objection_done()));
   connect(ui_vp_player_char, SIGNAL(done()), this, SLOT(preanim_done()));
 
-  connect(text_delay_timer, SIGNAL(timeout()), this, SLOT(start_chat_ticking()));
   connect(sfx_delay_timer, SIGNAL(timeout()), this, SLOT(play_sfx()));
 
   connect(chat_tick_timer, SIGNAL(timeout()), this, SLOT(chat_tick()));

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -1387,11 +1387,6 @@ void Courtroom::set_dropdowns()
 
 void Courtroom::set_font(QWidget *widget, QString p_identifier)
 {
-  set_font(widget, p_identifier, "");
-}
-
-void Courtroom::set_font(QWidget *widget, QString p_identifier, QString override_color)
-{
   QString design_file = fonts_ini;
   QString class_name = widget->metaObject()->className();
 
@@ -1409,32 +1404,22 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier, QString override
   }
   widget->setFont(QFont(font_name, f_weight));
 
-  if (override_color.isEmpty())
-  {
-    QString color = ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
-    if (color.isEmpty())
-      color = "255, 255, 255";
-    override_color = "rgba(" + color + ", 255)";
-  }
+  QString font_color = ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
+  if (font_color.isEmpty())
+    font_color = "255, 255, 255";
+  QString color = "rgba(" + font_color + ", 255)";
 
   int bold = ao_app->get_font_property(p_identifier + "_bold", design_file);
   QString is_bold = (bold == 1 ? "bold" : "");
 
-  QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" + "color: " + override_color +
-                               ";\n"
-                               "font: " +
-                               is_bold + "; }";
+  QString style_sheet_string = class_name + " { " + "background-color: rgba(0, 0, 0, 0);\n" + "color: " + color +
+                               ";\n" + "font: " + is_bold + ";" + " }";
   widget->setStyleSheet(style_sheet_string);
 }
 
 void Courtroom::set_drtextedit_font(DRTextEdit *widget, QString p_identifier)
 {
-  set_drtextedit_font(widget, p_identifier, "");
-}
-
-void Courtroom::set_drtextedit_font(DRTextEdit *widget, QString p_identifier, QString override_color)
-{
-  set_font(widget, p_identifier, override_color);
+  set_font(widget, p_identifier);
   // Do outlines
   bool outline = (ao_app->get_font_property(p_identifier + "_outline", fonts_ini) == 1);
   widget->set_outline(outline);

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -698,7 +698,7 @@ void Courtroom::set_widgets()
   ui_shout_down->hide();
 
   // courtroom_config.ini necessary + check for crash
-  if (ao_app->read_theme_ini("enable_single_shout", cc_config_ini) == "true" && ui_shouts.size() > 0)
+  if (ao_app->read_theme_ini_bool("enable_single_shout", cc_config_ini) && ui_shouts.size() > 0)
   {
     for (auto &shout : ui_shouts)
       move_widget(shout, "bullet");
@@ -726,7 +726,7 @@ void Courtroom::set_widgets()
   ui_effect_down->set_image("effectdown.png");
   ui_effect_down->hide();
 
-  if (ao_app->read_theme_ini("enable_single_effect", cc_config_ini) == "true" &&
+  if (ao_app->read_theme_ini_bool("enable_single_effect", cc_config_ini) &&
       ui_effects.size() > 0) // check to prevent crashing
   {
     for (auto &effect : ui_effects)
@@ -750,7 +750,7 @@ void Courtroom::set_widgets()
     set_size_and_pos(ui_wtce[i], wtce_names[i]);
   }
 
-  if (ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) == "true") // courtroom_config.ini necessary
+  if (ao_app->read_theme_ini_bool("enable_single_wtce", cc_config_ini)) // courtroom_config.ini necessary
   {
     for (auto &wtce : ui_wtce)
       move_widget(wtce, "wtce");
@@ -785,7 +785,7 @@ void Courtroom::set_widgets()
   ui_config_panel->setStyleSheet("");
   ui_note_button->setStyleSheet("");
 
-  if (ao_app->read_theme_ini("enable_button_images", cc_config_ini) == "true")
+  if (ao_app->read_theme_ini_bool("enable_button_images", cc_config_ini))
   {
     // Set files, ask questions later
     // set_image first tries the gamemode-timeofday folder, then the theme
@@ -838,7 +838,7 @@ void Courtroom::set_widgets()
     set_size_and_pos(ui_label_images[i], label_images[i].toLower() + "_image");
   }
 
-  if (ao_app->read_theme_ini("enable_label_images", cc_config_ini) == "true")
+  if (ao_app->read_theme_ini_bool("enable_label_images", cc_config_ini))
   {
     for (int i = 0; i < ui_checks.size(); ++i) // loop through checks
     {
@@ -1015,7 +1015,7 @@ int Courtroom::adapt_numbered_items(QVector<T *> &item_vector, QString config_it
   // &item_vector must be a vector of size at least 1!
 
   // Redraw the new correct number of items.
-  int new_item_number = ao_app->read_theme_ini(config_item_number, cc_config_ini).toInt();
+  int new_item_number = ao_app->read_theme_ini_int(config_item_number, cc_config_ini);
   int current_item_number = item_vector.size();
   // Note we use the fact that, if config_item_number is not there,
   // read_theme_ini returns an empty string, which .toInt() would fail to
@@ -1163,7 +1163,7 @@ void Courtroom::load_effects()
     delete_widget(widget);
 
   // And create new effects
-  int effect_number = ao_app->read_theme_ini("effect_number", cc_config_ini).toInt();
+  int effect_number = ao_app->read_theme_ini_int("effect_number", cc_config_ini);
   effects_enabled.resize(effect_number);
   ui_effects.resize(effect_number);
 
@@ -1198,7 +1198,7 @@ void Courtroom::load_free_blocks()
     delete_widget(widget);
 
   // And create new free block buttons
-  int free_block_number = ao_app->read_theme_ini("free_block_number", cc_config_ini).toInt();
+  int free_block_number = ao_app->read_theme_ini_int("free_block_number", cc_config_ini);
   free_blocks_enabled.resize(free_block_number);
   ui_free_blocks.resize(free_block_number);
 
@@ -1230,7 +1230,7 @@ void Courtroom::load_shouts()
     delete_widget(widget);
 
   // And create new shouts
-  int shout_number = ao_app->read_theme_ini("shout_number", cc_config_ini).toInt();
+  int shout_number = ao_app->read_theme_ini_int("shout_number", cc_config_ini);
   shouts_enabled.resize(shout_number);
   ui_shouts.resize(shout_number);
 
@@ -1268,7 +1268,7 @@ void Courtroom::load_wtce()
     delete_widget(widget);
 
   // And create new wtce buttons
-  int wtce_number = ao_app->read_theme_ini("wtce_number", cc_config_ini).toInt();
+  int wtce_number = ao_app->read_theme_ini_int("wtce_number", cc_config_ini);
   wtce_enabled.resize(wtce_number);
   ui_wtce.resize(wtce_number);
 
@@ -1336,7 +1336,7 @@ void Courtroom::set_judge_wtce()
     wtce->hide();
 
   // check if we use a single wtce or multiple
-  const bool is_single_wtce = ao_app->read_theme_ini("enable_single_wtce", cc_config_ini) == "true";
+  const bool is_single_wtce = ao_app->read_theme_ini_bool("enable_single_wtce", cc_config_ini);
 
   // update visibility for next/previous
   ui_wtce_up->setVisible(is_judge && is_single_wtce);

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -26,6 +26,7 @@ void Courtroom::create_widgets()
   keepalive_timer->start(60000);
 
   chat_tick_timer = new QTimer(this);
+  chat_tick_timer->setTimerType(Qt::PreciseTimer); // Prevents drift
 
   text_delay_timer = new QTimer(this);
   text_delay_timer->setSingleShot(true);

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -288,7 +288,7 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(log_is_topdown_changed(bool)), this, SLOT(on_chat_config_changed()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited(QString)));
+  connect(ui_sfx_search, SIGNAL(editingFinished()), this, SLOT(on_sfx_search_editing_finished()));
 
   connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));
@@ -304,7 +304,7 @@ void Courtroom::connect_widgets()
   connect(ui_flip, SIGNAL(clicked()), this, SLOT(on_flip_clicked()));
   connect(ui_hidden, SIGNAL(clicked()), this, SLOT(on_hidden_clicked()));
 
-  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_sfx_list_clicked(QModelIndex)));
+  connect(ui_sfx_list, SIGNAL(currentRowChanged(int)), this, SLOT(on_sfx_widget_list_row_changed()));
 
   connect(ui_evidence_button, SIGNAL(clicked()), this, SLOT(on_evidence_button_clicked()));
 
@@ -1247,7 +1247,7 @@ void Courtroom::load_shouts()
     l_button->stackUnder(ui_shout_up);
     l_button->stackUnder(ui_shout_down);
 
-    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked(bool)));
     connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_shout_button_toggled(bool)));
   }
 

--- a/src/drtextedit.cpp
+++ b/src/drtextedit.cpp
@@ -110,13 +110,13 @@ void DRTextEdit::refresh_horizontal_alignment()
   if (document()->toPlainText().isEmpty())
   {
     // Qt is very special and does not set this to 0 for empty documents.
-    current_document_blocks = 0;
+    m_current_document_blocks = 0;
     // We also don't need to do any adjusting for empty documents, so return immediately
     return;
   }
   // If we have not changed the number of blocks in the document with this new incoming text change,
   // We do not need to update anything, so we exit early.
-  if (new_document_blocks == current_document_blocks)
+  if (new_document_blocks == m_current_document_blocks)
     return;
 
   // Otherwise, we have changed the number of blocks. By induction only the current block needs to be
@@ -132,16 +132,16 @@ void DRTextEdit::refresh_vertical_alignment()
   if (document()->toPlainText().isEmpty())
   {
     // Qt is very special and does not set this to 0 for empty documents.
-    current_document_height = 0;
+    m_current_document_height = 0;
     // We also don't need to do any adjusting for empty documents, so return immediately
     return;
   }
   // If we have not changed the document height with this new incoming text change,
   // We do not need to update anything, so we exit early.
-  if (new_document_height == current_document_height)
+  if (new_document_height == m_current_document_height)
     return;
 
-  current_document_height = new_document_height;
+  m_current_document_height = new_document_height;
 
   // The way we will simulate vertical alignment is by adjusting the top margin to simulate
   // center alignment, or bottom alignment.

--- a/src/drtextedit.cpp
+++ b/src/drtextedit.cpp
@@ -73,11 +73,34 @@ void DRTextEdit::on_text_changed()
     return;
   m_status = Status::InProgress;
 
+  refresh_horizontal_alignment();
+  refresh_vertical_alignment();
+
+  // we're done
+  m_status = Status::Done;
+}
+
+void DRTextEdit::refresh_horizontal_alignment()
+{
   // Do computations to align text horizontally
   setAlignment(m_halign);
+}
 
+void DRTextEdit::refresh_vertical_alignment()
+{
   // This stores the total height of the totality of the text saved.
-  const int new_height = document()->size().height();
+  int new_text_height = document()->size().height();
+  if (document()->toPlainText().isEmpty())
+  {
+    // Qt is very special and does not set this to 0 for empty documents.
+    new_text_height = 0;
+  }
+  // If we have not changed the document height since the last time the text was updated
+  // We do not need to update anything, so we exit early.
+  if (new_text_height == current_document_height)
+    return;
+
+  current_document_height = new_text_height;
 
   // The way we will simulate vertical alignment is by adjusting the top margin to simulate
   // center alignment, or bottom alignment.
@@ -85,16 +108,13 @@ void DRTextEdit::on_text_changed()
   switch (m_valign)
   {
   case Qt::AlignVCenter:
-    top_margin = (height() - new_height) / 2;
+    top_margin = (height() - new_text_height) / 2;
     break;
   case Qt::AlignBottom:
-    top_margin = (height() - new_height);
+    top_margin = (height() - new_text_height);
     break;
   default:
     break;
   }
   setViewportMargins(0, top_margin, 0, 0);
-
-  // we're done
-  m_status = Status::Done;
 }

--- a/src/drtextedit.cpp
+++ b/src/drtextedit.cpp
@@ -73,6 +73,7 @@ void DRTextEdit::on_text_changed()
   // QT's textChanged signal as well.
   if (m_status == Status::InProgress)
     return;
+
   m_status = Status::InProgress;
 
   refresh_horizontal_alignment();

--- a/src/drtextedit.cpp
+++ b/src/drtextedit.cpp
@@ -25,6 +25,22 @@ bool DRTextEdit::get_outline()
   return this->m_outline;
 }
 
+bool DRTextEdit::get_auto_align()
+{
+  return this->m_auto_align;
+}
+
+void DRTextEdit::set_auto_align(bool new_auto_align)
+{
+  if (new_auto_align == m_auto_align)
+    return;
+  m_auto_align = new_auto_align;
+
+  if (m_auto_align)
+    on_text_changed();
+  return;
+}
+
 void DRTextEdit::set_vertical_alignment(Qt::Alignment p_align)
 {
   switch (p_align)
@@ -69,6 +85,9 @@ Qt::Alignment DRTextEdit::get_horizontal_alignment()
 
 void DRTextEdit::on_text_changed()
 {
+  if (!m_auto_align)
+    return;
+
   // We need to "lock" access to on_text_changed. That is because the refresh methods trigger
   // QT's textChanged signal as well.
   if (m_status == Status::InProgress)

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -170,6 +170,8 @@ void Courtroom::select_emote(int p_id)
   else
     ui_pre->setChecked(false);
 
+  select_default_sfx();
+
   ui_emote_dropdown->setCurrentIndex(current_emote);
 
   ui_ic_chat_message->setFocus();

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -11,7 +11,7 @@
 // depends. On Mac, it can be toggled. So, should the time ever come to that,
 // manually define CASE_SENSITIVE_FILESYSTEM if you're working on a Mac that
 // has, well, a case-sensitive filesystem.
-#if (defined(LINUX) || defined(__linux__))
+#ifdef Q_OS_LINUX
 #define CASE_SENSITIVE_FILESYSTEM
 #endif
 

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -800,16 +800,6 @@ int AOApplication::get_sfx_delay(QString p_char, int p_emote)
     return f_result.toInt();
 }
 
-int AOApplication::get_text_delay(QString p_char, QString p_emote)
-{
-  QString f_result = read_char_ini(p_char, p_emote, "[TextDelay]", "END_OF_FILE");
-
-  if (f_result == "")
-    return -1;
-  else
-    return f_result.toInt();
-}
-
 bool AOApplication::get_blank_blip()
 {
   return config->blank_blips_enabled();

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -816,3 +816,13 @@ QString AOApplication::read_theme_ini(QString p_identifier, QString p_file)
 
   return read_ini(p_identifier, path); // Could be the empty string
 }
+
+bool AOApplication::read_theme_ini_bool(QString p_identifier, QString p_file)
+{
+  return read_theme_ini(p_identifier, p_file) == "true";
+}
+
+int AOApplication::read_theme_ini_int(QString p_identifier, QString p_file)
+{
+  return read_theme_ini(p_identifier, p_file).toInt();
+}


### PR DESCRIPTION
* Reduces calls to horizontal alignment to only when the number of blocks change as opposed to every time text changes (which is good enough for text editors where we only do appends and sets, which is the use case for DRO)
* Allows turning off/on automatic alignment (which helps prevent frivolous computation when doing batch operations involving text editors, like reloading the log)
* Makes chat ticks only start appearing after rendering a sprite (which helps prevent having the first character of an IC message render, then the sprite, then the remaining characters render, which gives the illusion of lag)
* Removes unused text_delay_interval function
* Makes attempts to open preanimation "-", " - " (typically used in DRO to indicate no preanimation) fail immediately rather than as part of file I/O, which speeds up sprites rendering
* Precomputes file accesses in chat_tick and caches them, so there is no file I/O in chat_tick, which speeds up message rendering (most noticeable at chat tick intervals close to 20 ms)