### PR TITLE
Remove needless image setting in ackMS

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -96,13 +96,8 @@ public:
   void set_widgets();
   // sets font properties based on theme ini files
   void set_font(QWidget *widget, QString p_identifier);
-  // same as above, but use override color as color if it is not an empty
-  // string, otherwise use normal logic for color of set_font
-  void set_font(QWidget *widget, QString p_identifier, QString override_color);
-  // sets font properties for DRTextEdit (same as above but also text outline)
+  // sets font properties for DRTextEdit (same as above but also text outline, and alignments)
   void set_drtextedit_font(DRTextEdit *widget, QString p_identifier);
-  // same as second set_font but for drtextedit
-  void set_drtextedit_font(DRTextEdit *widget, QString p_identifier, QString override_color);
   // helper function that calls above function on the relevant widgets
   void set_fonts();
 
@@ -176,7 +171,10 @@ public:
 
   void list_areas();
 
-  void list_sfx();
+  QString current_sfx_file();
+  void update_sfx_list();
+  void update_sfx_widget_list();
+  void clear_sfx_widget_list_selection();
 
   void list_note_files();
 
@@ -308,7 +306,6 @@ private:
   QVector<evi_type> evidence_list;
   QVector<QString> music_list;
   QVector<QString> area_list;
-  QVector<QString> sfx_names;
   QVector<QString> area_names;
   QVector<QString> note_list;
 
@@ -401,9 +398,9 @@ private:
   bool m_msg_is_first_person = false;
 
   // Cached values for chat_tick
-  bool chatbox_message_outline = false;
-  bool chatbox_message_enable_highlighting = false;
-  QVector<QStringList> chatbox_message_highlight_colors;
+  bool m_chatbox_message_outline = false;
+  bool m_chatbox_message_enable_highlighting = false;
+  QVector<QStringList> m_chatbox_message_highlight_colors;
 
   // cid and this may differ in cases of ini-editing
   QString current_char;
@@ -452,7 +449,6 @@ private:
 
   int current_clock = -1;
   int timer_number = 0;
-  int current_sfx_id = -1;
 
   QString current_background = "gs4";
 
@@ -505,7 +501,11 @@ private:
   QListWidget *ui_mute_list = nullptr;
   QListWidget *ui_area_list = nullptr;
   QListWidget *ui_music_list = nullptr;
+
   QListWidget *ui_sfx_list = nullptr;
+  QVector<DR::SFX> m_sfx_list;
+  QColor m_sfx_color_found;
+  QColor m_sfx_color_missing;
 
   QLineEdit *ui_ic_chat_message = nullptr;
 
@@ -702,13 +702,14 @@ private slots:
 
   void on_ooc_return_pressed();
 
-  void on_music_search_edited(QString p_text);
+  void on_music_search_edited();
   void on_music_list_clicked();
   void on_area_list_clicked();
   void on_music_list_double_clicked(QModelIndex p_model);
   void on_area_list_double_clicked(QModelIndex p_model);
 
-  void on_sfx_search_edited(QString p_text);
+  void on_sfx_search_edited();
+  void on_sfx_widget_list_row_changed();
 
   void select_emote(int p_id);
 
@@ -771,21 +772,13 @@ private slots:
    * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_shout_buttons();
-
-  /**
-   * @brief Set the sprite of the given shout button, using the selected sprite if the button is selected.
-   * @param p_index Index of button to redraw.
-   * @details If a sprite cannot be found for the shout button, a regular push button is displayed for it with its
-   * shout name instead. If the index is out of bounds with respect to the number of shouts available, this method
-   * does nothing.
-   */
-  void draw_shout_button(int p_index);
+  void reset_shout_buttons();
 
   /**
    * @brief a general purpose function to toggle button selection
    */
-  void on_shout_clicked();
+  void on_shout_button_clicked(const bool);
+  void on_shout_button_toggled(const bool);
 
   /**
    * @brief Set the sprites of the effect buttons, and mark the currently
@@ -794,18 +787,9 @@ private slots:
    * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_effect_buttons();
-
-  /**
-   * @brief Set the sprite of the given effect button, using the selected sprite if the button is selected.
-   * @param p_index Index of button to redraw.
-   * @details If a sprite cannot be found for the effect button, a regular push button is displayed for it with its
-   * effect name instead. If the index is out of bounds with respect to the number of effects available, this method
-   * does nothing.
-   */
-  void draw_effect_button(int p_index);
-
-  void on_effect_button_clicked();
+  void reset_effect_buttons();
+  void on_effect_button_clicked(const bool);
+  void on_effect_button_toggled(const bool);
 
   void on_mute_clicked();
 
@@ -816,14 +800,15 @@ private slots:
 
   void on_text_color_changed(int p_color);
 
+  void on_witness_testimony_clicked();
+  void on_cross_examination_clicked();
   /**
    * @brief Set the sprites of the splash buttons.
    *
-   * @details If a sprite cannot be found for a splash button, a regular
+   * @details If a sprite cannot be found for a shout button, a regular
    * push button is displayed for it with its shout name instead.
    */
-  void draw_judge_wtce_buttons();
-
+  void reset_wtce_buttons();
   void on_wtce_clicked();
 
   void on_change_character_clicked();
@@ -842,8 +827,6 @@ private slots:
   void on_pre_clicked();
   void on_flip_clicked();
   void on_hidden_clicked();
-
-  void on_sfx_list_clicked(QModelIndex p_index);
 
   void on_evidence_button_clicked();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -806,8 +806,6 @@ private slots:
 
   void on_text_color_changed(int p_color);
 
-  void on_witness_testimony_clicked();
-  void on_cross_examination_clicked();
   /**
    * @brief Set the sprites of the splash buttons.
    *

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -708,7 +708,7 @@ private slots:
   void on_music_list_double_clicked(QModelIndex p_model);
   void on_area_list_double_clicked(QModelIndex p_model);
 
-  void on_sfx_search_edited();
+  void on_sfx_search_editing_finished();
   void on_sfx_widget_list_row_changed();
 
   void select_emote(int p_id);

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -504,6 +504,7 @@ private:
 
   QListWidget *ui_sfx_list = nullptr;
   QVector<DR::SFX> m_sfx_list;
+  const QString m_sfx_default_file = "__DEFAULT__";
   QColor m_sfx_color_found;
   QColor m_sfx_color_missing;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -800,7 +800,7 @@ private slots:
    * @brief Set the sprite of the given effect button, using the selected sprite if the button is selected.
    * @param p_index Index of button to redraw.
    * @details If a sprite cannot be found for the effect button, a regular push button is displayed for it with its
-   * effect name instead. If the index is out of bounds with respect to the number of effect available, this method
+   * effect name instead. If the index is out of bounds with respect to the number of effects available, this method
    * does nothing.
    */
   void draw_effect_button(int p_index);
