### PR TITLE
Added character content url

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -117,9 +117,11 @@ public:
 public:
   QString get_character();
   QString get_character_ini();
+  QString get_character_content_url();
   void update_iniswap_list();
   void update_default_iniswap_item();
   void select_base_character_iniswap();
+  void refresh_character_content_url();
 
   // Set the showname of the client
   void set_showname(QString p_showname);
@@ -320,6 +322,7 @@ private:
   int char_rows = 9;
   int m_page_max_chr_count = 90;
 
+  QString m_character_content_url;
   QVector<DREmote> m_emote_list;
   int m_emote_id = 0;
   int m_current_emote_page = 0;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -181,6 +181,7 @@ void Courtroom::enter_courtroom(int p_cid)
   if (l_changed_chr)
     set_character_position(ao_app->get_char_side(l_chr_name));
   select_base_character_iniswap();
+  refresh_character_content_url();
 
   const int l_prev_emote_count = m_emote_list.count();
   m_emote_list = ao_app->get_emote_list(l_chr_name);

--- a/src/courtroom_character.cpp
+++ b/src/courtroom_character.cpp
@@ -7,8 +7,10 @@
 
 #include <QComboBox>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QPixmap>
+#include <QUrl>
 
 int Courtroom::get_character_id()
 {
@@ -31,6 +33,19 @@ QString Courtroom::get_character()
 QString Courtroom::get_character_ini()
 {
   return ao_config->character_ini(get_character());
+}
+
+QString Courtroom::get_character_content_url()
+{
+  QFile l_contentFile(ao_app->get_character_path(get_character_ini(), "CONTENT.txt"));
+  if (!l_contentFile.open(QIODevice::ReadOnly))
+    return nullptr;
+
+  const QUrl l_url(QString(l_contentFile.readAll()).simplified());
+  if (l_url.isRelative() || l_url.isLocalFile())
+    return nullptr;
+
+  return l_url.toString();
 }
 
 namespace
@@ -91,6 +106,15 @@ void Courtroom::select_base_character_iniswap()
     return;
   }
   ui_iniswap_dropdown->setCurrentText(l_current_chr);
+}
+
+void Courtroom::refresh_character_content_url()
+{
+  const QString l_new_content_url = get_character_content_url();
+  if (m_character_content_url == l_new_content_url)
+    return;
+  m_character_content_url = l_new_content_url;
+  send_ooc_packet("/files_set " + m_character_content_url);
 }
 
 void Courtroom::on_iniswap_dropdown_changed(int p_index)


### PR DESCRIPTION
If `CONTENT.txt` is present within the base folder of the character, it will read the file and send a slash command (`files_set`) to notify the server of the current character content link.