### PR TITLE
Added emote preview, emote and iniswap visibility changes

### DIFF
--- a/include/aoemotebutton.h
+++ b/include/aoemotebutton.h
@@ -19,11 +19,17 @@ public:
   AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y);
 
   int get_emote_number();
-  void set_emote_number(int p_emote_number);
+  void set_emote_number(int emote_number);
   void set_image(DREmote emote, bool enabled);
 
 signals:
-  void emote_clicked(int p_emote_number);
+  void emote_clicked(int emote_number);
+  void tooltip_requested(int emote_number, QPoint global_pos);
+  void mouse_left(int emote_number);
+
+  // QPushButton interface
+protected:
+  bool event(QEvent *event) override;
 
 private:
   AOApplication *ao_app = nullptr;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -326,6 +326,7 @@ private:
   int emote_columns = 5;
   int emote_rows = 2;
   int m_page_max_emote_count = 10;
+  int m_emote_preview_id = -1;
 
   //  inmchatlog_changed;
 
@@ -403,6 +404,8 @@ private:
   QVector<AOEmoteButton *> ui_emote_list;
   AOButton *ui_emote_left = nullptr;
   AOButton *ui_emote_right = nullptr;
+  AOImageDisplay *ui_emote_preview = nullptr;
+  AOCharMovie *ui_emote_preview_character = nullptr;
 
   QComboBox *ui_emote_dropdown = nullptr;
   QComboBox *ui_iniswap_dropdown = nullptr;
@@ -579,7 +582,9 @@ private slots:
 
   void select_emote(int p_id);
 
-  void on_emote_clicked(int p_id);
+  void on_emote_clicked(int id);
+  void on_emote_tooltip_requested(int id, QPoint global_pos);
+  void on_emote_mouse_left(int id);
 
   void on_emote_left_clicked();
   void on_emote_right_clicked();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -583,8 +583,8 @@ private slots:
   void select_emote(int p_id);
 
   void on_emote_clicked(int id);
-  void on_emote_tooltip_requested(int id, QPoint global_pos);
-  void on_emote_mouse_left(int id);
+  void show_emote_tooltip(int id, QPoint global_pos);
+  void hide_emote_tooltip(int id);
 
   void on_emote_left_clicked();
   void on_emote_right_clicked();

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -3,6 +3,7 @@
 #include "aoapplication.h"
 #include "file_functions.h"
 
+#include <QHelpEvent>
 #include <QLabel>
 
 AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y) : QPushButton(p_parent)
@@ -76,4 +77,23 @@ void AOEmoteButton::set_image(DREmote p_emote, bool p_enabled)
 void AOEmoteButton::on_clicked()
 {
   Q_EMIT emote_clicked(m_index);
+}
+
+bool AOEmoteButton::event(QEvent *event)
+{
+  switch (event->type())
+  {
+  case QEvent::ToolTip:
+    Q_EMIT tooltip_requested(m_index, dynamic_cast<QHelpEvent *>(event)->globalPos());
+    break;
+
+  case QEvent::HoverLeave:
+    Q_EMIT mouse_left(m_index);
+    break;
+
+  default:
+    break;
+  }
+
+  return QPushButton::event(event);
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -204,9 +204,9 @@ void Courtroom::enter_courtroom(int p_cid)
   select_default_sfx();
 
   ui_emotes->setHidden(is_spectating());
-  ui_emote_dropdown->setHidden(is_spectating());
-  ui_iniswap_dropdown->setHidden(is_spectating());
-  ui_ic_chat_message->setEnabled(!is_spectating());
+  ui_emote_dropdown->setDisabled(is_spectating());
+  ui_iniswap_dropdown->setDisabled(is_spectating());
+  ui_ic_chat_message->setDisabled(is_spectating());
 
   // restore line field focus
   l_current_field->setFocus();

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -670,10 +670,17 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_emote_right, "emote_right", COURTROOM_DESIGN_INI, ao_app);
   ui_emote_right->set_image("arrow_right.png");
 
