### PR TITLE
Implemented #210, miscellaneous changes

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -71,14 +71,17 @@ public:
   // QString get_demothings_path();
   QString get_sounds_path(QString p_file);
   QString get_music_path(QString p_song);
-  QString get_background_path(QString p_file);
-  QString get_default_background_path(QString p_file);
+  QString format_background_path(QString p_identifier);
+  QStringList get_available_background_identifier_list();
+  QString get_current_background_path();
   QString get_evidence_path(QString p_file);
 
   QString sanitize_path(QString p_file);
 
   QString find_asset_path(QStringList file_list, QStringList extension_list);
   QString find_asset_path(QStringList file_list);
+  QString find_asset_path(QString p_file, QStringList p_extension_list);
+  QString find_asset_path(QString p_file);
   QString find_theme_asset_path(QString file, QStringList extension_list);
   QString find_theme_asset_path(QString file);
 

--- a/include/aoconfig.h
+++ b/include/aoconfig.h
@@ -33,9 +33,9 @@ public:
   bool discord_hide_character() const;
   QString theme() const;
   QString gamemode() const;
-  bool manual_gamemode_enabled() const;
-  QString timeofday() const;
-  bool manual_timeofday_enabled() const;
+  bool is_manual_gamemode_enabled() const;
+  QString time_of_day() const;
+  bool is_manual_time_of_day_enabled() const;
   bool always_pre_enabled() const;
   int chat_tick_interval() const;
   int log_max_lines() const;
@@ -80,9 +80,9 @@ public slots:
   void set_discord_hide_character(const bool p_enabled);
   void set_theme(QString p_string);
   void set_gamemode(QString p_string);
-  void set_manual_gamemode(bool p_enabled);
-  void set_timeofday(QString p_string);
-  void set_manual_timeofday(bool p_enabled);
+  void set_manual_gamemode_enabled(bool p_enabled);
+  void set_time_of_day(QString p_string);
+  void set_manual_time_of_day_enabled(bool p_enabled);
   void set_always_pre(bool p_enabled);
   void set_chat_tick_interval(int p_number);
   void set_log_max_lines(int p_number);
@@ -125,8 +125,8 @@ signals:
   void theme_changed(QString);
   void gamemode_changed(QString);
   void manual_gamemode_changed(bool);
-  void timeofday_changed(QString);
-  void manual_timeofday_changed(bool);
+  void time_of_day_changed(QString);
+  void manual_time_of_day_changed(bool);
   void showname_changed(QString);
   void showname_placeholder_changed(QString);
   void character_ini_changed(QString base_character);

--- a/include/aoconfigpanel.h
+++ b/include/aoconfigpanel.h
@@ -44,7 +44,7 @@ private slots:
   void on_reload_theme_clicked();
   void on_theme_changed(QString);
   void on_gamemode_changed(QString);
-  void on_timeofday_changed(QString);
+  void on_time_of_day_changed(QString);
   void on_gamemode_index_changed(QString p_text);
   void on_timeofday_index_changed(QString p_text);
   void on_showname_placeholder_changed(QString p_text);

--- a/include/commondefs.h
+++ b/include/commondefs.h
@@ -3,6 +3,7 @@
 class QString;
 
 extern const QString BACKGROUND_BACKGROUNDS_INI;
+extern const QString BACKGROUND_DEFAULT_NAME;
 
 extern const QString BASE_CONFIG_INI;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -74,7 +74,10 @@ public:
 
   // sets the current background to argument. also does some checks to see if
   // it's a legacy bg
-  void set_background(QString p_background);
+  DRAreaBackground get_background();
+  void set_background(DRAreaBackground p_area_bg);
+  QString get_time_of_day();
+  void set_time_of_day(QString p_tod);
 
   void set_tick_rate(const int tick_rate);
 
@@ -93,7 +96,7 @@ public:
   void done_received();
 
   // sets desk and bg based on pos in chatmessage