@@ -819,10 +819,11 @@ private slots:
   /**
    * @brief Set the sprites of the splash buttons.
    *
-   * @details If a sprite cannot be found for a shout button, a regular
+   * @details If a sprite cannot be found for a splash button, a regular
    * push button is displayed for it with its shout name instead.
    */
   void draw_judge_wtce_buttons();
+
   void on_wtce_clicked();
 
   void on_change_character_clicked();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -795,6 +795,16 @@ private slots:
    * push button is displayed for it with its shout name instead.
    */
   void draw_effect_buttons();
+
+  /**
+   * @brief Set the sprite of the given effect button, using the selected sprite if the button is selected.
+   * @param p_index Index of button to redraw.
+   * @details If a sprite cannot be found for the effect button, a regular push button is displayed for it with its
+   * effect name instead. If the index is out of bounds with respect to the number of effect available, this method
+   * does nothing.
+   */
+  void draw_effect_button(int p_index);
+
   void on_effect_button_clicked();
 
   void on_mute_clicked();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -174,7 +174,8 @@ public:
   QString current_sfx_file();
   void update_sfx_list();
   void update_sfx_widget_list();
-  void clear_sfx_widget_list_selection();
+  void select_default_sfx();
+  void clear_sfx_selection();
 
   void list_note_files();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -774,6 +774,15 @@ private slots:
   void draw_shout_buttons();
 
   /**
+   * @brief Set the sprite of the given shout button, using the selected sprite if the button is selected.
+   * @param p_index Index of button to redraw.
+   * @details If a sprite cannot be found for the shout button, a regular push button is displayed for it with its
+   * shout name instead. If the index is out of bounds with respect to the number of shouts available, this method
+   * does nothing.
+   */
+  void draw_shout_button(int p_index);
+
+  /**
    * @brief a general purpose function to toggle button selection
    */
   void on_shout_clicked();

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -60,6 +60,19 @@ private:
   bool system = false;
   bool music = false;
 };
+
+struct SFX
+{
+public:
+  SFX() = default;
+  SFX(QString p_name, QString p_file, bool p_is_found = false)
+      : name(p_name.trimmed()), file(p_file.trimmed()), is_found(p_is_found)
+  {}
+
+  QString name;
+  QString file;
+  bool is_found;
+};
 } // namespace DR
 
 struct server_type

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -719,12 +719,13 @@ void Courtroom::handle_acknowledged_ms()
   list_sfx();
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
-  int old_shout_state = m_shout_state;
+  int old_m_shout_state = m_shout_state;
   m_shout_state = 0;
-  draw_shout_button(old_shout_state - 1);
+  draw_shout_button(old_m_shout_state - 1);
 
+  int old_m_effect_state = m_effect_state;
   m_effect_state = 0;
-  draw_effect_buttons();
+  draw_effect_button(old_m_effect_state - 1);
 
   m_wtce_current = 0;
   draw_judge_wtce_buttons();
@@ -1987,8 +1988,9 @@ void Courtroom::on_shout_clicked()
     m_shout_state = f_shout_id;
 
   // Redraw old and new buttons
-  draw_shout_button(old_m_shout_state - 1);
   draw_shout_button(m_shout_state - 1);
+  if (m_shout_state != old_m_shout_state)
+    draw_shout_button(old_m_shout_state - 1);
   ui_ic_chat_message->setFocus();
 }
 
@@ -2051,19 +2053,26 @@ void Courtroom::cycle_wtce(int p_delta)
 
 void Courtroom::draw_effect_buttons()
 {
-  for (int i = 0; i < effect_names.size(); ++i)
-  {
-    QString effect_file = effect_names.at(i) + ".png";
-    ui_effects[i]->set_image(effect_file);
-    if (ao_app->find_theme_asset_path(effect_file).isEmpty())
-      ui_effects[i]->setText(effect_names.at(i));
-    else
-      ui_effects[i]->setText("");
-  }
+  for (int i = 0; i < ui_effects.size(); ++i)
+    draw_effect_button(i);
+}
 
-  // Mark selected button as such
-  if (m_effect_state != 0 && ui_effects.size() > 0)
-    ui_effects[m_effect_state - 1]->set_image(effect_names.at(m_effect_state - 1) + "_pressed.png");
+void Courtroom::draw_effect_button(int index)
+{
+  if (index < 0 || index >= ui_effects.size())
+    return;
+
+  QString effect_file;
+  if (m_effect_state - 1 == index)
+    effect_file = effect_names.at(index) + "_pressed.png";
+  else
+    effect_file = effect_names.at(index) + ".png";
+
+  ui_effects[index]->set_image(effect_file);
+  if (ao_app->find_theme_asset_path(effect_file).isEmpty())
+    ui_effects[index]->setText(effect_names.at(index));
+  else
+    ui_effects[index]->setText("");
 }
 
 void Courtroom::on_effect_button_clicked()
@@ -2071,12 +2080,17 @@ void Courtroom::on_effect_button_clicked()
   AOButton *f_button = static_cast<AOButton *>(this->sender());
 
   int f_effect_id = f_button->property("effect_id").toInt();
+  int old_m_effect_state = m_effect_state;
+
   if (m_effect_state == f_effect_id)
     m_effect_state = 0;
   else
     m_effect_state = f_effect_id;
 
-  draw_effect_buttons();
+  // Redraw old and new buttons
+  draw_effect_button(m_effect_state - 1);
+  if (m_effect_state != old_m_effect_state)
+    draw_effect_button(old_m_effect_state - 1);
 
   ui_ic_chat_message->setFocus();
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -442,7 +442,8 @@ QString Courtroom::current_sfx_file()
   QListWidgetItem *l_item = ui_sfx_list->currentItem();
   if (l_item == nullptr)
     return nullptr;
