### PR TITLE
Fix unmaximizing giving wrong size if player launched with theme of different size to current one

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -739,6 +739,7 @@ private:
   // QWidget interface
 protected:
   void closeEvent(QCloseEvent *event) override;
+  virtual void changeEvent(QEvent *event) override;
 };
 
 template <typename T> void Courtroom::insert_widget_names(QVector<QString> &p_widget_names, QVector<T *> &p_widgets)

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -220,6 +220,10 @@ signals:
   void closing();
 
 private:
+  bool m_first_theme_loading = true;
+  QSize m_default_size;
+  bool m_is_maximized = false;
+
   AOApplication *ao_app = nullptr;
   AOConfig *ao_config = nullptr;
 
@@ -738,6 +742,7 @@ private:
 
   // QWidget interface
 protected:
+  void changeEvent(QEvent *) override;
   void closeEvent(QCloseEvent *event) override;
 };
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -739,7 +739,6 @@ private:
   // QWidget interface
 protected:
   void closeEvent(QCloseEvent *event) override;
-  virtual void changeEvent(QEvent *event) override;
 };
 
 template <typename T> void Courtroom::insert_widget_names(QVector<QString> &p_widget_names, QVector<T *> &p_widgets)

--- a/include/lobby.h
+++ b/include/lobby.h
@@ -83,6 +83,10 @@ private slots:
   void on_about_clicked();
   void on_server_list_clicked(QModelIndex p_model);
   void on_chatfield_return_pressed();
+
+  // QWidget interface
+protected:
+  virtual void changeEvent(QEvent *event) override;
 };
 
 #endif // LOBBY_H

--- a/include/lobby.h
+++ b/include/lobby.h
@@ -83,10 +83,6 @@ private slots:
   void on_about_clicked();
   void on_server_list_clicked(QModelIndex p_model);
   void on_chatfield_return_pressed();
-
-  // QWidget interface
-protected:
-  virtual void changeEvent(QEvent *event) override;
 };
 
 #endif // LOBBY_H

--- a/include/theme.h
+++ b/include/theme.h
@@ -14,3 +14,4 @@ void set_text_alignment(QWidget *widget, QString identifier, QString ini_file, A
 void set_font(QWidget *widget, QString identifier, QString ini_file, AOApplication *ao_app);
 void set_drtextedit_font(DRTextEdit *widget, QString identifier, QString ini_file, AOApplication *ao_app);
 bool set_stylesheet(QWidget *widget, QString identifier, QString ini_file, AOApplication *ao_app);
+void center_widget_to_screen(QWidget *widget);

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -8,17 +8,12 @@
 #include "drpacket.h"
 #include "drserversocket.h"
 #include "lobby.h"
+#include "theme.h"
 #include "version.h"
 
 #include <QDir>
 #include <QFontDatabase>
 #include <QRegularExpression>
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-#include <QDesktopWidget>
-#else
-#include <QScreen>
-#endif
 
 const QString AOApplication::MASTER_NAME = "Master";
 const QString AOApplication::MASTER_HOST = "master.aceattorneyonline.com";
@@ -93,19 +88,7 @@ void AOApplication::construct_lobby()
 
   m_lobby = new Lobby(this);
   is_lobby_constructed = true;
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-  QRect screen_geometry = QApplication::desktop()->screenGeometry();
-#else
-  QScreen *screen = QApplication::screenAt(m_lobby->pos());
-  if (screen == nullptr)
-    return;
-  QRect screen_geometry = screen->geometry();
-#endif
-  int x = (screen_geometry.width() - m_lobby->width()) / 2;
-  int y = (screen_geometry.height() - m_lobby->height()) / 2;
-  m_lobby->move(x, y);
-
+  center_widget_to_screen(m_lobby);
   m_lobby->show();
 
   dr_discord->set_state(DRDiscord::State::Idle);
@@ -141,18 +124,7 @@ void AOApplication::construct_courtroom()
   connect(m_courtroom, SIGNAL(closing()), this, SLOT(on_courtroom_closing()));
   connect(m_courtroom, SIGNAL(destroyed()), this, SLOT(on_courtroom_destroyed()));
   is_courtroom_constructed = true;
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-  QRect screen_geometry = QApplication::desktop()->screenGeometry();
-#else
-  QScreen *screen = QApplication::screenAt(m_courtroom->pos());
-  if (screen == nullptr)
-    return;
-  QRect screen_geometry = screen->geometry();
-#endif
-  int x = (screen_geometry.width() - m_courtroom->width()) / 2;
-  int y = (screen_geometry.height() - m_courtroom->height()) / 2;
-  m_courtroom->move(x, y);
+  center_widget_to_screen(m_courtroom);
 }
 
 void AOApplication::destruct_courtroom()