-  void set_scene();
+  void update_background_scene();
 
   // sets text color based on text color in chatmessage
   void set_text_color();
@@ -339,7 +342,8 @@ private:
 
   int current_clock = -1;
 
-  QString current_background = "gs4";
+  DRAreaBackground m_background;
+  QString m_time_of_day;
 
   AOImageDisplay *ui_background = nullptr;
 

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -2,6 +2,7 @@
 #define DATATYPES_H
 
 #include <QDateTime>
+#include <QMap>
 
 class DREmote
 {
@@ -15,6 +16,13 @@ public:
   int desk_modifier = -1;
   QString sound_file;
   int sound_delay = 0;
+};
+
+class DRAreaBackground
+{
+public:
+  QString background;
+  QMap<QString, QString> background_tod_map;
 };
 
 class DRChatRecord

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -34,7 +34,8 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
 
   connect(ao_config, SIGNAL(theme_changed(QString)), this, SLOT(handle_theme_modification()));
   connect(ao_config, SIGNAL(gamemode_changed(QString)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(timeofday_changed(QString)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(time_of_day_changed(QString)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_time_of_day_changed(bool)), this, SLOT(handle_theme_modification()));
   connect(ao_config_panel, SIGNAL(reload_theme()), this, SLOT(handle_theme_modification()));
   ao_config_panel->hide();
 

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -55,8 +55,8 @@ private:
   QString theme;
   QString gamemode;
   bool manual_gamemode;
-  QString timeofday;
-  bool manual_timeofday;
+  QString time_of_day;
+  bool manual_time_of_day;
   QString showname;
   QString showname_placeholder;
   QMap<QString, QString> ini_map;
@@ -126,8 +126,8 @@ void AOConfigPrivate::read_file()
 
   gamemode = cfg.value("gamemode").toString();
   manual_gamemode = cfg.value("manual_gamemode", false).toBool();
-  timeofday = cfg.value("timeofday").toString();
-  manual_timeofday = cfg.value("manual_timeofday", false).toBool();
+  time_of_day = cfg.value("timeofday").toString();
+  manual_time_of_day = cfg.value("manual_timeofday", false).toBool();
   always_pre = cfg.value("always_pre", true).toBool();
   chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
   log_max_lines = cfg.value("chatlog_limit", 100).toInt();
@@ -197,8 +197,8 @@ void AOConfigPrivate::save_file()
   cfg.setValue("theme", theme);
   cfg.setValue("gamemode", gamemode);
   cfg.setValue("manual_gamemode", manual_gamemode);
-  cfg.setValue("timeofday", timeofday);
-  cfg.setValue("manual_timeofday", manual_timeofday);
+  cfg.setValue("timeofday", time_of_day);
+  cfg.setValue("manual_timeofday", manual_time_of_day);
   cfg.setValue("always_pre", always_pre);
   cfg.setValue("chat_tick_interval", chat_tick_interval);
   cfg.setValue("chatlog_limit", log_max_lines);
@@ -385,7 +385,7 @@ QString AOConfig::gamemode() const
  *
  * @return Current manual gamemode status.
  */
-bool AOConfig::manual_gamemode_enabled() const
+bool AOConfig::is_manual_gamemode_enabled() const
 {
   return d->manual_gamemode;
 }
@@ -396,9 +396,9 @@ bool AOConfig::manual_gamemode_enabled() const
  *
  * @return Current gamemode, or empty string if not set.
  */
-QString AOConfig::timeofday() const
+QString AOConfig::time_of_day() const
 {
-  return d->timeofday;
+  return d->time_of_day;
 }
 
 /**
@@ -411,9 +411,9 @@ QString AOConfig::timeofday() const
  *
  * @return Current manual time of day status.
  */
-bool AOConfig::manual_timeofday_enabled() const
+bool AOConfig::is_manual_time_of_day_enabled() const
 {
-  return d->manual_timeofday;
+  return d->manual_time_of_day;
 }
 
 bool AOConfig::always_pre_enabled() const
@@ -641,7 +641,7 @@ void AOConfig::set_gamemode(QString p_string)
   d->invoke_signal("gamemode_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_manual_gamemode(bool p_enabled)
+void AOConfig::set_manual_gamemode_enabled(bool p_enabled)
 {
   if (d->manual_gamemode == p_enabled)
     return;
@@ -649,20 +649,20 @@ void AOConfig::set_manual_gamemode(bool p_enabled)
   d->invoke_signal("manual_gamemode_changed", Q_ARG(bool, p_enabled));
 }
 
-void AOConfig::set_timeofday(QString p_string)
+void AOConfig::set_time_of_day(QString p_string)
 {
-  if (d->timeofday == p_string)
+  if (d->time_of_day == p_string)
     return;
-  d->timeofday = p_string;
-  d->invoke_signal("timeofday_changed", Q_ARG(QString, p_string));
+  d->time_of_day = p_string;
+  d->invoke_signal("time_of_day_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_manual_timeofday(bool p_enabled)
+void AOConfig::set_manual_time_of_day_enabled(bool p_enabled)
 {
-  if (d->manual_timeofday == p_enabled)
+  if (d->manual_time_of_day == p_enabled)
     return;
-  d->manual_timeofday = p_enabled;
-  d->invoke_signal("manual_timeofday_changed", Q_ARG(bool, p_enabled));
+  d->manual_time_of_day = p_enabled;
+  d->invoke_signal("manual_time_of_day_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_always_pre(bool p_enabled)

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -111,8 +111,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(m_config, SIGNAL(theme_changed(QString)), this, SLOT(on_theme_changed(QString)));
   connect(m_config, SIGNAL(gamemode_changed(QString)), this, SLOT(on_gamemode_changed(QString)));
   connect(m_config, SIGNAL(manual_gamemode_changed(bool)), ui_manual_gamemode, SLOT(setChecked(bool)));
-  connect(m_config, SIGNAL(timeofday_changed(QString)), this, SLOT(on_theme_changed(QString)));
-  connect(m_config, SIGNAL(manual_timeofday_changed(bool)), ui_manual_timeofday, SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(time_of_day_changed(QString)), this, SLOT(on_theme_changed(QString)));
+  connect(m_config, SIGNAL(manual_time_of_day_changed(bool)), ui_manual_timeofday, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(showname_changed(QString)), ui_showname, SLOT(setText(QString)));
   connect(m_config, SIGNAL(showname_placeholder_changed(QString)), this,
           SLOT(on_showname_placeholder_changed(QString)));
@@ -172,9 +172,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(ui_theme, SIGNAL(currentIndexChanged(QString)), m_config, SLOT(set_theme(QString)));
   connect(ui_reload_theme, SIGNAL(clicked()), this, SLOT(on_reload_theme_clicked()));
   connect(ui_gamemode, SIGNAL(currentIndexChanged(QString)), this, SLOT(on_gamemode_index_changed(QString)));
-  connect(ui_manual_gamemode, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_gamemode(bool)));
+  connect(ui_manual_gamemode, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_gamemode_enabled(bool)));
   connect(ui_timeofday, SIGNAL(currentIndexChanged(QString)), this, SLOT(on_timeofday_index_changed(QString)));
-  connect(ui_manual_timeofday, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_timeofday(bool)));
+  connect(ui_manual_timeofday, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_time_of_day_enabled(bool)));
   connect(ui_showname, SIGNAL(editingFinished()), this, SLOT(showname_editing_finished()));
   connect(ui_always_pre, SIGNAL(toggled(bool)), m_config, SLOT(set_always_pre(bool)));
   connect(ui_chat_tick_interval, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_tick_interval(int)));
@@ -218,9 +218,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   // game
   ui_theme->setCurrentText(m_config->theme());
   ui_gamemode->setCurrentText(m_config->gamemode());
-  ui_manual_gamemode->setChecked(m_config->manual_gamemode_enabled());
-  ui_timeofday->setCurrentText(m_config->timeofday());
-  ui_manual_timeofday->setChecked(m_config->manual_timeofday_enabled());
+  ui_manual_gamemode->setChecked(m_config->is_manual_gamemode_enabled());
+  ui_timeofday->setCurrentText(m_config->time_of_day());
+  ui_manual_timeofday->setChecked(m_config->is_manual_time_of_day_enabled());
   ui_showname->setText(m_config->showname());
   on_showname_placeholder_changed(m_config->showname_placeholder());
   ui_always_pre->setChecked(m_config->always_pre_enabled());
@@ -264,12 +264,12 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_blank_blips->setChecked(m_config->blank_blips_enabled());
 
   // Widget enabling connections
-  ui_gamemode->setEnabled(m_config->manual_gamemode_enabled());
-  ui_timeofday->setEnabled(m_config->manual_timeofday_enabled());
+  ui_gamemode->setEnabled(m_config->is_manual_gamemode_enabled());
+  ui_timeofday->setEnabled(m_config->is_manual_time_of_day_enabled());
   // The manual gamemode checkbox enables browsing the gamemode combox
   // similarly with time of day
   connect(m_config, SIGNAL(manual_gamemode_changed(bool)), ui_gamemode, SLOT(setEnabled(bool)));
-  connect(m_config, SIGNAL(manual_timeofday_changed(bool)), ui_timeofday, SLOT(setEnabled(bool)));
+  connect(m_config, SIGNAL(manual_time_of_day_changed(bool)), ui_timeofday, SLOT(setEnabled(bool)));
 }
 
 void AOConfigPanel::showEvent(QShowEvent *event)
@@ -425,7 +425,7 @@ void AOConfigPanel::on_gamemode_changed(QString p_name)
   ui_gamemode->setCurrentText(p_name);
 }
 