-  return m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
+  const QString l_file = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
+  return l_file == m_sfx_default_file ? ao_app->get_sfx_name(current_char, current_emote) : l_file;
 }
 
 void Courtroom::update_sfx_list()
@@ -453,7 +454,7 @@ void Courtroom::update_sfx_list()
 
   // items
   m_sfx_list.clear();
-  m_sfx_list.append(DR::SFX("Default", ao_app->get_sfx_name(current_char, current_emote)));
+  m_sfx_list.append(DR::SFX("Default", m_sfx_default_file));
   m_sfx_list.append(DR::SFX("Silence", nullptr));
 
   const QStringList l_sfx_list = ao_app->get_sfx_list();
@@ -659,6 +660,7 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(f_side);
 
   // sfx file
+  qDebug() << "foo" << current_sfx_file();
   packet_contents.append(current_sfx_file());
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -727,9 +727,11 @@ void Courtroom::handle_acknowledged_ms()
   m_effect_state = 0;
   draw_effect_button(old_m_effect_state - 1);
 
-  is_presenting_evidence = false;
-
-  ui_evidence_present->set_image("present_disabled.png");
+  if (is_presenting_evidence)
+  {
+    is_presenting_evidence = false;
+    ui_evidence_present->set_image("present_disabled.png");
+  }
 }
 
 void Courtroom::handle_chatmessage(QStringList p_contents)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -442,8 +442,7 @@ QString Courtroom::current_sfx_file()
   QListWidgetItem *l_item = ui_sfx_list->currentItem();
   if (l_item == nullptr)
     return nullptr;
-  return ui_sfx_list->currentRow() == 0 ? ao_app->get_sfx_name(current_char, current_emote)
-                                        : m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
+  return m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
 }
 
 void Courtroom::update_sfx_list()
@@ -454,7 +453,7 @@ void Courtroom::update_sfx_list()
 
   // items
   m_sfx_list.clear();
-  m_sfx_list.append(DR::SFX("Default", nullptr));
+  m_sfx_list.append(DR::SFX("Default", ao_app->get_sfx_name(current_char, current_emote)));
   m_sfx_list.append(DR::SFX("Silence", nullptr));
 
   const QStringList l_sfx_list = ao_app->get_sfx_list();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -128,8 +128,7 @@ void Courtroom::enter_courtroom(int p_cid)
   list_music();
   list_areas();
   update_sfx_list();
-
-  ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
+  select_default_sfx();
 
   // unmute audio
   suppress_audio(false);
@@ -491,7 +490,14 @@ void Courtroom::update_sfx_widget_list()
   on_sfx_widget_list_row_changed();
 }
 
-void Courtroom::clear_sfx_widget_list_selection()
+void Courtroom::select_default_sfx()
+{
+  if (ui_sfx_list->count() == 0)
+    return;
+  ui_sfx_list->setCurrentRow(0);
+}
+
+void Courtroom::clear_sfx_selection()
 {
   ui_sfx_list->setCurrentRow(-1);
 }
