### PR TITLE
Renamed gamemode and time of day in config, ...

### DIFF
--- a/include/aoconfig.h
+++ b/include/aoconfig.h
@@ -32,10 +32,12 @@ public:
   bool discord_hide_server() const;
   bool discord_hide_character() const;
   QString theme() const;
+  QString gamemode() const;
   QString manual_gamemode() const;
   bool is_manual_gamemode_selection_enabled() const;
-  QString manual_time_of_day() const;
-  bool is_manual_time_of_day_selection_enabled() const;
+  QString timeofday() const;
+  QString manual_timeofday() const;
+  bool is_manual_timeofday_selection_enabled() const;
   bool always_pre_enabled() const;
   int chat_tick_interval() const;
   int log_max_lines() const;
@@ -79,10 +81,12 @@ public slots:
   void set_discord_hide_server(const bool p_enabled);
   void set_discord_hide_character(const bool p_enabled);
   void set_theme(QString p_string);
+  void set_gamemode(QString p_string);
   void set_manual_gamemode(QString p_string);
   void set_manual_gamemode_selection_enabled(bool p_enabled);
-  void set_manual_time_of_day(QString p_string);
-  void set_manual_time_of_day_selection_enabled(bool p_enabled);
+  void set_timeofday(QString p_string);
+  void set_manual_timeofday(QString p_string);
+  void set_manual_timeofday_selection_enabled(bool p_enabled);
   void set_always_pre(bool p_enabled);
   void set_chat_tick_interval(int p_number);
   void set_log_max_lines(int p_number);
@@ -123,10 +127,12 @@ signals:
 
   // game
   void theme_changed(QString);
+  void gamemode_changed(QString);
   void manual_gamemode_changed(QString);
   void manual_gamemode_selection_changed(bool);
-  void manual_time_of_day_changed(QString);
-  void manual_time_of_day_selection_changed(bool);
+  void timeofday_changed(QString);
+  void manual_timeofday_changed(QString);
+  void manual_timeofday_selection_changed(bool);
   void showname_changed(QString);
   void showname_placeholder_changed(QString);
   void character_ini_changed(QString base_character);

--- a/include/aoconfig.h
+++ b/include/aoconfig.h
@@ -32,10 +32,10 @@ public:
   bool discord_hide_server() const;
   bool discord_hide_character() const;
   QString theme() const;
-  QString gamemode() const;
-  bool is_manual_gamemode_enabled() const;
-  QString time_of_day() const;
-  bool is_manual_time_of_day_enabled() const;
+  QString manual_gamemode() const;
+  bool is_manual_gamemode_selection_enabled() const;
+  QString manual_time_of_day() const;
+  bool is_manual_time_of_day_selection_enabled() const;
   bool always_pre_enabled() const;
   int chat_tick_interval() const;
   int log_max_lines() const;
@@ -79,10 +79,10 @@ public slots:
   void set_discord_hide_server(const bool p_enabled);
   void set_discord_hide_character(const bool p_enabled);
   void set_theme(QString p_string);
-  void set_gamemode(QString p_string);
-  void set_manual_gamemode_enabled(bool p_enabled);
-  void set_time_of_day(QString p_string);
-  void set_manual_time_of_day_enabled(bool p_enabled);
+  void set_manual_gamemode(QString p_string);
+  void set_manual_gamemode_selection_enabled(bool p_enabled);
+  void set_manual_time_of_day(QString p_string);
+  void set_manual_time_of_day_selection_enabled(bool p_enabled);
   void set_always_pre(bool p_enabled);
   void set_chat_tick_interval(int p_number);
   void set_log_max_lines(int p_number);
@@ -123,10 +123,10 @@ signals:
 
   // game
   void theme_changed(QString);
-  void gamemode_changed(QString);
-  void manual_gamemode_changed(bool);
-  void time_of_day_changed(QString);
-  void manual_time_of_day_changed(bool);
+  void manual_gamemode_changed(QString);
+  void manual_gamemode_selection_changed(bool);
+  void manual_time_of_day_changed(QString);
+  void manual_time_of_day_selection_changed(bool);
   void showname_changed(QString);
   void showname_placeholder_changed(QString);
   void character_ini_changed(QString base_character);

--- a/include/aoconfigpanel.h
+++ b/include/aoconfigpanel.h
@@ -44,9 +44,13 @@ private slots:
   void on_reload_theme_clicked();
   void on_theme_changed(QString);
   void on_gamemode_changed(QString);