@@ -253,19 +225,9 @@ void AOApplication::toggle_config_panel()
   ao_config_panel->setVisible(!ao_config_panel->isVisible());
   if (ao_config_panel->isVisible())
   {
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-    QRect screen_geometry = QApplication::desktop()->screenGeometry();
-#else
-    QScreen *screen = QApplication::screenAt(ao_config_panel->pos());
-    if (screen == nullptr)
-      return;
-    QRect screen_geometry = screen->geometry();
-#endif
-    int x = (screen_geometry.width() - ao_config_panel->width()) / 2;
-    int y = (screen_geometry.height() - ao_config_panel->height()) / 2;
     ao_config_panel->setFocus();
     ao_config_panel->raise();
-    ao_config_panel->move(x, y);
+    center_widget_to_screen(ao_config_panel);
   }
 }
 

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -107,14 +107,8 @@ void Courtroom::reset_char_select()
 void Courtroom::set_char_select()
 {
   pos_size_type f_charselect = ao_app->get_element_dimensions("char_select", COURTROOM_DESIGN_INI);
-
   if (f_charselect.width < 0 || f_charselect.height < 0)
-  {
-    qDebug() << "W: did not find courtroom width or height in courtroom_design.ini!";
-    this->resize(714, 668);
-  }
-  else
-    this->resize(f_charselect.width, f_charselect.height);
+    qWarning() << "warning: char_select not found or invalid within courtroom_design.ini";
 
   ui_char_select_background->resize(f_charselect.width, f_charselect.height);
   ui_char_select_background->set_image("charselect_background.png");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2227,10 +2227,21 @@ void Courtroom::ping_server()
   ao_app->send_server_packet(DRPacket("CH", {QString::number(m_chr_id)}));
 }
 
