### PR TITLE
Build QtApng plugin instead of downloading

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -260,11 +260,17 @@ jobs:
         cp ./bass.h ./DRO-Client/3rd/include/bass.h
         cp ./x64/libbass.so ./DRO-Client/3rd/x86_64/libbass.so
         
-    - name: Fetch QtApng external library
+    - name: Build QtApng external library
       shell: bash
       working-directory: ${{env.parentworkspace}}
       run: |
-        curl -L https://cdn.discordapp.com/attachments/422857337133596692/845396654642954260/libqapng.so -o libqapng.so
+        git clone https://github.com/Skycoder42/QtApng
+        cd QtApng
+        qmake
+        make -j2
+        cp plugins/imageformats/libqapng.so ..
+        cd ..
+        rm -r -f QtApng
         
     - name: Install Qt
       shell: bash

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -260,6 +260,16 @@ jobs:
         cp ./bass.h ./DRO-Client/3rd/include/bass.h
         cp ./x64/libbass.so ./DRO-Client/3rd/x86_64/libbass.so
         
+    - name: Install Qt
+      shell: bash
+      working-directory: ${{env.parentworkspace}}
+      run: |
+        sudo apt-get install build-essential
+        sudo apt-get install qt5-default qttools5-dev
+        sudo apt-get install libqt5designer5
+        sudo apt-get install git
+        sudo snap install discord
+        
     - name: Build QtApng external library
       shell: bash
       working-directory: ${{env.parentworkspace}}
@@ -271,16 +281,6 @@ jobs:
         cp plugins/imageformats/libqapng.so ..
         cd ..
         rm -r -f QtApng
-        
-    - name: Install Qt
-      shell: bash
-      working-directory: ${{env.parentworkspace}}
-      run: |
-        sudo apt-get install build-essential
-        sudo apt-get install qt5-default qttools5-dev
-        sudo apt-get install libqt5designer5
-        sudo apt-get install git
-        sudo snap install discord
         
     - name: Run qmake
       shell: bash


### PR DESCRIPTION
The official release of the plugin is based on Qt 5.14.1, incompatible with the older versions of Qt (specifically the one from Ubuntu 20.04)

This will always build the plugin based on the latest version of Ubuntu 20.04[at the time of writing] (or whatever current version is defined by the Github CLI)