-  void on_time_of_day_changed(QString);
-  void on_gamemode_index_changed(QString p_text);
-  void on_timeofday_index_changed(QString p_text);
+  void on_manual_gamemode_changed(QString);
+  void on_manual_gamemode_index_changed(QString p_text);
+  void on_manual_gamemode_selection_changed(bool);
+  void on_timeofday_changed(QString);
+  void on_manual_timeofday_changed(QString);
+  void on_manual_timeofday_index_changed(QString p_text);
+  void on_manual_timeofday_selection_changed(bool);
   void on_showname_placeholder_changed(QString p_text);
   void on_log_is_topdown_changed(bool p_enabled);
   void on_device_current_index_changed(int p_index);
@@ -79,10 +83,12 @@ private:
   // game
   QComboBox *ui_theme = nullptr;
   QPushButton *ui_reload_theme = nullptr;
-  QComboBox *ui_gamemode = nullptr;
-  QCheckBox *ui_manual_gamemode = nullptr;
-  QComboBox *ui_timeofday = nullptr;
-  QCheckBox *ui_manual_timeofday = nullptr;
+  QLineEdit *ui_gamemode = nullptr;
+  QComboBox *ui_manual_gamemode = nullptr;
+  QCheckBox *ui_manual_gamemode_selection = nullptr;
+  QLineEdit *ui_timeofday = nullptr;
+  QComboBox *ui_manual_timeofday = nullptr;
+  QCheckBox *ui_manual_timeofday_selection = nullptr;
   QLineEdit *ui_showname = nullptr;
   QCheckBox *ui_always_pre = nullptr;
   QSpinBox *ui_chat_tick_interval = nullptr;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -76,8 +76,10 @@ public:
   // it's a legacy bg
   DRAreaBackground get_background();
   void set_background(DRAreaBackground p_area_bg);
+  QString get_gamemode();
+  void set_gamemode(QString p_gamemode);
   QString get_time_of_day();
-  void set_time_of_day(QString p_tod);
+  void set_time_of_day(QString p_time_of_day);
 
   void set_tick_rate(const int tick_rate);
 
@@ -343,6 +345,7 @@ private:
   int m_current_clock = -1;
 
   DRAreaBackground m_background;
+  QString m_gamemode;
   QString m_time_of_day;
 
   AOImageDisplay *ui_background = nullptr;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -78,8 +78,8 @@ public:
   void set_background(DRAreaBackground p_area_bg);
   QString get_gamemode();
   void set_gamemode(QString p_gamemode);
-  QString get_time_of_day();
-  void set_time_of_day(QString p_time_of_day);
+  QString get_timeofday();
+  void set_timeofday(QString p_time_of_day);
 
   void set_tick_rate(const int tick_rate);
 
@@ -346,7 +346,7 @@ private:
 
   DRAreaBackground m_background;
   QString m_gamemode;
