### PR TITLE
Add post-version to version identifiers

### DIFF
--- a/dronline-client.pro
+++ b/dronline-client.pro
@@ -3,7 +3,7 @@ QT += core gui widgets uitools network
 CONFIG += c++17
 
 TEMPLATE = app
-VERSION = 1.0.2.0
+VERSION = 1.1.0.0
 TARGET = dro-client
 
 RC_ICONS = icon.ico

--- a/include/version.h
+++ b/include/version.h
@@ -5,5 +5,6 @@ class QString;
 int get_release_version();
 int get_major_version();
 int get_minor_version();
+QString get_post_version();
 QString get_version_string();
 QString get_about_message();

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -13,17 +13,17 @@ int get_release_version()
 
 int get_major_version()
 {
-  return 0;
+  return 1;
 }
 
 int get_minor_version()
 {
-  return 2;
+  return 0;
 }
 
 QString get_post_version()
 {
-  return "";
+  return "b1";
 }
 
 QString get_version_string()

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -21,10 +21,20 @@ int get_minor_version()
   return 2;
 }
 
+QString get_post_version()
+{
+  return "";
+}
+
 QString get_version_string()
 {
-  return QString::number(get_release_version()) + "." + QString::number(get_major_version()) + "." +
-         QString::number(get_minor_version());
+  const QString post = get_post_version();
+  const QString prefix = (
+        QString::number(get_release_version()) + "." + QString::number(get_major_version()) + "." +
+        QString::number(get_minor_version()));
+  if (post.isEmpty())
+    return prefix;
+  return prefix + "-" + post;
 }
 
 QString get_resource_file_text(QString filename)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -28,13 +28,15 @@ QString get_post_version()
 
 QString get_version_string()
 {
-  const QString post = get_post_version();
-  const QString prefix = (
-        QString::number(get_release_version()) + "." + QString::number(get_major_version()) + "." +
-        QString::number(get_minor_version()));
-  if (post.isEmpty())
-    return prefix;
-  return prefix + "-" + post;
+  QString l_version = QString("%1.%2.%3").arg(get_release_version()).arg(get_major_version()).arg(get_minor_version());
+
+  const QString l_post = get_post_version();
+  if (!l_post.isEmpty())
+  {
+    l_version += QString("-" + l_post);
+  }
+
+  return l_version;
 }
 
 QString get_resource_file_text(QString filename)


### PR DESCRIPTION
Useful to internally mark development client versions (e.g. "b1").
Also bumped to 1.1.0-b1.