-  set_size_and_pos(ui_emote_preview, "emote_preview", COURTROOM_DESIGN_INI, ao_app);
-  ui_emote_preview->set_image("emote_preview.png");
-  set_size_and_pos(ui_emote_preview_character, "emote_preview", COURTROOM_DESIGN_INI, ao_app);
-  ui_emote_preview_character->move(0, 0);
+  { // emote preview
+    pos_size_type l_emote_preview_size = ao_app->get_element_dimensions("emote_preview", COURTROOM_DESIGN_INI);
+    if (l_emote_preview_size.width <= 0 || l_emote_preview_size.height <= 0)
+    {
+      l_emote_preview_size.width = 320;
+      l_emote_preview_size.height = 192;
+    }
+    ui_emote_preview->resize(l_emote_preview_size.width, l_emote_preview_size.height);
+    ui_emote_preview->set_image("emote_preview.png");
+    ui_emote_preview_character->resize(l_emote_preview_size.width, l_emote_preview_size.height);
+  }
 
   set_size_and_pos(ui_emote_dropdown, "emote_dropdown", COURTROOM_DESIGN_INI, ao_app);
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -667,6 +667,14 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_emote_right, "emote_right", COURTROOM_DESIGN_INI, ao_app);
   ui_emote_right->set_image("arrow_right.png");
 
+  set_size_and_pos(ui_emote_right, "emote_right", COURTROOM_DESIGN_INI, ao_app);
+  ui_emote_right->set_image("arrow_right.png");
+
+  set_size_and_pos(ui_emote_preview, "emote_preview", COURTROOM_DESIGN_INI, ao_app);
+  ui_emote_preview->set_image("emote_preview.png");
+  set_size_and_pos(ui_emote_preview_character, "emote_preview", COURTROOM_DESIGN_INI, ao_app);
+  ui_emote_preview_character->move(0, 0);
+
   set_size_and_pos(ui_emote_dropdown, "emote_dropdown", COURTROOM_DESIGN_INI, ao_app);
 
   set_size_and_pos(ui_iniswap_dropdown, "iniswap_dropdown", COURTROOM_DESIGN_INI, ao_app);
@@ -959,13 +967,13 @@ void Courtroom::set_widgets()
   }
 
   // This is used to force already existing notepicker elements to reset their image and theme setting
-  for (AONotePicker *notepicker : ui_note_area->findChildren<AONotePicker*>())
+  for (AONotePicker *notepicker : ui_note_area->findChildren<AONotePicker *>())
   {
-    for (AOButton *button : notepicker->findChildren<AOButton*>())
+    for (AOButton *button : notepicker->findChildren<AOButton *>())
     {
       button->refresh_image();
     }
-    QLineEdit *f_line = notepicker->findChild<QLineEdit*>();
+    QLineEdit *f_line = notepicker->findChild<QLineEdit *>();
     set_dropdown(f_line, "[LINE EDIT]");
   }
 

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -81,8 +81,8 @@ void Courtroom::construct_emote_page_layout()
     f_emote->set_emote_number(n);
 
     connect(f_emote, SIGNAL(emote_clicked(int)), this, SLOT(on_emote_clicked(int)));
-    connect(f_emote, SIGNAL(tooltip_requested(int, QPoint)), this, SLOT(on_emote_tooltip_requested(int, QPoint)));
-    connect(f_emote, SIGNAL(mouse_left(int)), this, SLOT(on_emote_mouse_left(int)));
+    connect(f_emote, SIGNAL(tooltip_requested(int, QPoint)), this, SLOT(show_emote_tooltip(int, QPoint)));
+    connect(f_emote, SIGNAL(mouse_left(int)), this, SLOT(hide_emote_tooltip(int)));
 
     ++x_mod_count;
 
@@ -116,6 +116,7 @@ void Courtroom::refresh_emote_page(const bool p_scroll_to_current_emote)
   const int l_emote_count = m_emote_list.length();
   for (AOEmoteButton *i_button : qAsConst(ui_emote_list))
     i_button->hide();
+  hide_emote_tooltip(m_emote_preview_id);
 
   const int l_page_count =
       qFloor(l_emote_count / m_page_max_emote_count) + bool(l_emote_count % m_page_max_emote_count);