-  QString m_time_of_day;
+  QString m_timeofday;
 
   AOImageDisplay *ui_background = nullptr;
 

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -193,16 +193,47 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QComboBox" name="gamemode">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QLineEdit" name="gamemode">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="font">
+              <font>
+               <italic>true</italic>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600; color:#0000ff;&quot;&gt;currently active&lt;/span&gt; gamemode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>&lt;default&gt;</string>
+             </property>
+             <property name="frame">
+              <bool>false</bool>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="manual_gamemode">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600; color:#0000ff;&quot;&gt;current manually selected&lt;/span&gt; gamemode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="QCheckBox" name="manual_gamemode">
+          <widget class="QCheckBox" name="manual_gamemode_selection">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -227,12 +258,44 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QComboBox" name="timeofday"/>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QLineEdit" name="timeofday">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="font">
+              <font>
+               <italic>true</italic>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600; color:#0000ff;&quot;&gt;currently active&lt;/span&gt; time of day.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>&lt;default&gt;</string>
+             </property>
+             <property name="frame">
+              <bool>false</bool>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="manual_timeofday">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600; color:#0000ff;&quot;&gt;current manually selected&lt;/span&gt; time of day.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="QCheckBox" name="manual_timeofday">
+          <widget class="QCheckBox" name="manual_timeofday_selection">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
              <horstretch>0</horstretch>

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -223,7 +223,7 @@
            <item>
             <widget class="QComboBox" name="manual_gamemode">
              <property name="enabled">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600; color:#0000ff;&quot;&gt;current manually selected&lt;/span&gt; gamemode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -33,9 +33,10 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   m_server_socket = new DRServerSocket(this);
 
   connect(ao_config, SIGNAL(theme_changed(QString)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(gamemode_changed(QString)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(time_of_day_changed(QString)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(manual_time_of_day_changed(bool)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_gamemode_changed(QString)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_gamemode_selection_changed(bool)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_time_of_day_changed(QString)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_time_of_day_selection_changed(bool)), this, SLOT(handle_theme_modification()));
   connect(ao_config_panel, SIGNAL(reload_theme()), this, SLOT(handle_theme_modification()));
   ao_config_panel->hide();
 

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -35,8 +35,8 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   connect(ao_config, SIGNAL(theme_changed(QString)), this, SLOT(handle_theme_modification()));
   connect(ao_config, SIGNAL(manual_gamemode_changed(QString)), this, SLOT(handle_theme_modification()));
   connect(ao_config, SIGNAL(manual_gamemode_selection_changed(bool)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(manual_time_of_day_changed(QString)), this, SLOT(handle_theme_modification()));
-  connect(ao_config, SIGNAL(manual_time_of_day_selection_changed(bool)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_timeofday_changed(QString)), this, SLOT(handle_theme_modification()));
+  connect(ao_config, SIGNAL(manual_timeofday_selection_changed(bool)), this, SLOT(handle_theme_modification()));
   connect(ao_config_panel, SIGNAL(reload_theme()), this, SLOT(handle_theme_modification()));
   ao_config_panel->hide();
 

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -56,9 +56,9 @@ private:
   QString gamemode;
   QString manual_gamemode;
   bool manual_gamemode_selection;
-  QString time_of_day;
-  QString manual_time_of_day;
-  bool manual_time_of_day_selection;
+  QString timeofday;
+  QString manual_timeofday;
+  bool manual_timeofday_selection;
   QString showname;
   QString showname_placeholder;
   QMap<QString, QString> ini_map;
@@ -128,8 +128,8 @@ void AOConfigPrivate::read_file()
 
   manual_gamemode = cfg.value("gamemode").toString();
   manual_gamemode_selection = cfg.value("manual_gamemode", false).toBool();
-  manual_time_of_day = cfg.value("timeofday").toString();
-  manual_time_of_day_selection = cfg.value("manual_timeofday", false).toBool();
+  manual_timeofday = cfg.value("timeofday").toString();
+  manual_timeofday_selection = cfg.value("manual_timeofday", false).toBool();
   always_pre = cfg.value("always_pre", true).toBool();
   chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
   log_max_lines = cfg.value("chatlog_limit", 100).toInt();
@@ -199,8 +199,8 @@ void AOConfigPrivate::save_file()
   cfg.setValue("theme", theme);
   cfg.setValue("gamemode", manual_gamemode);
   cfg.setValue("manual_gamemode", manual_gamemode_selection);
-  cfg.setValue("timeofday", manual_time_of_day);
-  cfg.setValue("manual_timeofday", manual_time_of_day_selection);
+  cfg.setValue("timeofday", manual_timeofday);
+  cfg.setValue("manual_timeofday", manual_timeofday_selection);
   cfg.setValue("always_pre", always_pre);
   cfg.setValue("chat_tick_interval", chat_tick_interval);
   cfg.setValue("chatlog_limit", log_max_lines);
@@ -366,6 +366,11 @@ QString AOConfig::theme() const
   return d->theme;
 }
 
+QString AOConfig::gamemode() const
+{
+  return d->gamemode;
+}
+
 /**
  * @brief Return the current gamemode. If no gamemode is set, return the
  * empty string.
@@ -392,15 +397,20 @@ bool AOConfig::is_manual_gamemode_selection_enabled() const
   return d->manual_gamemode_selection;
 }
 
+QString AOConfig::timeofday() const
+{
+  return d->timeofday;
+}
+
 /**
  * @brief Returns the current manual time of day. If no time of day is set, return
  * the empty string.
  *
  * @return Current manual time of day, or empty string if not set.
  */
-QString AOConfig::manual_time_of_day() const
+QString AOConfig::manual_timeofday() const
 {
-  return d->manual_time_of_day;
+  return d->manual_timeofday;
 }
 
 /**
@@ -413,9 +423,9 @@ QString AOConfig::manual_time_of_day() const
  *
  * @return Current manual time of day status.
  */
-bool AOConfig::is_manual_time_of_day_selection_enabled() const
+bool AOConfig::is_manual_timeofday_selection_enabled() const
 {
-  return d->manual_time_of_day_selection;
+  return d->manual_timeofday_selection;
 }
 
 bool AOConfig::always_pre_enabled() const
@@ -635,6 +645,14 @@ void AOConfig::set_theme(QString p_string)
   d->invoke_signal("theme_changed", Q_ARG(QString, p_string));
 }
 
+void AOConfig::set_gamemode(QString p_string)
+{
+  if (d->gamemode == p_string)
+    return;
+  d->gamemode = p_string;
+  d->invoke_signal("gamemode_changed", Q_ARG(QString, p_string));
+}
+
 void AOConfig::set_manual_gamemode(QString p_string)
 {
   if (d->manual_gamemode == p_string)
@@ -651,20 +669,28 @@ void AOConfig::set_manual_gamemode_selection_enabled(bool p_enabled)
   d->invoke_signal("manual_gamemode_selection_changed", Q_ARG(bool, p_enabled));
 }
 
-void AOConfig::set_manual_time_of_day(QString p_string)
+void AOConfig::set_timeofday(QString p_string)
 {
-  if (d->manual_time_of_day == p_string)
+  if (d->timeofday == p_string)
     return;
-  d->manual_time_of_day = p_string;
-  d->invoke_signal("manual_time_of_day_changed", Q_ARG(QString, p_string));
+  d->timeofday = p_string;
+  d->invoke_signal("timeofday_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_manual_time_of_day_selection_enabled(bool p_enabled)
+void AOConfig::set_manual_timeofday(QString p_string)
 {
-  if (d->manual_time_of_day_selection == p_enabled)
+  if (d->manual_timeofday == p_string)
     return;
-  d->manual_time_of_day_selection = p_enabled;
-  d->invoke_signal("manual_time_of_day_selection_changed", Q_ARG(bool, p_enabled));
+  d->manual_timeofday = p_string;
+  d->invoke_signal("manual_timeofday_changed", Q_ARG(QString, p_string));
+}
+
+void AOConfig::set_manual_timeofday_selection_enabled(bool p_enabled)
+{
+  if (d->manual_timeofday_selection == p_enabled)
+    return;
+  d->manual_timeofday_selection = p_enabled;
+  d->invoke_signal("manual_timeofday_selection_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_always_pre(bool p_enabled)

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -54,9 +54,11 @@ private:
   bool discord_hide_character = false;
   QString theme;
   QString gamemode;
-  bool manual_gamemode;
+  QString manual_gamemode;
+  bool manual_gamemode_selection;
   QString time_of_day;
-  bool manual_time_of_day;
+  QString manual_time_of_day;
+  bool manual_time_of_day_selection;
   QString showname;
   QString showname_placeholder;
   QMap<QString, QString> ini_map;
@@ -124,10 +126,10 @@ void AOConfigPrivate::read_file()
   if (theme.trimmed().isEmpty())
     theme = "default";
 
-  gamemode = cfg.value("gamemode").toString();
-  manual_gamemode = cfg.value("manual_gamemode", false).toBool();
-  time_of_day = cfg.value("timeofday").toString();
-  manual_time_of_day = cfg.value("manual_timeofday", false).toBool();
+  manual_gamemode = cfg.value("gamemode").toString();
+  manual_gamemode_selection = cfg.value("manual_gamemode", false).toBool();
+  manual_time_of_day = cfg.value("timeofday").toString();
+  manual_time_of_day_selection = cfg.value("manual_timeofday", false).toBool();
   always_pre = cfg.value("always_pre", true).toBool();
   chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
   log_max_lines = cfg.value("chatlog_limit", 100).toInt();
@@ -195,10 +197,10 @@ void AOConfigPrivate::save_file()
   cfg.setValue("discord_hide_character", discord_hide_character);
 
   cfg.setValue("theme", theme);
-  cfg.setValue("gamemode", gamemode);
-  cfg.setValue("manual_gamemode", manual_gamemode);
-  cfg.setValue("timeofday", time_of_day);
-  cfg.setValue("manual_timeofday", manual_time_of_day);
+  cfg.setValue("gamemode", manual_gamemode);
+  cfg.setValue("manual_gamemode", manual_gamemode_selection);
+  cfg.setValue("timeofday", manual_time_of_day);
+  cfg.setValue("manual_timeofday", manual_time_of_day_selection);
   cfg.setValue("always_pre", always_pre);
   cfg.setValue("chat_tick_interval", chat_tick_interval);
   cfg.setValue("chatlog_limit", log_max_lines);
@@ -370,9 +372,9 @@ QString AOConfig::theme() const
  *
  * @return Current gamemode, or empty string if not set.
  */
-QString AOConfig::gamemode() const
+QString AOConfig::manual_gamemode() const
 {
-  return d->gamemode;
+  return d->manual_gamemode;
 }
 
 /**
@@ -385,20 +387,20 @@ QString AOConfig::gamemode() const
  *
  * @return Current manual gamemode status.
  */
-bool AOConfig::is_manual_gamemode_enabled() const
+bool AOConfig::is_manual_gamemode_selection_enabled() const
 {
-  return d->manual_gamemode;
+  return d->manual_gamemode_selection;
 }
 
 /**
- * @brief Returns the current time of day. If no time of day is set, return
+ * @brief Returns the current manual time of day. If no time of day is set, return
  * the empty string.
  *
- * @return Current gamemode, or empty string if not set.
+ * @return Current manual time of day, or empty string if not set.
  */
-QString AOConfig::time_of_day() const
+QString AOConfig::manual_time_of_day() const
 {
-  return d->time_of_day;
+  return d->manual_time_of_day;
 }
 
 /**
@@ -411,9 +413,9 @@ QString AOConfig::time_of_day() const
  *
  * @return Current manual time of day status.
  */
-bool AOConfig::is_manual_time_of_day_enabled() const
+bool AOConfig::is_manual_time_of_day_selection_enabled() const
 {
-  return d->manual_time_of_day;
+  return d->manual_time_of_day_selection;
 }
 
 bool AOConfig::always_pre_enabled() const
@@ -606,7 +608,7 @@ void AOConfig::set_discord_presence(const bool p_enabled)
   if (d->discord_presence == p_enabled)
     return;
   d->discord_presence = p_enabled;
-  Q_EMIT d->invoke_signal("discord_presence_changed", Q_ARG(bool, d->discord_presence));
+  d->invoke_signal("discord_presence_changed", Q_ARG(bool, d->discord_presence));
 }
 
 void AOConfig::set_discord_hide_server(const bool p_enabled)
@@ -614,7 +616,7 @@ void AOConfig::set_discord_hide_server(const bool p_enabled)
   if (d->discord_hide_server == p_enabled)
     return;
   d->discord_hide_server = p_enabled;
-  Q_EMIT d->invoke_signal("discord_hide_server_changed", Q_ARG(bool, d->discord_hide_server));
+  d->invoke_signal("discord_hide_server_changed", Q_ARG(bool, d->discord_hide_server));
 }
 
 void AOConfig::set_discord_hide_character(const bool p_enabled)
@@ -622,7 +624,7 @@ void AOConfig::set_discord_hide_character(const bool p_enabled)
   if (d->discord_hide_character == p_enabled)
     return;
   d->discord_hide_character = p_enabled;
-  Q_EMIT d->invoke_signal("discord_hide_character_changed", Q_ARG(bool, d->discord_hide_character));
+  d->invoke_signal("discord_hide_character_changed", Q_ARG(bool, d->discord_hide_character));
 }
 
 void AOConfig::set_theme(QString p_string)
@@ -633,36 +635,36 @@ void AOConfig::set_theme(QString p_string)
   d->invoke_signal("theme_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_gamemode(QString p_string)
+void AOConfig::set_manual_gamemode(QString p_string)
 {
-  if (d->gamemode == p_string)
+  if (d->manual_gamemode == p_string)
     return;
-  d->gamemode = p_string;
-  d->invoke_signal("gamemode_changed", Q_ARG(QString, p_string));
+  d->manual_gamemode = p_string;
+  d->invoke_signal("manual_gamemode_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_manual_gamemode_enabled(bool p_enabled)
+void AOConfig::set_manual_gamemode_selection_enabled(bool p_enabled)
 {
-  if (d->manual_gamemode == p_enabled)
+  if (d->manual_gamemode_selection == p_enabled)
     return;
-  d->manual_gamemode = p_enabled;
-  d->invoke_signal("manual_gamemode_changed", Q_ARG(bool, p_enabled));
+  d->manual_gamemode_selection = p_enabled;
+  d->invoke_signal("manual_gamemode_selection_changed", Q_ARG(bool, p_enabled));
 }
 
-void AOConfig::set_time_of_day(QString p_string)
+void AOConfig::set_manual_time_of_day(QString p_string)
 {
-  if (d->time_of_day == p_string)
+  if (d->manual_time_of_day == p_string)
     return;
-  d->time_of_day = p_string;
-  d->invoke_signal("time_of_day_changed", Q_ARG(QString, p_string));
+  d->manual_time_of_day = p_string;
+  d->invoke_signal("manual_time_of_day_changed", Q_ARG(QString, p_string));
 }
 
-void AOConfig::set_manual_time_of_day_enabled(bool p_enabled)
+void AOConfig::set_manual_time_of_day_selection_enabled(bool p_enabled)
 {
-  if (d->manual_time_of_day == p_enabled)
+  if (d->manual_time_of_day_selection == p_enabled)
     return;
-  d->manual_time_of_day = p_enabled;
-  d->invoke_signal("manual_time_of_day_changed", Q_ARG(bool, p_enabled));
+  d->manual_time_of_day_selection = p_enabled;
+  d->invoke_signal("manual_time_of_day_selection_changed", Q_ARG(bool, p_enabled));
 }
 
 void AOConfig::set_always_pre(bool p_enabled)

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -659,6 +659,7 @@ void AOConfig::set_manual_gamemode(QString p_string)
     return;
   d->manual_gamemode = p_string;
   d->invoke_signal("manual_gamemode_changed", Q_ARG(QString, p_string));
+  set_manual_timeofday(nullptr);
 }
 
 void AOConfig::set_manual_gamemode_selection_enabled(bool p_enabled)

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -109,10 +109,10 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
 
   // game
   connect(m_config, SIGNAL(theme_changed(QString)), this, SLOT(on_theme_changed(QString)));
-  connect(m_config, SIGNAL(gamemode_changed(QString)), this, SLOT(on_gamemode_changed(QString)));
-  connect(m_config, SIGNAL(manual_gamemode_changed(bool)), ui_manual_gamemode, SLOT(setChecked(bool)));
-  connect(m_config, SIGNAL(time_of_day_changed(QString)), this, SLOT(on_theme_changed(QString)));
-  connect(m_config, SIGNAL(manual_time_of_day_changed(bool)), ui_manual_timeofday, SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(manual_gamemode_changed(QString)), this, SLOT(on_gamemode_changed(QString)));
+  connect(m_config, SIGNAL(manual_gamemode_selection_changed(bool)), ui_manual_gamemode, SLOT(setChecked(bool)));
+  connect(m_config, SIGNAL(manual_time_of_day_changed(QString)), this, SLOT(on_theme_changed(QString)));
+  connect(m_config, SIGNAL(manual_time_of_day_selection_changed(bool)), ui_manual_timeofday, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(showname_changed(QString)), ui_showname, SLOT(setText(QString)));
   connect(m_config, SIGNAL(showname_placeholder_changed(QString)), this,
           SLOT(on_showname_placeholder_changed(QString)));
@@ -172,9 +172,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(ui_theme, SIGNAL(currentIndexChanged(QString)), m_config, SLOT(set_theme(QString)));
   connect(ui_reload_theme, SIGNAL(clicked()), this, SLOT(on_reload_theme_clicked()));
   connect(ui_gamemode, SIGNAL(currentIndexChanged(QString)), this, SLOT(on_gamemode_index_changed(QString)));
-  connect(ui_manual_gamemode, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_gamemode_enabled(bool)));
+  connect(ui_manual_gamemode, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_gamemode_selection_enabled(bool)));
   connect(ui_timeofday, SIGNAL(currentIndexChanged(QString)), this, SLOT(on_timeofday_index_changed(QString)));
-  connect(ui_manual_timeofday, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_time_of_day_enabled(bool)));
+  connect(ui_manual_timeofday, SIGNAL(toggled(bool)), m_config, SLOT(set_manual_time_of_day_selection_enabled(bool)));
   connect(ui_showname, SIGNAL(editingFinished()), this, SLOT(showname_editing_finished()));
   connect(ui_always_pre, SIGNAL(toggled(bool)), m_config, SLOT(set_always_pre(bool)));
   connect(ui_chat_tick_interval, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_tick_interval(int)));
@@ -217,10 +217,10 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
 
   // game
   ui_theme->setCurrentText(m_config->theme());
-  ui_gamemode->setCurrentText(m_config->gamemode());
-  ui_manual_gamemode->setChecked(m_config->is_manual_gamemode_enabled());
-  ui_timeofday->setCurrentText(m_config->time_of_day());
-  ui_manual_timeofday->setChecked(m_config->is_manual_time_of_day_enabled());
+  ui_gamemode->setCurrentText(m_config->manual_gamemode());
+  ui_manual_gamemode->setChecked(m_config->is_manual_gamemode_selection_enabled());
+  ui_timeofday->setCurrentText(m_config->manual_time_of_day());
+  ui_manual_timeofday->setChecked(m_config->is_manual_time_of_day_selection_enabled());
   ui_showname->setText(m_config->showname());
   on_showname_placeholder_changed(m_config->showname_placeholder());
   ui_always_pre->setChecked(m_config->always_pre_enabled());
@@ -264,12 +264,12 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_blank_blips->setChecked(m_config->blank_blips_enabled());
 
   // Widget enabling connections
-  ui_gamemode->setEnabled(m_config->is_manual_gamemode_enabled());
-  ui_timeofday->setEnabled(m_config->is_manual_time_of_day_enabled());
+  ui_gamemode->setEnabled(m_config->is_manual_gamemode_selection_enabled());
+  ui_timeofday->setEnabled(m_config->is_manual_time_of_day_selection_enabled());
   // The manual gamemode checkbox enables browsing the gamemode combox
   // similarly with time of day
-  connect(m_config, SIGNAL(manual_gamemode_changed(bool)), ui_gamemode, SLOT(setEnabled(bool)));
-  connect(m_config, SIGNAL(manual_time_of_day_changed(bool)), ui_timeofday, SLOT(setEnabled(bool)));
+  connect(m_config, SIGNAL(manual_gamemode_selection_changed(bool)), ui_gamemode, SLOT(setEnabled(bool)));
+  connect(m_config, SIGNAL(manual_time_of_day_selection_changed(bool)), ui_timeofday, SLOT(setEnabled(bool)));
 }
 
 void AOConfigPanel::showEvent(QShowEvent *event)