-void AOConfigPanel::on_timeofday_changed(QString p_name)
+void AOConfigPanel::on_time_of_day_changed(QString p_name)
 {
   refresh_theme_list();
   refresh_gamemode_list();
@@ -442,7 +442,7 @@ void AOConfigPanel::on_gamemode_index_changed(QString p_text)
 void AOConfigPanel::on_timeofday_index_changed(QString p_text)
 {
   Q_UNUSED(p_text);
-  m_config->set_timeofday(ui_timeofday->currentData().toString());
+  m_config->set_time_of_day(ui_timeofday->currentData().toString());
 }
 
 void AOConfigPanel::on_showname_placeholder_changed(QString p_text)

--- a/src/aoscene.cpp
+++ b/src/aoscene.cpp
@@ -13,24 +13,11 @@ AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent), ao_
 
 void AOScene::set_image(QString p_image)
 {
-  QString target_path = ao_app->get_default_background_path(p_image);
-
-  // background specific path
-  QString background_path = ao_app->get_background_path(p_image);
-
-  for (auto &ext : animated_or_static_extensions())
-  {
-    QString full_background_path = ao_app->get_case_sensitive_path(background_path + ext);
-
-    if (file_exists(full_background_path))
-    {
-      target_path = full_background_path;
-      break;
-    }
-  }
+  const QString l_file_path =
+      ao_app->find_asset_path(ao_app->get_current_background_path() + "/" + p_image, animated_or_static_extensions());
 
   // do not update the movie if we're using the same file
-  if (m_reader->fileName() == target_path)
+  if (m_reader->fileName() == l_file_path)
     return;
 
   m_reader->stop();
@@ -38,7 +25,7 @@ void AOScene::set_image(QString p_image)
 
   m_reader = new QMovie(this);
   m_reader->setScaledSize(size());
-  m_reader->setFileName(target_path);
+  m_reader->setFileName(l_file_path);
   setMovie(m_reader);
   m_reader->start();
 }