+void Courtroom::changeEvent(QEvent *event)
+{
+  QMainWindow::changeEvent(event);
+  if (event->type() == QEvent::WindowStateChange)
+  {
+    m_is_maximized = windowState().testFlag(Qt::WindowMaximized);
+    if (!m_is_maximized)
+      resize(m_default_size);
+  }
+}
+
 void Courtroom::closeEvent(QCloseEvent *event)
 {
-  Q_EMIT closing();
   QMainWindow::closeEvent(event);
+  Q_EMIT closing();
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -39,6 +39,7 @@
 #include <QScrollBar>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <QWindowStateChangeEvent>
 
 const int Courtroom::DEFAULT_WIDTH = 714;
 const int Courtroom::DEFAULT_HEIGHT = 668;
@@ -2231,6 +2232,19 @@ void Courtroom::closeEvent(QCloseEvent *event)
 {
   Q_EMIT closing();
   QMainWindow::closeEvent(event);
+}
+
+void Courtroom::changeEvent(QEvent* e )
+{
+  if (e->type() == QEvent::WindowStateChange)
+  {
+    QWindowStateChangeEvent* event = static_cast< QWindowStateChangeEvent* >( e );
+    const Qt::WindowStates oldState = event->oldState();
+    const Qt::WindowStates newState = this->windowState();
+
+    if (oldState == Qt::WindowMaximized && newState == Qt::WindowNoState)
+      resize(size());
+  }
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -39,7 +39,6 @@
 #include <QScrollBar>
 #include <QTimer>
 #include <QVBoxLayout>
-#include <QWindowStateChangeEvent>
 
 const int Courtroom::DEFAULT_WIDTH = 714;
 const int Courtroom::DEFAULT_HEIGHT = 668;
@@ -2232,19 +2231,6 @@ void Courtroom::closeEvent(QCloseEvent *event)
 {
   Q_EMIT closing();
   QMainWindow::closeEvent(event);
-}
-
-void Courtroom::changeEvent(QEvent* e )
-{
-  if (e->type() == QEvent::WindowStateChange)
-  {
-    QWindowStateChangeEvent* event = static_cast< QWindowStateChangeEvent* >( e );
-    const Qt::WindowStates oldState = event->oldState();
-    const Qt::WindowStates newState = this->windowState();
-
-    if (oldState == Qt::WindowMaximized && newState == Qt::WindowNoState)
-      resize(size());
-  }
 }
 
 void Courtroom::on_set_notes_clicked()

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -552,17 +552,16 @@ void Courtroom::set_widget_layers()
 void Courtroom::set_widgets()
 {
   pos_size_type f_courtroom = ao_app->get_element_dimensions("courtroom", COURTROOM_DESIGN_INI);
-
   if (f_courtroom.width < 0 || f_courtroom.height < 0)
   {
-    qDebug() << "W: did not find courtroom width or height in " << COURTROOM_DESIGN_INI;
+    qWarning() << "W: did not find courtroom width or height in " << COURTROOM_DESIGN_INI;
+    f_courtroom.width = DEFAULT_WIDTH;
+    f_courtroom.height = DEFAULT_HEIGHT;
+  }
 
-    resize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
-  }
-  else
-  {
-    resize(f_courtroom.width, f_courtroom.height);
-  }
+  setWindowState(Qt::WindowNoState);
+  resize(f_courtroom.width, f_courtroom.height);
+  center_widget_to_screen(this);
 
   ui_background->move(0, 0);
   ui_background->resize(size());

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -559,12 +559,20 @@ void Courtroom::set_widgets()
     f_courtroom.height = DEFAULT_HEIGHT;
   }
 
-  setWindowState(Qt::WindowNoState);
-  resize(f_courtroom.width, f_courtroom.height);
-  center_widget_to_screen(this);
+  m_default_size = QSize(f_courtroom.width, f_courtroom.height);
+  if (!m_is_maximized)
+  {
+    resize(m_default_size);
+  }
+
+  if (m_first_theme_loading)
+  {
+    m_first_theme_loading = false;
+    center_widget_to_screen(this);
+  }
 
   ui_background->move(0, 0);
-  ui_background->resize(size());
+  ui_background->resize(m_default_size);
   ui_background->set_image("courtroombackground.png");
 
   set_size_and_pos(ui_viewport, "viewport", COURTROOM_DESIGN_INI, ao_app);

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -19,7 +19,6 @@
 #include <QListWidget>
 #include <QMessageBox>
 #include <QProgressBar>
-#include <QWindowStateChangeEvent>
 
 Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 {
@@ -92,7 +91,9 @@ void Lobby::set_widgets()
 
   if (f_lobby.width < 0 || f_lobby.height < 0)
   {
-    qDebug() << "W: did not find lobby width or height in " << LOBBY_DESIGN_INI;
+    qWarning() << "W: did not find lobby width or height in " << LOBBY_DESIGN_INI;
+    f_lobby.width = 517;
+    f_lobby.height = 666;
 
     // Most common symptom of bad config files, missing assets, or misnamed
     // theme folder
@@ -107,13 +108,10 @@ void Lobby::set_widgets()
                 "3. If it is there, check that your current theme folder exists in "
                 "base/themes. According to base/config.ini, your current theme is " +
                 ao_config->theme());
-
-    this->resize(517, 666);
   }
-  else
-  {
-    this->resize(f_lobby.width, f_lobby.height);
-  }
+  setWindowState(Qt::WindowNoState);
+  resize(f_lobby.width, f_lobby.height);
+  center_widget_to_screen(this);
 
   set_size_and_pos(ui_background, "lobby", LOBBY_DESIGN_INI, ao_app);
   ui_background->set_image("lobbybackground.png");
@@ -408,17 +406,4 @@ void Lobby::set_player_count(int players_online, int max_players)
   if (l_text.contains(l_regex))
     l_text.replace(l_regex, "<a href=\"\\1\">\\1</a>");
   ui_description->setHtml(l_text.replace("\n", "<br />"));
-}
-
-void Lobby::changeEvent(QEvent* e)
-{
-  if (e->type() == QEvent::WindowStateChange)
-  {
-    QWindowStateChangeEvent* event = static_cast< QWindowStateChangeEvent* >( e );
-    const Qt::WindowStates oldState = event->oldState();
-    const Qt::WindowStates newState = this->windowState();
-
-    if (oldState == Qt::WindowMaximized && newState == Qt::WindowNoState)
-      resize(size());
-  }
 }

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -19,6 +19,7 @@
 #include <QListWidget>
 #include <QMessageBox>
 #include <QProgressBar>
