### PR TITLE
Self-identification highlight coloring

### DIFF
--- a/include/aoconfig.h
+++ b/include/aoconfig.h
@@ -37,6 +37,7 @@ public:
   int chat_tick_interval() const;
   int log_max_lines() const;
   bool log_display_timestamp_enabled() const;
+  bool log_display_self_highlight_enabled() const;
   bool log_display_empty_messages_enabled() const;
   bool log_is_topdown_enabled() const;
   bool log_format_use_newline_enabled() const;
@@ -79,6 +80,7 @@ public slots:
   void set_chat_tick_interval(int p_number);
   void set_log_max_lines(int p_number);
   void set_log_display_timestamp(bool p_enabled);
+  void set_log_display_self_highlight(bool p_enabled);
   void set_log_display_empty_messages(bool p_enabled);
   void set_log_is_topdown(bool p_enabled);
   void set_log_format_use_newline(bool p_enabled);
@@ -117,6 +119,7 @@ signals:
   void chat_tick_interval_changed(int);
   void log_max_lines_changed(int);
   void log_display_timestamp_changed(bool);
+  void log_display_self_highlight_changed(bool);
   void log_display_empty_messages_changed(bool);
   void log_is_topdown_changed(bool);
   void log_format_use_newline_changed(bool);

--- a/include/aoconfigpanel.h
+++ b/include/aoconfigpanel.h
@@ -91,6 +91,7 @@ private:
   // IC Chatlog
   QSpinBox *w_log_max_lines = nullptr;
   QCheckBox *w_log_display_timestamp = nullptr;
+  QCheckBox *w_log_display_self_highlight = nullptr;
   QCheckBox *w_log_format_use_newline = nullptr;
   QCheckBox *w_log_display_empty_messages = nullptr;
   QCheckBox *w_log_display_music_switch = nullptr;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -226,7 +226,7 @@ public:
   // selected
   // or the user isn't already scrolled to the top
   void update_ic_log(bool p_reset_log);