@@ -349,11 +349,11 @@ void AOConfigPanel::refresh_timeofday_list()
   // decide path to look for times of day. This differs whether there is a
   // gamemode chosen or not
   QString path;
-  if (m_config->gamemode().isEmpty())
+  if (m_config->manual_gamemode().isEmpty())
     path = DRPather::get_application_path() + "/base/themes/" + m_config->theme() + "/times/";
   else
     path = DRPather::get_application_path() + "/base/themes/" + m_config->theme() + "/gamemodes/" +
-           m_config->gamemode() + "/times/";
+           m_config->manual_gamemode() + "/times/";
 
   // times of day
   for (const QString &i_folder : QDir(ao_app->get_case_sensitive_path(path)).entryList(QDir::Dirs))
@@ -436,13 +436,13 @@ void AOConfigPanel::on_time_of_day_changed(QString p_name)
 void AOConfigPanel::on_gamemode_index_changed(QString p_text)
 {
   Q_UNUSED(p_text);
-  m_config->set_gamemode(ui_gamemode->currentData().toString());
+  m_config->set_manual_gamemode(ui_gamemode->currentData().toString());
 }
 
 void AOConfigPanel::on_timeofday_index_changed(QString p_text)
 {
   Q_UNUSED(p_text);
-  m_config->set_time_of_day(ui_timeofday->currentData().toString());
+  m_config->set_manual_time_of_day(ui_timeofday->currentData().toString());
 }
 
 void AOConfigPanel::on_showname_placeholder_changed(QString p_text)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -326,6 +326,8 @@ void Courtroom::set_gamemode(QString p_gamemode)
     return;
   m_gamemode = p_gamemode;
   ao_config->set_gamemode(p_gamemode);