+#include <QWindowStateChangeEvent>
 
 Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 {
@@ -407,4 +408,17 @@ void Lobby::set_player_count(int players_online, int max_players)
   if (l_text.contains(l_regex))
     l_text.replace(l_regex, "<a href=\"\\1\">\\1</a>");
   ui_description->setHtml(l_text.replace("\n", "<br />"));
+}
+
+void Lobby::changeEvent(QEvent* e)
+{
+  if (e->type() == QEvent::WindowStateChange)
+  {
+    QWindowStateChangeEvent* event = static_cast< QWindowStateChangeEvent* >( e );
+    const Qt::WindowStates oldState = event->oldState();
+    const Qt::WindowStates newState = this->windowState();
+
+    if (oldState == Qt::WindowMaximized && newState == Qt::WindowNoState)
+      resize(size());
+  }
 }

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -1,15 +1,22 @@
 #include "theme.h"
 
-// src
-#include "aoapplication.h"
-#include "datatypes.h"
-#include "drtextedit.h"
+// std
+#include <string>
 
 // qt
 #include <QDebug>
 #include <QFontDatabase>
 
-#include <string>
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+#include <QDesktopWidget>
+#else
+#include <QScreen>
+#endif
+
+// src
+#include "aoapplication.h"
+#include "datatypes.h"
+#include "drtextedit.h"
 
 void set_size_and_pos(QWidget *p_widget, QString p_identifier, QString p_ini_file, AOApplication *ao_app)
 {
@@ -105,4 +112,26 @@ bool set_stylesheet(QWidget *p_widget, QString p_identifier, QString p_ini_file,
   const QString p_style = ao_app->get_stylesheet(p_identifier, p_ini_file);
   p_widget->setStyleSheet(p_style);
   return !p_style.isEmpty();
+}
+
+/**
+ * @brief Center the widget on the screen it's resting in.
+ * @param widget The widget to center.
+ */
+void center_widget_to_screen(QWidget *p_widget)
+{
+  if (!p_widget || p_widget->parentWidget())
+    return;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+  QRect screen_geometry = QApplication::desktop()->screenGeometry();
+#else
+  QScreen *screen = QApplication::screenAt(p_widget->pos());
+  if (screen == nullptr)
+    return;
+  QRect screen_geometry = screen->geometry();
+#endif
+  int x = (screen_geometry.width() - p_widget->width()) / 2;
+  int y = (screen_geometry.height() - p_widget->height()) / 2;
+  p_widget->move(x, y);
 }


### PR DESCRIPTION
Steps of bug.
1. Join server with theme A.
2. Once logged in, switch to theme B, whose `courtroom` size is of different size from theme A
3. Maximize DRO
4. Unmaximize DRO
5. Now DRO has the size of courtroom from theme A rather than B. 