### PR TITLE
Character availability request packet

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -148,7 +148,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+        
     - name: Setup workspace
       shell: bash
       working-directory: ${{github.workspace}}
@@ -204,7 +204,7 @@ jobs:
       run: |
         ./Qt/5.14.2/clang_64/bin/qmake -makefile -o Makefile ./DRO-Client/dronline-client.pro -spec macx-clang "CONFIG+=x86_64" "CONFIG+=qtquickcompiler"
   
-    - name: Run Make
+    - name: Run make
       shell: bash
       working-directory: ${{env.parentworkspace}}
       run: |
@@ -254,6 +254,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update worker
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade
+        
     - name: Setup workspace
       shell: bash
       working-directory: ${{github.workspace}}

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -52,6 +52,7 @@ public:
   bool has_character_declaration_feature() const;
   bool has_showname_declaration_feature() const;
   bool has_chat_speed_feature() const;
+  bool has_character_availability_request_feature() const;
 
   ///////////////////////////////////////////
 
@@ -230,6 +231,7 @@ private:
   bool feature_showname = false;
   bool feature_chrini = false;
   bool feature_chat_speed = false;
+  bool feature_charscheck = false;
 
   ///////////////loading info///////////////////
   // player number, it's hardly used but might be needed for some old servers

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -194,6 +194,11 @@ bool AOApplication::has_chat_speed_feature() const
   return feature_chat_speed;
 }
 
+bool AOApplication::has_character_availability_request_feature() const
+{
+  return feature_charscheck;
+}
+
 void AOApplication::handle_theme_modification()
 {
   load_fonts();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3,6 +3,7 @@
 #include "aoapplication.h"
 #include "aoblipplayer.h"
 #include "aobutton.h"
+#include "aocharbutton.h"
 #include "aocharmovie.h"
 #include "aoconfig.h"
 #include "aoevidencedisplay.h"
@@ -229,7 +230,6 @@ void Courtroom::done_received()
   suppress_audio(true);
 
   set_char_select_page();
-
   set_char_select();
 
   show();
@@ -302,6 +302,10 @@ void Courtroom::set_taken(int n_char, bool p_taken)
   f_char.taken = p_taken;
 
   m_chr_list.replace(n_char, f_char);
+  AOCharButton *l_button = ui_char_button_list.at(n_char);
+  if (l_button->isVisible()) {
+    l_button->set_taken(p_taken);
+  }
 }
 
 DRAreaBackground Courtroom::get_background()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -229,8 +229,8 @@ void Courtroom::done_received()
 
   suppress_audio(true);
 
-  set_char_select_page();
   set_char_select();
+  set_char_select_page();
 
   show();
 
@@ -2134,9 +2134,12 @@ void Courtroom::on_change_character_clicked()
   suppress_audio(true);
 
   set_char_select();
+  set_char_select_page();
 
-  ui_char_select_background->show();
   ui_spectator->show();
+
+  if (ao_app->has_character_availability_request_feature())
+    ao_app->send_server_packet(DRPacket("CharsCheck"));
 }
 
 void Courtroom::on_app_reload_theme_requested()

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -61,6 +61,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     feature_showname = false;
     feature_chrini = false;
     feature_chat_speed = false;
+    feature_charscheck = false;
 
     send_server_packet(DRPacket("HI", {get_hdid()}));
   }
@@ -90,6 +91,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     feature_showname = l_content.contains("showname", Qt::CaseInsensitive);
     feature_chrini = l_content.contains("chrini", Qt::CaseInsensitive);
     feature_chat_speed = l_content.contains("chat_speed", Qt::CaseInsensitive);
+    feature_charscheck = l_content.contains("charscheck", Qt::CaseInsensitive);
   }
   else if (l_header == "PN")
   {


### PR DESCRIPTION
* Adds packet "CharsCheck", sent only to compatible servers. This packet is sent whenever the client opens their character select screen. Compatible servers promise they will send a "CharsCheck" packet to the client indicating the characters the current client can see.
* Makes the character choice buttons be updated whenever a "CharsCheck" packet is received from the server.