@@ -504,7 +510,6 @@ void Courtroom::on_sfx_search_editing_finished()
 void Courtroom::on_sfx_widget_list_row_changed()
 {
   const int p_current_row = ui_sfx_list->currentRow();
-  ui_pre->setChecked(p_current_row != -1);
 
   for (int i = 0; i < ui_sfx_list->count(); ++i)
   {
@@ -514,6 +519,8 @@ void Courtroom::on_sfx_widget_list_row_changed()
     QColor i_color = l_is_found ? m_sfx_color_found : m_sfx_color_missing;
     if (i == p_current_row)
     {
+      ui_pre->setChecked(ui_pre->isChecked() || l_is_found);
+
       // Calculate the amount of lightness it would take to light up the row. We
       // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
       // nothing. +0.4 is just an arbitrarily chosen number.
@@ -737,7 +744,7 @@ void Courtroom::handle_acknowledged_ms()
   reset_shout_buttons();
   reset_effect_buttons();
   reset_wtce_buttons();
-  clear_sfx_widget_list_selection();
+  clear_sfx_selection();
 
   is_presenting_evidence = false;
   ui_evidence_present->set_image("present_disabled.png");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -719,8 +719,9 @@ void Courtroom::handle_acknowledged_ms()
   list_sfx();
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
+  int old_shout_state = m_shout_state;
   m_shout_state = 0;
-  draw_shout_buttons();
+  draw_shout_button(old_shout_state - 1);
 
   m_effect_state = 0;
   draw_effect_buttons();
@@ -1952,24 +1953,32 @@ void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
 void Courtroom::draw_shout_buttons()
 {
   for (int i = 0; i < ui_shouts.size(); ++i)
-  {
-    QString shout_file = shout_names.at(i) + ".png";
-    ui_shouts[i]->set_image(shout_file);
-    if (ao_app->find_theme_asset_path(shout_file).isEmpty())
-      ui_shouts[i]->setText(shout_names.at(i));
-    else
-      ui_shouts[i]->setText("");
-  }
+    draw_shout_button(i);
+}
 
-  // Mark selected button as such
-  if (m_shout_state != 0 && ui_shouts.size() > 0)
-    ui_shouts.at(m_shout_state - 1)->set_image(shout_names.at(m_shout_state - 1) + "_selected.png");
+void Courtroom::draw_shout_button(int index)
+{
+  if (index < 0 || index >= ui_shouts.size())
+    return;
+
+  QString shout_file;
+  if (m_shout_state - 1 == index)
+    shout_file = shout_names.at(index) + "_selected.png";
+  else
+    shout_file = shout_names.at(index) + ".png";
+
+  ui_shouts[index]->set_image(shout_file);
+  if (ao_app->find_theme_asset_path(shout_file).isEmpty())
+    ui_shouts[index]->setText(shout_names.at(index));
+  else
+    ui_shouts[index]->setText("");
 }
 
 void Courtroom::on_shout_clicked()
 {
   AOButton *f_shout_button = static_cast<AOButton *>(sender());
   int f_shout_id = f_shout_button->property("shout_id").toInt();
+  int old_m_shout_state = m_shout_state;
 
   // update based on current button selected
   if (f_shout_id == m_shout_state)
@@ -1977,8 +1986,9 @@ void Courtroom::on_shout_clicked()
   else
     m_shout_state = f_shout_id;
 
-  draw_shout_buttons();
-
+  // Redraw old and new buttons
+  draw_shout_button(old_m_shout_state - 1);
+  draw_shout_button(m_shout_state - 1);
   ui_ic_chat_message->setFocus();
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2133,26 +2133,6 @@ void Courtroom::on_text_color_changed(int p_color)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_witness_testimony_clicked()
-{
-  if (is_client_muted)
-    return;
-
-  ao_app->send_server_packet(new AOPacket("RT#testimony1#%"));
-
-  ui_ic_chat_message->setFocus();
-}
-
-void Courtroom::on_cross_examination_clicked()
-{
-  if (is_client_muted)
-    return;
-
-  ao_app->send_server_packet(new AOPacket("RT#testimony2#%"));
-
-  ui_ic_chat_message->setFocus();
-}
-
 void Courtroom::draw_judge_wtce_buttons()
 {
   for (int i = 0; i < wtce_names.size(); ++i)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -86,7 +86,7 @@ void Courtroom::enter_courtroom(int p_cid)
   m_effect_state = 0;
   m_effect_current = 0;
   m_wtce_current = 0;
-  draw_judge_wtce_buttons();
+  reset_wtce_buttons();
 
   // setup chat
   on_chat_config_changed();
@@ -127,7 +127,7 @@ void Courtroom::enter_courtroom(int p_cid)
 
   list_music();
   list_areas();
-  list_sfx();
+  update_sfx_list();
 
   ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
@@ -437,68 +437,96 @@ void Courtroom::list_areas()
   }
 }
 
-void Courtroom::list_sfx()
+QString Courtroom::current_sfx_file()
 {
+  QListWidgetItem *l_item = ui_sfx_list->currentItem();
+  if (l_item == nullptr)
+    return "0";
+  const QString l_file = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
+  return l_file.isEmpty() ? "0" : l_file;
+}
+
+void Courtroom::update_sfx_list()
+{
+  // colors
+  m_sfx_color_found = ao_app->get_color("found_song_color", design_ini);
+  m_sfx_color_missing = ao_app->get_color("missing_song_color", design_ini);
+
+  // items
+  m_sfx_list.clear();
+  m_sfx_list.append(DR::SFX("Default", nullptr));
+  m_sfx_list.append(DR::SFX("Silence", nullptr));
+
+  const QStringList l_sfx_list = ao_app->get_sfx_list();
+  for (const QString &i_sfx_line : l_sfx_list)
+  {
+    const QStringList l_sfx_entry = i_sfx_line.split("=", DR::SkipEmptyParts);
+
+    const QString l_name = l_sfx_entry.at(l_sfx_entry.size() - 1).trimmed();
+    const QString l_file = QString(l_sfx_entry.size() >= 2 ? l_sfx_entry.at(0) : nullptr).trimmed();
+    const bool l_is_found = !ao_app->find_asset_path({ao_app->get_sounds_path(l_file)}, audio_extensions()).isEmpty();
+    m_sfx_list.append(DR::SFX(l_name, l_file, l_is_found));
+  }
+
+  update_sfx_widget_list();
+}
+
+void Courtroom::update_sfx_widget_list()
+{
+  QSignalBlocker l_blocker(ui_sfx_list);
   ui_sfx_list->clear();
-  sfx_names.clear();
-  current_sfx_id = -1; // Restart current SFX, because it may no longer be valid
 
-  QString f_file = design_ini;
-
-  QStringList sfx_list = ao_app->get_sfx_list();
-
-  QBrush found_brush(ao_app->get_color("found_song_color", f_file));
-  QBrush missing_brush(ao_app->get_color("missing_song_color", f_file));
-
-  // Add hardcoded items
-  // FIXME: Rewrite
-  ui_sfx_list->addItem("Default");
-  ui_sfx_list->addItem("Silence");
-
-  sfx_names.append("1"); // Default
-  sfx_names.append("1"); // Silence
-
-  QString default_sfx_root = ao_app->get_sounds_path("1");
-  QString default_sfx_path = ao_app->find_asset_path({default_sfx_root}, audio_extensions());
-  if (!default_sfx_path.isEmpty())
+  const QString l_name_filter = ui_sfx_search->text();
+  for (int i = 0; i < m_sfx_list.length(); ++i)
   {
-    ui_sfx_list->item(0)->setBackground(found_brush);
-    ui_sfx_list->item(1)->setBackground(found_brush);
-  }
-  else
-  {
-    ui_sfx_list->item(0)->setBackground(missing_brush);
-    ui_sfx_list->item(1)->setBackground(missing_brush);
+    const DR::SFX &i_sfx = m_sfx_list.at(i);
+    if (!i_sfx.name.contains(l_name_filter, Qt::CaseInsensitive))
+      continue;
+    QListWidgetItem *l_item = new QListWidgetItem;
+    l_item->setText(i_sfx.name);
+    l_item->setData(Qt::UserRole, i);
+    ui_sfx_list->addItem(l_item);
   }
 
-  // Now add the other SFXs given by the character's sound.ini
-  for (int n_sfx = 0; n_sfx < sfx_list.size(); ++n_sfx)
-  {
-    QStringList sfx = sfx_list.at(n_sfx).split("=");
-    QString i_sfx = sfx.at(0).trimmed();
-    QString d_sfx = "";
-    sfx_names.append(i_sfx);
-    if (sfx_list.at(n_sfx).split("=").size() < 2)
-      d_sfx = i_sfx;
-    else
-      d_sfx = sfx.at(1).trimmed();
+  on_sfx_widget_list_row_changed();
+}
 
-    if (i_sfx.toLower().contains(ui_sfx_search->text().toLower()))
+void Courtroom::clear_sfx_widget_list_selection()
+{
+  ui_sfx_list->setCurrentRow(-1);
+}
+
+void Courtroom::on_sfx_search_edited()
+{
+  update_sfx_list();
+}
+
+void Courtroom::on_sfx_widget_list_row_changed()
+{
+  const int p_current_row = ui_sfx_list->currentRow();
+  ui_pre->setChecked(p_current_row != -1);
+
+  for (int i = 0; i < ui_sfx_list->count(); ++i)
+  {
+    QListWidgetItem *l_item = ui_sfx_list->item(i);
+    const bool l_is_found = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).is_found;
+
+    QColor i_color = l_is_found ? m_sfx_color_found : m_sfx_color_missing;
+    if (i == p_current_row)
     {
-      ui_sfx_list->addItem(d_sfx);
-      int last_index = ui_sfx_list->count() - 1;
-      ui_sfx_list->item(last_index)->setStatusTip(QString::number(n_sfx + 2));
+      // Calculate the amount of lightness it would take to light up the row. We
+      // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
+      // nothing. +0.4 is just an arbitrarily chosen number.
+      const double l_final_lightness = qMin(1.0, i_color.lightnessF() + 0.4);
 
-      // Apply appropriate color whether SFX exists or not
-      QString sfx_root = ao_app->get_sounds_path(i_sfx);
-      QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
-
-      if (!sfx_path.isEmpty())
-        ui_sfx_list->item(last_index)->setBackground(found_brush);
-      else
-        ui_sfx_list->item(last_index)->setBackground(missing_brush);
+      // This is just the reverse of the above, basically. We set the colour, and we
+      // set the brush to have that colour.
+      i_color.setHslF(i_color.hueF(), i_color.saturationF(), l_final_lightness);
     }
+
+    l_item->setBackground(i_color);
   }
+  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::list_note_files()
@@ -631,20 +659,8 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(f_side);
 
-  //  packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
-  //  packet_contents.append(ui_sfx_search->text());
-
-  int row = ui_sfx_list->currentRow();
-  if (row == -1 || row == 0) // default
-    packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
-  else if (QListWidgetItem *item = ui_sfx_list->item(row)) // selection
-  {
-    double d_ind = item->statusTip().toDouble();
-    int ind = int(d_ind);
-    qDebug() << ind;
-    packet_contents.append(sfx_names.at(ind));
-    //    packet_contents.append(sfx_names.at(row));
-  }
+  // sfx file
+  packet_contents.append(current_sfx_file());
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
@@ -716,22 +732,14 @@ void Courtroom::handle_acknowledged_ms()
 
   // reset states
   ui_pre->setChecked(ao_config->always_pre_enabled());
-  list_sfx();
-  ui_sfx_list->setCurrentItem(ui_sfx_list->item(0)); // prevents undefined errors
 
-  int old_m_shout_state = m_shout_state;
-  m_shout_state = 0;
-  draw_shout_button(old_m_shout_state - 1);
+  reset_shout_buttons();
+  reset_effect_buttons();
+  reset_wtce_buttons();
+  clear_sfx_widget_list_selection();
 
-  int old_m_effect_state = m_effect_state;
-  m_effect_state = 0;
-  draw_effect_button(old_m_effect_state - 1);
-
-  if (is_presenting_evidence)
-  {
-    is_presenting_evidence = false;
-    ui_evidence_present->set_image("present_disabled.png");
-  }
+  is_presenting_evidence = false;
+  ui_evidence_present->set_image("present_disabled.png");
 }
 
 void Courtroom::handle_chatmessage(QStringList p_contents)
@@ -803,8 +811,6 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   {
     f_showname = m_chatmessage[CMShowName];
   }
-
-  QString f_message = f_showname + ": " + m_chatmessage[CMMessage] + "\n";
 
   m_effects_player->stop_all();
 
@@ -880,11 +886,6 @@ void Courtroom::handle_chatmessage_2() // handles IC
   {
     f_showname = m_chatmessage[CMShowName];
   }
-
-  // Check if char.ini has color property, which overrides the theme's default
-  // showname color
-  QString f_color = ao_app->read_char_ini(real_name, "color", "[Options]", "[Time]");
-  set_drtextedit_font(ui_vp_showname, "showname", f_color);
 
   ui_vp_showname->setText(f_showname);
 
@@ -1367,9 +1368,9 @@ void Courtroom::setup_chat()
   blip_pos = 0;
 
   // Cache these so chat_tick performs better
-  chatbox_message_outline = (ao_app->get_font_property("message_outline", fonts_ini) == 1);
-  chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", cc_config_ini));
-  chatbox_message_highlight_colors = ao_app->get_highlight_colors();
+  m_chatbox_message_outline = (ao_app->get_font_property("message_outline", fonts_ini) == 1);
+  m_chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", cc_config_ini));
+  m_chatbox_message_highlight_colors = ao_app->get_highlight_colors();
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CMChrName]);
 
@@ -1385,7 +1386,7 @@ void Courtroom::chat_tick()
   // note: this is called fairly often(every 60 ms when char is talking)
   // do not perform heavy operations here
   QTextCharFormat vp_message_format = ui_vp_message->currentCharFormat();
-  if (chatbox_message_outline)
+  if (m_chatbox_message_outline)
     vp_message_format.setTextOutline(QPen(Qt::black, 1));
   else
     vp_message_format.setTextOutline(Qt::NoPen);
@@ -1444,7 +1445,7 @@ void Courtroom::chat_tick()
 
       ui_vp_message->textCursor().insertText(f_character, vp_message_format);
     }