-  void append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music);
+  void append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music, bool p_self);
 
   /**
    * @brief Appends a message arriving from system to the IC chatlog.

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -30,6 +30,10 @@ public:
   {
     return message;
   }
+  bool is_self() const
+  {
+    return self;
+  }
   bool is_system() const
   {
     return system;
@@ -40,6 +44,12 @@ public:
   }
 
   // set
+  void set_self(const bool p_enabled)
+  {
+    if (self == p_enabled)
+      return;
+    self = p_enabled;
+  }
   void set_system(bool p_enabled)
   {
     if (system == p_enabled)
@@ -57,6 +67,7 @@ private:
   QDateTime timestamp = QDateTime::currentDateTime();
   QString name;
   QString message;
+  bool self = false;
   bool system = false;
   bool music = false;
 };

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -360,9 +360,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="toolTip">
-             <string>Extra newlines are </string>
-            </property>
             <property name="text">
              <string>Display timestamp</string>
             </property>
@@ -382,9 +379,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Extra newlines are </string>
             </property>
             <property name="text">
              <string>Display empty messages</string>

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -364,23 +364,14 @@
              <string>Extra newlines are </string>
             </property>
             <property name="text">
-             <string>Display Timestamp</string>
+             <string>Display timestamp</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QCheckBox" name="log_format_use_newline">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Extra newlines are </string>
-            </property>
+           <widget class="QCheckBox" name="log_display_self_highlight">
             <property name="text">
-             <string>Format use newline</string>
+             <string>Display self-identification highlight</string>
             </property>
            </widget>
           </item>
@@ -410,6 +401,22 @@
             </property>
             <property name="text">
              <string>Display music switch</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="log_format_use_newline">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extra newlines are added between the name and message.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Format use newline</string>
             </property>
            </widget>
           </item>

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -60,6 +60,7 @@ private:
   int chat_tick_interval;
   int log_max_lines;
   bool log_display_timestamp;
+  bool log_display_self_highlight;
   bool log_display_empty_messages;
   bool log_is_topdown;
   bool log_format_use_newline;
@@ -126,7 +127,8 @@ void AOConfigPrivate::read_file()
   chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
   log_max_lines = cfg.value("chatlog_limit", 200).toInt();
   log_is_topdown = cfg.value("chatlog_scrolldown", true).toBool();
-  log_display_timestamp = cfg.value("chatlog_display_timestamp", false).toBool();
+  log_display_timestamp = cfg.value("chatlog_display_timestamp", true).toBool();
+  log_display_self_highlight = cfg.value("chatlog_display_self_highlight", true).toBool();
   log_display_empty_messages = cfg.value("chatlog_display_empty_messages", false).toBool();
   log_format_use_newline = cfg.value("chatlog_newline", false).toBool();
   log_display_music_switch = cfg.value("music_change_log", true).toBool();
@@ -181,6 +183,7 @@ void AOConfigPrivate::save_file()
   cfg.setValue("chat_tick_interval", chat_tick_interval);
   cfg.setValue("chatlog_limit", log_max_lines);
   cfg.setValue("chatlog_display_timestamp", log_display_timestamp);
+  cfg.setValue("chatlog_display_self_highlight", log_display_self_highlight);
   cfg.setValue("chatlog_newline", log_format_use_newline);
   cfg.setValue("chatlog_display_empty_messages", log_display_empty_messages);
   cfg.setValue("music_change_log", log_display_music_switch);
@@ -347,6 +350,11 @@ int AOConfig::log_max_lines() const
 bool AOConfig::log_display_timestamp_enabled() const
 {
   return d->log_display_timestamp;
+}
+
+bool AOConfig::log_display_self_highlight_enabled() const
+{
+  return d->log_display_self_highlight;
 }
 
 bool AOConfig::log_display_empty_messages_enabled() const
@@ -564,6 +572,14 @@ void AOConfig::set_log_display_timestamp(bool p_enabled)
     return;
   d->log_display_timestamp = p_enabled;
   d->invoke_signal("log_display_timestamp_changed", Q_ARG(bool, p_enabled));
+}
+
+void AOConfig::set_log_display_self_highlight(bool p_enabled)
+{
+  if (d->log_display_self_highlight == p_enabled)
+    return;
+  d->log_display_self_highlight = p_enabled;
+  d->invoke_signal("log_display_self_highlight_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_log_display_empty_messages(bool p_enabled)

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -51,6 +51,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   // IC Chatlog
   w_log_max_lines = AO_GUI_WIDGET(QSpinBox, "log_length");
   w_log_display_timestamp = AO_GUI_WIDGET(QCheckBox, "log_display_timestamp");
+  w_log_display_self_highlight = AO_GUI_WIDGET(QCheckBox, "log_display_self_highlight");
   w_log_format_use_newline = AO_GUI_WIDGET(QCheckBox, "log_format_use_newline");
   w_log_display_empty_messages = AO_GUI_WIDGET(QCheckBox, "log_display_empty_messages");
   w_log_display_music_switch = AO_GUI_WIDGET(QCheckBox, "log_display_music_switch");
@@ -102,6 +103,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   // log
   connect(m_config, SIGNAL(log_max_lines_changed(int)), w_log_max_lines, SLOT(setValue(int)));
   connect(m_config, SIGNAL(log_display_timestamp_changed(bool)), w_log_display_timestamp, SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(log_display_self_highlight_changed(bool)), w_log_display_self_highlight,
+          SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(log_format_use_newline_changed(bool)), w_log_format_use_newline, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(log_display_empty_messages_changed(bool)), w_log_display_empty_messages,
           SLOT(setChecked(bool)));
@@ -154,6 +157,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   // out, log
   connect(w_log_max_lines, SIGNAL(valueChanged(int)), m_config, SLOT(set_log_max_lines(int)));
   connect(w_log_display_timestamp, SIGNAL(toggled(bool)), m_config, SLOT(set_log_display_timestamp(bool)));
+  connect(w_log_display_self_highlight, SIGNAL(toggled(bool)), m_config, SLOT(set_log_display_self_highlight(bool)));
   connect(w_log_format_use_newline, SIGNAL(toggled(bool)), m_config, SLOT(set_log_format_use_newline(bool)));
   connect(w_log_display_empty_messages, SIGNAL(toggled(bool)), m_config, SLOT(set_log_display_empty_messages(bool)));
   connect(w_log_display_music_switch, SIGNAL(toggled(bool)), m_config, SLOT(set_log_display_music_switch(bool)));
@@ -203,6 +207,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   }
 
   w_log_display_timestamp->setChecked(m_config->log_display_timestamp_enabled());
+  w_log_display_self_highlight->setChecked(m_config->log_display_self_highlight_enabled());
   w_log_format_use_newline->setChecked(m_config->log_format_use_newline_enabled());
   w_log_display_empty_messages->setChecked(m_config->log_display_empty_messages_enabled());
   w_log_display_music_switch->setChecked(m_config->log_display_music_switch_enabled());

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -823,7 +823,7 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   if (is_system_speaking)
     append_system_text(f_showname, m_chatmessage[CMMessage]);
   else
-    append_ic_text(f_showname, m_chatmessage[CMMessage], false, false);
+    append_ic_text(f_showname, m_chatmessage[CMMessage], false, false, f_char_id == m_cid);
 
   if (ao_config->log_is_recording_enabled() && (!chatmessage_is_empty || !is_system_speaking))
   {
@@ -1143,6 +1143,15 @@ void Courtroom::update_ic_log(bool p_reset_log)
     showname_color = default_color;
   name_format.setForeground(showname_color);
 
+  QTextCharFormat selfname_format = name_format;
+
+  {
+    QColor selfname_color = ao_app->get_color("ic_chatlog_selfname_color", fonts_ini);
+    if (selfname_color == not_found_color)
+      selfname_color = showname_color;
+    selfname_format.setForeground(selfname_color);
+  }
+
   QTextCharFormat line_format = ui_ic_chatlog->currentCharFormat();
   line_format.setFontWeight(QFont::Normal);
   QColor message_color = ao_app->get_color("ic_chatlog_message_color", fonts_ini);
@@ -1179,6 +1188,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
   {
     DR::ChatRecord record = m_ic_record_queue.takeFirst();
     m_ic_record_list.append(record);
+    const QTextCharFormat l_record_name_format = record.is_self() ? selfname_format : name_format;
 
     if (record.get_message().trimmed().isEmpty() && !ao_config->log_display_empty_messages_enabled())
       continue;
@@ -1192,7 +1202,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
     const QString record_end = (QString(QChar::LineFeed) + (chatlog_newline ? QString(QChar::LineFeed) : ""));
 
     if (ao_config->log_display_timestamp_enabled())
-      cursor.insertText(QString("[%1] ").arg(record.get_timestamp().toString("hh:mm")), name_format);
+      cursor.insertText(QString("[%1] ").arg(record.get_timestamp().toString("hh:mm")), l_record_name_format);
 
     if (record.is_system())
     {
@@ -1207,7 +1217,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
         separator = ": ";
       else
         separator = " ";
-      cursor.insertText(record.get_name() + separator, name_format);
+      cursor.insertText(record.get_name() + separator, l_record_name_format);
       cursor.insertText(record.get_message() + record_end, line_format);
     }
   }
@@ -1283,7 +1293,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
   }
 }
 
-void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music)
+void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system, bool p_music, bool p_self)
 {
   if (p_name.trimmed().isEmpty())
     p_name = "Anonymous";
@@ -1294,6 +1304,7 @@ void Courtroom::append_ic_text(QString p_name, QString p_line, bool p_system, bo
   DR::ChatRecord new_record(p_name, p_line);
   new_record.set_music(p_music);
   new_record.set_system(p_system);
+  new_record.set_self(p_self);
   m_ic_record_queue.append(new_record);
   update_ic_log(false);
 }
@@ -1303,7 +1314,7 @@ void Courtroom::append_system_text(QString p_showname, QString p_line)
   if (chatmessage_is_empty)
     return;
 
-  append_ic_text(p_showname, p_line, true, false);
+  append_ic_text(p_showname, p_line, true, false, false);
 }
 
 void Courtroom::play_preanim()
@@ -1613,7 +1624,7 @@ void Courtroom::handle_song(QStringList p_contents)
     return;
 
   QString f_song = p_contents.at(0);
-  int n_char = p_contents.at(1).toInt();
+  int l_chr_id = p_contents.at(1).toInt();
 
   for (auto &ext : audio_extensions())
   {
@@ -1626,7 +1637,7 @@ void Courtroom::handle_song(QStringList p_contents)
     }
   }
 
-  if (n_char < 0 || n_char >= char_list.size())
+  if (l_chr_id < 0 || l_chr_id >= char_list.size())
   {
     m_music_player->play(f_song);
   }
@@ -1651,16 +1662,16 @@ void Courtroom::handle_song(QStringList p_contents)
     QString str_char;
     if (f_showname.isEmpty())
     {
-      str_char = ao_app->get_showname(char_list.at(n_char).name);
+      str_char = ao_app->get_showname(char_list.at(l_chr_id).name);
     }
     else
     {
       str_char = f_showname;
     }
 
-    if (!mute_map.value(n_char))
+    if (!mute_map.value(l_chr_id))
     {
-      append_ic_text(str_char, "has played a song: " + f_song, false, true);
+      append_ic_text(str_char, "has played a song: " + f_song, false, true, l_chr_id == m_cid);
       if (ao_config->log_is_recording_enabled())
         save_textlog(str_char + " has played a song: " + f_song);
       m_music_player->play(f_song);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1145,6 +1145,7 @@ void Courtroom::update_ic_log(bool p_reset_log)
 
   QTextCharFormat selfname_format = name_format;
 
+  if (ao_config->log_display_self_highlight_enabled())
   {
     QColor selfname_color = ao_app->get_color("ic_chatlog_selfname_color", fonts_ini);
     if (selfname_color == not_found_color)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -895,13 +895,24 @@ void Courtroom::handle_chatmessage_2() // handles IC
   ui_vp_chatbox->hide();
   ui_vp_showname_image->hide();
 
-  QString chatbox = ao_app->get_chat(m_chatmessage[CMChrName]);
+  QString l_chatbox_name = ao_app->get_chat(m_chatmessage[CMChrName]);
 
-  if (chatbox == "")
-    ui_vp_chatbox->set_image("chatmed.png");
+  if (l_chatbox_name.isEmpty())
+  {
+    l_chatbox_name = "chatmed.png";
+
+    if (ao_config->log_display_self_highlight_enabled() && m_chatmessage[CMChrId].toInt() == m_cid)
+    {
+      const QString l_chatbox_self_name = "chatbox_self.png";
+      if (file_exists(ao_app->find_theme_asset_path(l_chatbox_self_name)))
+        l_chatbox_name = l_chatbox_self_name;
+    }
+
+    ui_vp_chatbox->set_image(l_chatbox_name);
+  }
   else
   {
-    QString chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + ".png";
+    QString chatbox_path = ao_app->get_base_path() + "misc/" + l_chatbox_name + ".png";
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -284,6 +284,7 @@ void Courtroom::connect_widgets()
 
   connect(ao_config, SIGNAL(log_max_lines_changed(int)), this, SLOT(on_chat_config_changed()));
   connect(ao_config, SIGNAL(log_display_timestamp_changed(bool)), this, SLOT(on_chat_config_changed()));
+  connect(ao_config, SIGNAL(log_display_self_highlight_changed(bool)), this, SLOT(on_chat_config_changed()));
   connect(ao_config, SIGNAL(log_format_use_newline_changed(bool)), this, SLOT(on_chat_config_changed()));
   connect(ao_config, SIGNAL(log_display_empty_messages_changed(bool)), this, SLOT(on_chat_config_changed()));
   connect(ao_config, SIGNAL(log_display_music_switch_changed(bool)), this, SLOT(on_chat_config_changed()));


### PR DESCRIPTION
Resolve #144, resolve #87

Added personal highlight color for names, this will look for the color (`ic_chatlog_selfname_color`) in `courtroom_fonts.ini`.

Failing that, it will simply use the name color (`ic_chatlog_showname_color`). If neither are set, it will use the default color.

The self-identification is done by comparing the message's chr_id to the one we currently are.