--- a/src/commondefs.cpp
+++ b/src/commondefs.cpp
@@ -3,6 +3,7 @@
 #include <QString>
 
 const QString BACKGROUND_BACKGROUNDS_INI = "backgrounds.ini";
+const QString BACKGROUND_DEFAULT_NAME = "gs4";
 
 const QString BASE_CONFIG_INI = "/base/config.ini";
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -240,14 +240,14 @@ void Courtroom::set_window_title(QString p_title)
   this->setWindowTitle(p_title);
 }
 
-void Courtroom::set_scene()
+void Courtroom::update_background_scene()
 {
   // witness is default if pos is invalid
   QString f_background = "witnessempty";
   QString f_desk_image = "stand";
   QString f_desk_mod = m_chatmessage[CMDeskModifier];
   QString f_side = m_chatmessage[CMPosition];
-  QString ini_path = ao_app->get_background_path(BACKGROUND_BACKGROUNDS_INI);
+  QString ini_path = ao_app->format_background_path(BACKGROUND_BACKGROUNDS_INI);
 
   if (file_exists(ini_path))
   {
@@ -291,21 +291,22 @@ void Courtroom::set_scene()
       f_desk_image = "stand";
     }
 
-    bool has_all_desks = true;
+    bool l_all_desks_exists = true;
     QStringList alldesks{"defensedesk", "prosecutiondesk", "stand"};
-    for (const QString &desk : alldesks)
+    for (const QString &i_desk : alldesks)
     {
-      QString full_path = ao_app->find_asset_path({get_background_path(desk)}, animated_or_static_extensions());
-      if (full_path.isEmpty())
+      const QString l_desk_path = ao_app->find_asset_path(ao_app->get_current_background_path() + "/" + i_desk,
+                                                          animated_or_static_extensions());
+      if (l_desk_path.isEmpty())
       {
-        has_all_desks = false;
+        l_all_desks_exists = false;
         break;
       }
     }
 
     if (f_desk_mod == "0" || (f_desk_mod != "1" && (f_side == "jud" || f_side == "hld" || f_side == "hlp")))
       ui_vp_desk->hide();
-    else if (!has_all_desks)
+    else if (!l_all_desks_exists)
       ui_vp_desk->hide();
     else
       ui_vp_desk->show();
@@ -330,9 +331,26 @@ void Courtroom::set_taken(int n_char, bool p_taken)
   m_chr_list.replace(n_char, f_char);
 }
 