-    else if (chatbox_message_enable_highlighting)
+    else if (m_chatbox_message_enable_highlighting)
     {
       bool highlight_found = false;
       bool render_character = true;
@@ -1454,7 +1455,7 @@ void Courtroom::chat_tick()
       if (m_color_stack.isEmpty())
         m_color_stack.push("");
 
-      for (const auto &col : chatbox_message_highlight_colors)
+      for (const auto &col : m_chatbox_message_highlight_colors)
       {
         if (f_character == col[0][0] && m_string_color != col[1])
         {
@@ -1478,7 +1479,7 @@ void Courtroom::chat_tick()
 
       QString m_future_string_color = m_string_color;
 
-      for (const auto &col : chatbox_message_highlight_colors)
+      for (const auto &col : m_chatbox_message_highlight_colors)
       {
         if (f_character == col[0][1] && !highlight_found)
         {
@@ -1834,19 +1835,10 @@ void Courtroom::on_ooc_return_pressed()
   ui_ooc_chat_message->setFocus();
 }
 
-void Courtroom::on_music_search_edited(QString p_text)
+void Courtroom::on_music_search_edited()
 {
-  // preventing compiler warnings
-  p_text += "a";
   list_music();
   list_areas();
-}
-
-void Courtroom::on_sfx_search_edited(QString p_text)
-{
-  // preventing compiler warnings
-  p_text += "a";
-  list_sfx();
 }
 
 void Courtroom::on_pos_dropdown_changed(int p_index)
@@ -1950,47 +1942,50 @@ void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::draw_shout_buttons()
+void Courtroom::reset_shout_buttons()
 {
-  for (int i = 0; i < ui_shouts.size(); ++i)
-    draw_shout_button(i);
+  for (AOButton *i_button : qAsConst(ui_shouts))
+    i_button->setChecked(false);
+  m_shout_state = 0;
 }
 
-void Courtroom::draw_shout_button(int index)
+void Courtroom::on_shout_button_clicked(const bool p_checked)
 {
-  if (index < 0 || index >= ui_shouts.size())
+  AOButton *l_button = dynamic_cast<AOButton *>(sender());
+  if (l_button == nullptr)
     return;
 
-  QString shout_file;
-  if (m_shout_state - 1 == index)
-    shout_file = shout_names.at(index) + "_selected.png";
-  else
-    shout_file = shout_names.at(index) + ".png";
+  bool l_ok = false;
+  const int l_id = l_button->property("shout_id").toInt(&l_ok);
+  if (!l_ok)
+    return;
 
-  ui_shouts[index]->set_image(shout_file);
-  if (ao_app->find_theme_asset_path(shout_file).isEmpty())
-    ui_shouts[index]->setText(shout_names.at(index));
-  else
-    ui_shouts[index]->setText("");
+  // disable all other buttons
+  for (AOButton *i_button : qAsConst(ui_shouts))
+  {
+    if (i_button == l_button)
+      continue;
+    i_button->setChecked(false);
+  }
+  m_shout_state = p_checked ? l_id : 0;
+
+  ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_shout_clicked()
+void Courtroom::on_shout_button_toggled(const bool p_checked)
 {
-  AOButton *f_shout_button = static_cast<AOButton *>(sender());
-  int f_shout_id = f_shout_button->property("shout_id").toInt();
-  int old_m_shout_state = m_shout_state;
+  AOButton *l_button = dynamic_cast<AOButton *>(sender());
+  if (l_button == nullptr)
+    return;
 
-  // update based on current button selected
-  if (f_shout_id == m_shout_state)
-    m_shout_state = 0;
-  else
-    m_shout_state = f_shout_id;
+  const QString l_name = l_button->property("shout_name").toString();
+  if (l_name.isEmpty())
+    return;
 
-  // Redraw old and new buttons
-  draw_shout_button(m_shout_state - 1);
-  if (m_shout_state != old_m_shout_state)
-    draw_shout_button(old_m_shout_state - 1);
-  ui_ic_chat_message->setFocus();
+  const QString l_image_name(QString("%1%2.png").arg(l_name, QString(p_checked ? "_selected" : nullptr)));
+  l_button->set_image(l_image_name);
+  if (ao_app->find_theme_asset_path(l_image_name).isEmpty())
+    l_button->setText(l_name);
 }
 
 void Courtroom::on_cycle_clicked()
@@ -2050,48 +2045,50 @@ void Courtroom::cycle_wtce(int p_delta)
   set_judge_wtce();
 }
 
-void Courtroom::draw_effect_buttons()
+void Courtroom::reset_effect_buttons()
 {
-  for (int i = 0; i < ui_effects.size(); ++i)
-    draw_effect_button(i);
+  for (AOButton *i_button : qAsConst(ui_effects))
+    i_button->setChecked(false);
+  m_effect_state = 0;
 }
 
-void Courtroom::draw_effect_button(int index)
+void Courtroom::on_effect_button_clicked(const bool p_checked)
 {
-  if (index < 0 || index >= ui_effects.size())
+  AOButton *l_button = dynamic_cast<AOButton *>(sender());
+  if (l_button == nullptr)
     return;
 
-  QString effect_file;
-  if (m_effect_state - 1 == index)
-    effect_file = effect_names.at(index) + "_pressed.png";
-  else
-    effect_file = effect_names.at(index) + ".png";
+  bool l_ok = false;
+  const int l_id = l_button->property("effect_id").toInt(&l_ok);
+  if (!l_ok)
+    return;
 
-  ui_effects[index]->set_image(effect_file);
-  if (ao_app->find_theme_asset_path(effect_file).isEmpty())
-    ui_effects[index]->setText(effect_names.at(index));
-  else
-    ui_effects[index]->setText("");
+  // disable all other buttons
+  for (AOButton *i_button : qAsConst(ui_effects))
+  {
+    if (i_button == l_button)
+      continue;
+    i_button->setChecked(false);
+  }
+
+  m_effect_state = p_checked ? l_id : 0;
+  ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::on_effect_button_clicked()
+void Courtroom::on_effect_button_toggled(const bool p_checked)
 {
-  AOButton *f_button = static_cast<AOButton *>(this->sender());
+  AOButton *l_button = dynamic_cast<AOButton *>(sender());
+  if (l_button == nullptr)
+    return;
 
-  int f_effect_id = f_button->property("effect_id").toInt();
-  int old_m_effect_state = m_effect_state;
+  const QString l_name = l_button->property("effect_name").toString();
+  if (l_name.isEmpty())
+    return;
 
-  if (m_effect_state == f_effect_id)
-    m_effect_state = 0;
-  else
-    m_effect_state = f_effect_id;
-
-  // Redraw old and new buttons
-  draw_effect_button(m_effect_state - 1);
-  if (m_effect_state != old_m_effect_state)
-    draw_effect_button(old_m_effect_state - 1);
-
-  ui_ic_chat_message->setFocus();
+  const QString l_image_name(QString("%1%2.png").arg(l_name, QString(p_checked ? "_pressed" : nullptr)));
+  l_button->set_image(l_image_name);
+  if (ao_app->find_theme_asset_path(l_image_name).isEmpty())
+    l_button->setText(l_name);
 }
 
 void Courtroom::on_mute_clicked()
@@ -2146,7 +2143,27 @@ void Courtroom::on_text_color_changed(int p_color)
   ui_ic_chat_message->setFocus();
 }
 
-void Courtroom::draw_judge_wtce_buttons()
+void Courtroom::on_witness_testimony_clicked()
+{
+  if (is_client_muted)
+    return;
+
+  ao_app->send_server_packet(new AOPacket("RT#testimony1#%"));
+
+  ui_ic_chat_message->setFocus();
+}
+
+void Courtroom::on_cross_examination_clicked()
+{
+  if (is_client_muted)
+    return;
+
+  ao_app->send_server_packet(new AOPacket("RT#testimony2#%"));
+
+  ui_ic_chat_message->setFocus();
+}
+
+void Courtroom::reset_wtce_buttons()
 {
   for (int i = 0; i < wtce_names.size(); ++i)
   {
@@ -2157,6 +2174,8 @@ void Courtroom::draw_judge_wtce_buttons()
     else
       ui_wtce[i]->setText("");
   }
+
+  m_wtce_current = 0;
 
   // Unlike the other reset functions, the judge buttons are of immediate
   // action and thus are immediately unpressed after being pressed.
@@ -2346,52 +2365,6 @@ void Courtroom::closeEvent(QCloseEvent *event)
 {
   Q_EMIT closing();
   QMainWindow::closeEvent(event);
-}
-
-void Courtroom::on_sfx_list_clicked(QModelIndex p_index)
-{
-  if (p_index.isValid())
-    ui_pre->setChecked(p_index.isValid());
-
-  QListWidgetItem *new_sfx = ui_sfx_list->currentItem();
-
-  QBrush found_brush(ao_app->get_color("found_song_color", design_ini));
-  QBrush missing_brush(ao_app->get_color("missing_song_color", design_ini));
-
-  if (current_sfx_id != -1)
-  {
-    QListWidgetItem *old_sfx = ui_sfx_list->item(current_sfx_id);
-
-    // Apply appropriate color whether SFX exists or not
-    QString sfx_root = ao_app->get_sounds_path(sfx_names.at(current_sfx_id));
-    QString sfx_path = ao_app->find_asset_path({sfx_root}, audio_extensions());
-
-    if (!sfx_path.isEmpty())
-      old_sfx->setBackground(found_brush);
-    else
-      old_sfx->setBackground(missing_brush);
-  }
-
-  // Grab the colour of the selected row's brush.
-  QBrush selected_brush = new_sfx->background();
-  QColor selected_col = selected_brush.color();
-
-  // Calculate the amount of lightness it would take to light up the row. We
-  // also limit it to 1.0, as giving lightness values above 1.0 to QColor does
-  // nothing. +0.4 is just an arbitrarily chosen number.
-  double final_lightness = qMin(1.0, selected_col.lightnessF() + 0.4);
-
-  // This is just the reverse of the above, basically. We set the colour, and we
-  // set the brush to have that colour.
-  selected_col.setHslF(selected_col.hueF(), selected_col.saturationF(), final_lightness);
-  selected_brush.setColor(selected_col);
-
-  // Finally, we set the selected SFX's background to be the lightened-up brush.
-  new_sfx->setBackground(selected_brush);
-
-  current_sfx_id = ui_sfx_list->currentRow();
-
-  ui_ic_chat_message->setFocus();
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -441,9 +441,9 @@ QString Courtroom::current_sfx_file()
 {
   QListWidgetItem *l_item = ui_sfx_list->currentItem();
   if (l_item == nullptr)
-    return "0";
-  const QString l_file = m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
-  return l_file.isEmpty() ? "0" : l_file;
+    return nullptr;
+  return ui_sfx_list->currentRow() == 0 ? ao_app->get_sfx_name(current_char, current_emote)
+                                        : m_sfx_list.at(l_item->data(Qt::UserRole).toInt()).file;
 }
 
 void Courtroom::update_sfx_list()
@@ -1968,7 +1968,7 @@ void Courtroom::on_shout_button_clicked(const bool p_checked)
     i_button->setChecked(false);
   }
   m_shout_state = p_checked ? l_id : 0;
-  
+
   ui_ic_chat_message->setFocus();
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -495,7 +495,7 @@ void Courtroom::clear_sfx_widget_list_selection()
   ui_sfx_list->setCurrentRow(-1);
 }
 
-void Courtroom::on_sfx_search_edited()
+void Courtroom::on_sfx_search_editing_finished()
 {
   update_sfx_list();
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -727,9 +727,6 @@ void Courtroom::handle_acknowledged_ms()
   m_effect_state = 0;
   draw_effect_button(old_m_effect_state - 1);
 
-  m_wtce_current = 0;
-  draw_judge_wtce_buttons();
-
   is_presenting_evidence = false;
 
   ui_evidence_present->set_image("present_disabled.png");

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -288,7 +288,7 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(log_is_topdown_changed(bool)), this, SLOT(on_chat_config_changed()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited()));
+  connect(ui_sfx_search, SIGNAL(editingFinished()), this, SLOT(on_sfx_search_editing_finished()));
 
   connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -288,7 +288,7 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(log_is_topdown_changed(bool)), this, SLOT(on_chat_config_changed()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this, SLOT(on_music_search_edited(QString)));
-  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited(QString)));
+  connect(ui_sfx_search, SIGNAL(textChanged(QString)), this, SLOT(on_sfx_search_edited()));
 
   connect(ui_change_character, SIGNAL(clicked()), this, SLOT(on_change_character_clicked()));
   connect(ui_call_mod, SIGNAL(clicked()), this, SLOT(on_call_mod_clicked()));
@@ -304,7 +304,7 @@ void Courtroom::connect_widgets()
   connect(ui_flip, SIGNAL(clicked()), this, SLOT(on_flip_clicked()));
   connect(ui_hidden, SIGNAL(clicked()), this, SLOT(on_hidden_clicked()));
 
-  connect(ui_sfx_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_sfx_list_clicked(QModelIndex)));
+  connect(ui_sfx_list, SIGNAL(currentRowChanged(int)), this, SLOT(on_sfx_widget_list_row_changed()));
 
   connect(ui_evidence_button, SIGNAL(clicked()), this, SLOT(on_evidence_button_clicked()));
 
@@ -688,7 +688,7 @@ void Courtroom::set_widgets()
   //  ui_shouts[0]->show();
   //  ui_shouts[1]->show();
   //  ui_shouts[2]->show();
-  draw_shout_buttons();
+  reset_shout_buttons();
 
   set_size_and_pos(ui_shout_up, "shout_up");
   ui_shout_up->set_image("shoutup.png");
@@ -717,7 +717,7 @@ void Courtroom::set_widgets()
   {
     set_size_and_pos(ui_effects[i], effect_names[i]);
   }
-  draw_effect_buttons();
+  reset_effect_buttons();
 
   set_size_and_pos(ui_effect_up, "effect_up");
   ui_effect_up->set_image("effectup.png");
@@ -757,7 +757,7 @@ void Courtroom::set_widgets()
     qDebug() << "AA: single wtce";
   }
   set_judge_wtce();