+  if (ao_config->is_manual_gamemode_selection_enabled())
+    return;
   setup_courtroom();
   update_background_scene();
 }
@@ -341,6 +343,8 @@ void Courtroom::set_timeofday(QString p_timeofday)
     return;
   m_timeofday = p_timeofday;
   ao_config->set_timeofday(p_timeofday);
+  if (ao_config->is_manual_timeofday_selection_enabled())
+    return;
   setup_courtroom();
   update_background_scene();
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -62,6 +62,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 
 Courtroom::~Courtroom()
 {
+  ao_config->set_gamemode(nullptr);
+  ao_config->set_timeofday(nullptr);
   stop_all_audio();
 }
 
@@ -323,20 +325,22 @@ void Courtroom::set_gamemode(QString p_gamemode)
   if (m_gamemode == p_gamemode)
     return;
   m_gamemode = p_gamemode;
+  ao_config->set_gamemode(p_gamemode);
   setup_courtroom();
   update_background_scene();
 }
 
-QString Courtroom::get_time_of_day()
+QString Courtroom::get_timeofday()
 {
-  return m_time_of_day;
+  return m_timeofday;
 }
 
-void Courtroom::set_time_of_day(QString p_time_of_day)
+void Courtroom::set_timeofday(QString p_timeofday)
 {
-  if (m_time_of_day == p_time_of_day)
+  if (m_timeofday == p_timeofday)
     return;
-  m_time_of_day = p_time_of_day;
+  m_timeofday = p_timeofday;
+  ao_config->set_timeofday(p_timeofday);
   setup_courtroom();
   update_background_scene();
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -247,7 +247,7 @@ void Courtroom::update_background_scene()
   QString f_desk_image = "stand";
   QString f_desk_mod = m_chatmessage[CMDeskModifier];
   QString f_side = m_chatmessage[CMPosition];
-  
+
   if (f_side == "def")
   {
     f_background = "defenseempty";
@@ -313,14 +313,30 @@ void Courtroom::set_background(DRAreaBackground p_background)
   update_background_scene();
 }
 
+QString Courtroom::get_gamemode()
+{
+  return m_gamemode;
+}
+
+void Courtroom::set_gamemode(QString p_gamemode)
+{
+  if (m_gamemode == p_gamemode)
+    return;
+  m_gamemode = p_gamemode;
+  setup_courtroom();
+  update_background_scene();
+}
+
 QString Courtroom::get_time_of_day()
 {
   return m_time_of_day;
 }
 
-void Courtroom::set_time_of_day(QString p_tod)
+void Courtroom::set_time_of_day(QString p_time_of_day)
 {
-  m_time_of_day = p_tod;
+  if (m_time_of_day == p_time_of_day)
+    return;
+  m_time_of_day = p_time_of_day;
   setup_courtroom();
   update_background_scene();
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -63,9 +63,9 @@ QStringList AOApplication::get_available_background_identifier_list()
     const DRAreaBackground l_area_bg = m_courtroom->get_background();
 
     const QMap<QString, QString> &l_bg_map = l_area_bg.background_tod_map;
-    if (ao_config->is_manual_time_of_day_enabled())
+    if (ao_config->is_manual_time_of_day_selection_enabled())
     {
-      const QString l_manual_tod = ao_config->time_of_day();
+      const QString l_manual_tod = ao_config->manual_time_of_day();
       if (!l_manual_tod.isEmpty() && l_bg_map.contains(l_manual_tod))
         l_bg_list.append(l_bg_map.value(l_manual_tod));
     }
@@ -252,10 +252,12 @@ QString AOApplication::find_theme_asset_path(QString p_file, QStringList p_exten
   QStringList l_path_list;
 
   // Only add gamemode and/or time of day if non empty.
-  const QString l_gamemode = ao_config->gamemode();
-  const QString l_timeofday = ao_config->is_manual_time_of_day_enabled() ? ao_config->time_of_day()
-                              : is_courtroom_constructed                 ? m_courtroom->get_time_of_day()
-                                                                         : nullptr;
+  const QString l_gamemode = ao_config->is_manual_gamemode_selection_enabled() ? ao_config->manual_gamemode()
+                             : is_courtroom_constructed                        ? m_courtroom->get_gamemode()
+                                                                               : nullptr;
+  const QString l_timeofday = ao_config->is_manual_time_of_day_selection_enabled() ? ao_config->manual_time_of_day()
+                              : is_courtroom_constructed                           ? m_courtroom->get_time_of_day()
+                                                                                   : nullptr;
   const QString l_theme_root = get_base_path() + "themes/" + ao_config->theme();
 
   if (!l_gamemode.isEmpty())

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -63,14 +63,14 @@ QStringList AOApplication::get_available_background_identifier_list()
     const DRAreaBackground l_area_bg = m_courtroom->get_background();
 
     const QMap<QString, QString> &l_bg_map = l_area_bg.background_tod_map;
-    if (ao_config->is_manual_time_of_day_selection_enabled())
+    if (ao_config->is_manual_timeofday_selection_enabled())
     {
-      const QString l_manual_tod = ao_config->manual_time_of_day();
+      const QString l_manual_tod = ao_config->manual_timeofday();
       if (!l_manual_tod.isEmpty() && l_bg_map.contains(l_manual_tod))
         l_bg_list.append(l_bg_map.value(l_manual_tod));
     }
 
-    const QString l_tod = m_courtroom->get_time_of_day();
+    const QString l_tod = m_courtroom->get_timeofday();
     if (!l_tod.isEmpty() && l_bg_map.contains(l_tod))
       l_bg_list.append(l_bg_map.value(l_tod));
 
@@ -255,9 +255,9 @@ QString AOApplication::find_theme_asset_path(QString p_file, QStringList p_exten
   const QString l_gamemode = ao_config->is_manual_gamemode_selection_enabled() ? ao_config->manual_gamemode()
                              : is_courtroom_constructed                        ? m_courtroom->get_gamemode()
                                                                                : nullptr;
-  const QString l_timeofday = ao_config->is_manual_time_of_day_selection_enabled() ? ao_config->manual_time_of_day()
-                              : is_courtroom_constructed                           ? m_courtroom->get_time_of_day()
-                                                                                   : nullptr;
+  const QString l_timeofday = ao_config->is_manual_timeofday_selection_enabled() ? ao_config->manual_timeofday()
+                              : is_courtroom_constructed                         ? m_courtroom->get_timeofday()
+                                                                                 : nullptr;
   const QString l_theme_root = get_base_path() + "themes/" + ao_config->theme();
 
   if (!l_gamemode.isEmpty())

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -388,9 +388,9 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
   {
     if (l_content.length() < 1)
       return;
-    if (ao_config->is_manual_gamemode_enabled())
+    if (!is_courtroom_constructed)
       return;
-    ao_config->set_gamemode(l_content.at(0));
+    m_courtroom->set_gamemode(l_content.at(0));
   }
   else if (l_header == "TOD")
   {

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -398,7 +398,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
       return;
     if (!is_courtroom_constructed)
       return;
-    m_courtroom->set_time_of_day(l_content.at(0));
+    m_courtroom->set_timeofday(l_content.at(0));
   }
   else if (l_header == "TR")
   {


### PR DESCRIPTION
* Renamed `gamemode` and `time_of_day` in `AOConfig` to `manual_gamemode` and `manual_time_of_day` respectively
* Courtroom now preserve the server's gamemode state (consistent with server time of day)