-void Courtroom::set_background(QString p_background)
+DRAreaBackground Courtroom::get_background()
 {
-  current_background = p_background;
+  return m_background;
+}
+
+void Courtroom::set_background(DRAreaBackground p_background)
+{
+  m_background = p_background;
+  update_background_scene();
+}
+
+QString Courtroom::get_time_of_day()
+{
+  return m_time_of_day;
+}
+
+void Courtroom::set_time_of_day(QString p_tod)
+{
+  m_time_of_day = p_tod;
+  update_background_scene();
 }
 
 void Courtroom::set_tick_rate(const int p_tick_rate)
@@ -868,7 +886,7 @@ void Courtroom::handle_chatmessage_2() // handles IC
 
   if (m_msg_is_first_person == false)
   {
-    set_scene();
+    update_background_scene();
   }
 
   int emote_mod = m_chatmessage[CMEmoteModifier].toInt();
@@ -2134,7 +2152,7 @@ void Courtroom::on_app_reload_theme_requested()
   setup_courtroom();
 
   // to update status on the background
-  set_background(current_background);
+  update_background_scene();
 }
 
 void Courtroom::on_back_to_lobby_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -351,6 +351,7 @@ void Courtroom::set_time_of_day(QString p_tod)
 {
   m_time_of_day = p_tod;
   setup_courtroom();
+  update_background_scene();
 }
 
 void Courtroom::set_tick_rate(const int p_tick_rate)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -350,7 +350,7 @@ QString Courtroom::get_time_of_day()
 void Courtroom::set_time_of_day(QString p_tod)
 {
   m_time_of_day = p_tod;
-  update_background_scene();
+  setup_courtroom();
 }
 
 void Courtroom::set_tick_rate(const int p_tick_rate)

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -83,6 +83,8 @@ QStringList AOApplication::get_available_background_identifier_list()
   return l_bg_list;
 }
 