-  draw_judge_wtce_buttons();
+  reset_wtce_buttons();
 
   for (int i = 0; i < free_block_names.size(); ++i)
   {
@@ -1169,15 +1169,16 @@ void Courtroom::load_effects()
 
   for (int i = 0; i < ui_effects.size(); ++i)
   {
-    ui_effects[i] = new AOButton(this, ao_app);
-    ui_effects[i]->setProperty("effect_id", i + 1);
-    ui_effects[i]->stackUnder(ui_effect_up);
-    ui_effects[i]->stackUnder(ui_effect_down);
-  }
+    AOButton *l_button = new AOButton(this, ao_app);
+    ui_effects.replace(i, l_button);
+    l_button->setCheckable(true);
+    l_button->setProperty("effect_id", i + 1);
+    l_button->stackUnder(ui_effect_up);
+    l_button->stackUnder(ui_effect_down);
 
-  // And connect their actions
-  for (auto &effect : ui_effects)
-    connect(effect, SIGNAL(clicked(bool)), this, SLOT(on_effect_button_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_effect_button_clicked(bool)));
+    connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_effect_button_toggled(bool)));
+  }
 
   // And add names
   effect_names.clear();
@@ -1186,8 +1187,11 @@ void Courtroom::load_effects()
     QStringList names = ao_app->get_effect(i);
     if (!names.isEmpty())
     {
-      QString name = names.at(0).trimmed();
-      effect_names.append(name);
+      const QString l_name = names.at(0).trimmed();
+      effect_names.append(l_name);
+      AOButton *l_button = ui_effects.at(i - 1);
+      l_button->setProperty("effect_name", l_name);
+      Q_EMIT l_button->toggled(l_button->isChecked());
     }
   }
 }
