### PR TITLE
Fix frivolous chat rendering and chat arrow appearing if chatbox becomes invisible.

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1330,7 +1330,7 @@ void Courtroom::calculate_chat_tick_interval()
 void Courtroom::next_chat_letter()
 {
   const QString &f_message = m_chatmessage[CMMessage];
-  if (m_tick_step >= f_message.length())
+  if (m_tick_step >= f_message.length() || !ui_vp_chatbox->isVisible())
   {
     post_chat();
     return;
@@ -1489,9 +1489,9 @@ void Courtroom::post_chat()
 
   m_message_color_name = "";
   m_message_color_stack.clear();
-  if (!chatmessage_is_empty)
+  if (ui_vp_chatbox->isVisible())
     ui_vp_chat_arrow->restart();
-  ui_vp_chat_arrow->setHidden(chatmessage_is_empty);
+  ui_vp_chat_arrow->setVisible(ui_vp_chatbox->isVisible());
 }
 
 void Courtroom::play_sfx()


### PR DESCRIPTION
* Stop rendering message process if chatbox becomes invisible
* Prevent chat arrow from appearing if chatbox becomes invisible.

This mostly affects the case where a character is talking and during that the client reloads theme. The first one has a noticeable effect if the client has a low blip rate (e.g. 1), as they wil continue hearing blip rates despite them not seeing any message.