+#include <QDebug>
+
 QString AOApplication::get_current_background_path()
 {
   QString l_bg_path;
@@ -93,7 +95,7 @@ QString AOApplication::get_current_background_path()
     for (QString &i_bg : l_bg_list)
     {
       i_bg = get_case_sensitive_path(format_background_path(i_bg));
-      if (i_bg.isEmpty())
+      if (!dir_exists(i_bg))
         continue;
       l_bg_path = i_bg;
       break;

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -251,8 +251,9 @@ QString AOApplication::find_theme_asset_path(QString p_file, QStringList p_exten
 
   // Only add gamemode and/or time of day if non empty.
   const QString l_gamemode = ao_config->gamemode();
-  const QString l_timeofday =
-      ao_config->is_manual_time_of_day_enabled() ? ao_config->time_of_day() : m_courtroom->get_time_of_day();
+  const QString l_timeofday = ao_config->is_manual_time_of_day_enabled() ? ao_config->time_of_day()
+                              : is_courtroom_constructed                 ? m_courtroom->get_time_of_day()
+                                                                         : nullptr;
   const QString l_theme_root = get_base_path() + "themes/" + ao_config->theme();
 
   if (!l_gamemode.isEmpty())

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -251,7 +251,8 @@ QString AOApplication::find_theme_asset_path(QString p_file, QStringList p_exten
 
   // Only add gamemode and/or time of day if non empty.
   const QString l_gamemode = ao_config->gamemode();
-  const QString l_timeofday = ao_config->time_of_day();
+  const QString l_timeofday =
+      ao_config->is_manual_time_of_day_enabled() ? ao_config->time_of_day() : m_courtroom->get_time_of_day();
   const QString l_theme_root = get_base_path() + "themes/" + ao_config->theme();
 
   if (!l_gamemode.isEmpty())

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -1,6 +1,7 @@
 #include "aoapplication.h"
 
 #include "aoconfig.h"
+#include "commondefs.h"
 #include "courtroom.h"
 #include "drpather.h"
 #include "file_functions.h"
@@ -48,21 +49,58 @@ QString AOApplication::get_music_path(QString p_song)
   return get_case_sensitive_path(path);
 }
 
-QString AOApplication::get_background_path(QString p_file)
+QString AOApplication::format_background_path(QString p_identifier)
 {
-  if (is_courtroom_constructed)
-  {
-    return get_case_sensitive_path(m_courtroom->get_background_path(p_file));
-  }
-  // this function being called when the courtroom isn't constructed makes no
-  // sense
-  return "";
+  return get_base_path() + "background/" + p_identifier;
 }
 
-QString AOApplication::get_default_background_path(QString p_file)
+QStringList AOApplication::get_available_background_identifier_list()
 {
-  QString path = get_base_path() + "background/gs4/" + p_file;
-  return get_case_sensitive_path(path);
+  QStringList l_bg_list;
+
+  if (is_courtroom_constructed)
+  {
+    const DRAreaBackground l_area_bg = m_courtroom->get_background();
+
+    const QMap<QString, QString> &l_bg_map = l_area_bg.background_tod_map;
+    if (ao_config->is_manual_time_of_day_enabled())
+    {
+      const QString l_manual_tod = ao_config->time_of_day();
+      if (!l_manual_tod.isEmpty() && l_bg_map.contains(l_manual_tod))
+        l_bg_list.append(l_bg_map.value(l_manual_tod));
+    }
+
+    const QString l_tod = m_courtroom->get_time_of_day();
+    if (!l_tod.isEmpty() && l_bg_map.contains(l_tod))
+      l_bg_list.append(l_bg_map.value(l_tod));
+
+    if (!l_area_bg.background.isEmpty())
+      l_bg_list.append(l_area_bg.background);
+
+    l_bg_list.append(BACKGROUND_DEFAULT_NAME);
+  }
+
+  return l_bg_list;
+}
+
+QString AOApplication::get_current_background_path()
+{
+  QString l_bg_path;
+
+  if (is_courtroom_constructed)
+  {
+    QStringList l_bg_list = get_available_background_identifier_list();
+    for (QString &i_bg : l_bg_list)
+    {
+      i_bg = get_case_sensitive_path(format_background_path(i_bg));
+      if (i_bg.isEmpty())
+        continue;
+      l_bg_path = i_bg;
+      break;
+    }
+  }
+
+  return l_bg_path;
 }
 
 QString AOApplication::get_evidence_path(QString p_file)
@@ -74,11 +112,6 @@ QString AOApplication::get_evidence_path(QString p_file)
     return default_path;
   else
     return alt_path;
-}
-
-QString Courtroom::get_background_path(QString p_file)
-{
-  return ao_app->get_base_path() + "background/" + current_background + "/" + p_file;
 }
 
 /**
@@ -181,6 +214,16 @@ QString AOApplication::find_asset_path(QStringList p_file_list)
   return find_asset_path(p_file_list, QStringList{""});
 }
 
+QString AOApplication::find_asset_path(QString p_file, QStringList p_extension_list)
+{
+  return find_asset_path(QStringList{p_file}, p_extension_list);
+}
+
+QString AOApplication::find_asset_path(QString p_file)
+{
+  return find_asset_path(QStringList{p_file});
+}
+
 /**
  * @brief Returns the first case-sensitive file in the theme folder that is
  * of the form name+extension, or empty string if it fails.
@@ -208,7 +251,7 @@ QString AOApplication::find_theme_asset_path(QString p_file, QStringList p_exten
 
   // Only add gamemode and/or time of day if non empty.
   const QString l_gamemode = ao_config->gamemode();
-  const QString l_timeofday = ao_config->timeofday();
+  const QString l_timeofday = ao_config->time_of_day();
   const QString l_theme_root = get_base_path() + "themes/" + ao_config->theme();
 
   if (!l_gamemode.isEmpty())

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -264,11 +264,23 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     if (l_content.size() < 1)
       return;
 
-    if (is_courtroom_constructed)
+    if (!is_courtroom_constructed)
+      return;
+
+    DRAreaBackground l_area_bg;
+    l_area_bg.background = l_content.at(0);
+
+    for (int i = 1; i < l_content.size(); ++i)
     {
-      m_courtroom->set_background(l_content.at(0));
-      m_courtroom->set_scene();
+      const QStringList l_tod_data = l_content.at(i).split("|", DR::SkipEmptyParts);
+      if (l_tod_data.size() < 2)
+        continue;
+      l_area_bg.background_tod_map.insert(l_tod_data.at(0), l_tod_data.at(1));
     }
+
+    qDebug() << l_area_bg.background << l_area_bg.background_tod_map;
+
+    m_courtroom->set_background(l_area_bg);
   }
   else if (l_header == "chat_tick_rate")
   {
@@ -376,7 +388,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
   {
     if (l_content.length() < 1)
       return;
-    if (ao_config->manual_gamemode_enabled())
+    if (ao_config->is_manual_gamemode_enabled())
       return;
     ao_config->set_gamemode(l_content.at(0));
   }
@@ -384,9 +396,9 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
   {
     if (l_content.length() < 1)
       return;
-    if (ao_config->manual_timeofday_enabled())
+    if (!is_courtroom_constructed)
       return;
-    ao_config->set_timeofday(l_content.at(0));
+    m_courtroom->set_time_of_day(l_content.at(0));
   }
   else if (l_header == "TR")
   {


### PR DESCRIPTION
* Implemented #210
* Renamed a couple `AOConfig` methods and variables
* Removed `get_background_path` from `Courtroom`
This had a severe case of circling around for no good reason. `AOApplication` -> `Courtroom` -> `AOApplication` for background pathing. This has been removed.