@@ -1236,15 +1240,16 @@ void Courtroom::load_shouts()
 
   for (int i = 0; i < ui_shouts.size(); ++i)
   {
-    ui_shouts[i] = new AOButton(this, ao_app);
-    ui_shouts[i]->setProperty("shout_id", i + 1);
-    ui_shouts[i]->stackUnder(ui_shout_up);
-    ui_shouts[i]->stackUnder(ui_shout_down);
-  }
+    AOButton *l_button = new AOButton(this, ao_app);
+    ui_shouts.replace(i, l_button);
+    l_button->setCheckable(true);
+    l_button->setProperty("shout_id", i + 1);
+    l_button->stackUnder(ui_shout_up);
+    l_button->stackUnder(ui_shout_down);
 
-  // And connect their actions
-  for (auto &shout : ui_shouts)
-    connect(shout, SIGNAL(clicked(bool)), this, SLOT(on_shout_clicked()));
+    connect(l_button, SIGNAL(clicked(bool)), this, SLOT(on_shout_button_clicked(bool)));
+    connect(l_button, SIGNAL(toggled(bool)), this, SLOT(on_shout_button_toggled(bool)));
+  }
 
   // And add names
   shout_names.clear();
@@ -1255,8 +1260,11 @@ void Courtroom::load_shouts()
     {
       qDebug() << "SHOUT " << name << " " << ui_shouts[i - 1];
       shout_names.append(name);
-      widget_names[name] = ui_shouts[i - 1];
-      ui_shouts[i - 1]->setObjectName(name);
+      AOButton *l_button = ui_shouts.at(i - 1);
+      widget_names.insert(name, l_button);
+      l_button->setObjectName(name);
+      l_button->setProperty("shout_name", name);
+      Q_EMIT l_button->toggled(l_button->isChecked());
     }
   }
   qDebug() << widget_names;