@@ -199,13 +200,13 @@ void Courtroom::on_emote_clicked(int p_id)
   select_emote(p_id + m_page_max_emote_count * m_current_emote_page);
 }
 
-void Courtroom::on_emote_tooltip_requested(int p_id, QPoint p_global_pos)
+void Courtroom::show_emote_tooltip(int p_id, QPoint p_global_pos)
 {
-  const int l_real_id = p_id + m_page_max_emote_count * m_current_emote_page;
-  if (m_emote_preview_id != -1 || m_emote_preview_id == l_real_id)
+  if (m_emote_preview_id != -1 || m_emote_preview_id == p_id)
     return;
-  m_emote_preview_id = l_real_id;
-  const DREmote &l_emote = m_emote_list.at(m_emote_preview_id);
+  m_emote_preview_id = p_id;
+  const int l_real_id = p_id + m_page_max_emote_count * m_current_emote_page;
+  const DREmote &l_emote = m_emote_list.at(l_real_id);
   ui_emote_preview_character->set_mirrored(ui_flip->isChecked());
   ui_emote_preview_character->play_idle(l_emote.character, l_emote.dialog);
 
@@ -232,10 +233,9 @@ void Courtroom::on_emote_tooltip_requested(int p_id, QPoint p_global_pos)
   ui_emote_preview->show();
 }
 
-void Courtroom::on_emote_mouse_left(int p_id)
+void Courtroom::hide_emote_tooltip(int p_id)
 {
-  const int l_real_id = p_id + m_page_max_emote_count * m_current_emote_page;
-  if (m_emote_preview_id == -1 || m_emote_preview_id != l_real_id)
+  if (m_emote_preview_id == -1 || m_emote_preview_id != p_id)
     return;
   m_emote_preview_id = -1;
   ui_emote_preview->hide();

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -220,15 +220,15 @@ void Courtroom::on_emote_tooltip_requested(int p_id, QPoint p_global_pos)
 
   // position below cursor
   const int l_vertical_spacing = 8;
-  p_global_pos.setY(p_global_pos.y() + l_vertical_spacing);
+  QPoint l_final_global_pos(p_global_pos.x(), p_global_pos.y() + l_vertical_spacing);
 
-  if (l_screen_geometry.width() < ui_emote_preview->width() + p_global_pos.x())
-    p_global_pos.setX(p_global_pos.x() - ui_emote_preview->width());
+  if (l_screen_geometry.width() < ui_emote_preview->width() + l_final_global_pos.x())
+    l_final_global_pos.setX(p_global_pos.x() - ui_emote_preview->width());
 
-  if (l_screen_geometry.height() < ui_emote_preview->height() + p_global_pos.y())
-    p_global_pos.setY(p_global_pos.y() - ui_emote_preview->height() - l_vertical_spacing * 2);
+  if (l_screen_geometry.height() < ui_emote_preview->height() + l_final_global_pos.y())
+    l_final_global_pos.setY(p_global_pos.y() - ui_emote_preview->height() - l_vertical_spacing);
 
-  ui_emote_preview->move(p_global_pos);
+  ui_emote_preview->move(l_final_global_pos);
   ui_emote_preview->show();
 }
 

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -225,8 +225,8 @@ void Courtroom::on_emote_tooltip_requested(int p_id, QPoint p_global_pos)
   if (l_screen_geometry.width() < ui_emote_preview->width() + p_global_pos.x())
     p_global_pos.setX(p_global_pos.x() - ui_emote_preview->width());
 
-  if (l_screen_geometry.height() < ui_emote_preview->height() + p_global_pos.y() + l_vertical_spacing)
-    p_global_pos.setY(p_global_pos.y() - ui_emote_preview->height() - l_vertical_spacing);
+  if (l_screen_geometry.height() < ui_emote_preview->height() + p_global_pos.y())
+    p_global_pos.setY(p_global_pos.y() - ui_emote_preview->height() - l_vertical_spacing * 2);
 
   ui_emote_preview->move(p_global_pos);
   ui_emote_preview->show();


### PR DESCRIPTION
* Emote preview size can be changed by adding a `courtroom_design.ini` entry that list the position & size of `emote_preview` widget
* Emote and iniswap dropdowns are now disabled instead of hidden when spectating