@@ -1387,11 +1395,6 @@ void Courtroom::set_dropdowns()
 
 void Courtroom::set_font(QWidget *widget, QString p_identifier)
 {
-  set_font(widget, p_identifier, "");
-}
-
-void Courtroom::set_font(QWidget *widget, QString p_identifier, QString override_color)
-{
   QString design_file = fonts_ini;
   QString class_name = widget->metaObject()->className();
 
@@ -1409,32 +1412,22 @@ void Courtroom::set_font(QWidget *widget, QString p_identifier, QString override
   }
   widget->setFont(QFont(font_name, f_weight));
 
-  if (override_color.isEmpty())
-  {
-    QString color = ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
-    if (color.isEmpty())
-      color = "255, 255, 255";
-    override_color = "rgba(" + color + ", 255)";
-  }
+  QString font_color = ao_app->read_theme_ini(p_identifier + "_color", "courtroom_fonts.ini");
+  if (font_color.isEmpty())
+    font_color = "255, 255, 255";
+  QString color = "rgba(" + font_color + ", 255)";
 
   int bold = ao_app->get_font_property(p_identifier + "_bold", design_file);
   QString is_bold = (bold == 1 ? "bold" : "");
 
-  QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" + "color: " + override_color +
-                               ";\n"
-                               "font: " +
-                               is_bold + "; }";
+  QString style_sheet_string = class_name + " { " + "background-color: rgba(0, 0, 0, 0);\n" + "color: " + color +
+                               ";\n" + "font: " + is_bold + ";" + " }";
   widget->setStyleSheet(style_sheet_string);
 }
 
 void Courtroom::set_drtextedit_font(DRTextEdit *widget, QString p_identifier)
 {
-  set_drtextedit_font(widget, p_identifier, "");
-}
-
-void Courtroom::set_drtextedit_font(DRTextEdit *widget, QString p_identifier, QString override_color)
-{
-  set_font(widget, p_identifier, override_color);
+  set_font(widget, p_identifier);
   // Do outlines
   bool outline = (ao_app->get_font_property(p_identifier + "_outline", fonts_ini) == 1);
   widget->set_outline(outline);

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -170,6 +170,8 @@ void Courtroom::select_emote(int p_id)
   else
     ui_pre->setChecked(false);
 
+  select_default_sfx();
+
   ui_emote_dropdown->setCurrentIndex(current_emote);
 
   ui_ic_chat_message->setFocus();


### PR DESCRIPTION
A few methods that are run in ackMS update sprites that need not be updated. This causes needless delay in processing messages, given there is file I/O involved. This PR makes it so that these methods are replaced with methods that target specifically only what needs to be redrawn.