### PR TITLE
Use witness background/desk if positional background/desk unavailable

### DIFF
--- a/include/drmovie.h
+++ b/include/drmovie.h
@@ -21,6 +21,7 @@ public:
   void set_hide_on_done(bool);
 
   bool is_running();
+  bool is_valid();
   void start();
   void stop();
 

--- a/include/drmovie.h
+++ b/include/drmovie.h
@@ -38,6 +38,7 @@ private:
   bool m_hide_when_done = false;
 
   QString m_file_name;
+  bool m_file_exists = false;
   QMovie m_movie;
   int m_frame_count = 0;
   int m_frame_number = 0;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -250,8 +250,10 @@ void Courtroom::set_window_title(QString p_title)
 void Courtroom::update_background_scene()
 {
   // witness is default if pos is invalid
-  QString f_background = "witnessempty";
-  QString f_desk_image = "stand";
+  QString f_default_background = "witnessempty";
+  QString f_default_desk_image = "stand";
+  QString f_background = f_default_background;
+  QString f_desk_image = f_default_desk_image;
   QString f_desk_mod = m_chatmessage[CMDeskModifier];
   QString f_side = m_chatmessage[CMPosition];
 
@@ -289,9 +291,13 @@ void Courtroom::update_background_scene()
   {
     ui_vp_desk->show();
     ui_vp_desk->set_image(f_desk_image);
+    if (!ui_vp_desk->is_valid())
+      ui_vp_desk->set_image(f_default_desk_image);
   }
 
   ui_vp_background->set_image(f_background);
+  if (!ui_vp_background->is_valid())
+    ui_vp_background->set_image(f_default_background);
 }
 
 DRAreaBackground Courtroom::get_background()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -250,12 +250,12 @@ void Courtroom::set_window_title(QString p_title)
 void Courtroom::update_background_scene()
 {
   // witness is default if pos is invalid
-  QString f_default_background = "witnessempty";
-  QString f_default_desk_image = "stand";
-  QString f_background = f_default_background;
-  QString f_desk_image = f_default_desk_image;
-  QString f_desk_mod = m_chatmessage[CMDeskModifier];
-  QString f_side = m_chatmessage[CMPosition];
+  const QString L_DEFAULT_BACK = "witnessempty";
+  const QString L_DEFAULT_FRONT = "stand";
+  const QString f_desk_mod = m_chatmessage[CMDeskModifier];
+  const QString f_side = m_chatmessage[CMPosition];
+  QString f_background = L_DEFAULT_BACK;
+  QString f_desk_image = L_DEFAULT_FRONT;
 
   if (f_side == "def")
   {
@@ -292,12 +292,18 @@ void Courtroom::update_background_scene()
     ui_vp_desk->show();
     ui_vp_desk->set_image(f_desk_image);
     if (!ui_vp_desk->is_valid())
-      ui_vp_desk->set_image(f_default_desk_image);
+    {
+      qWarning() << "warning: background missing file (" << m_background.background << f_side << f_desk_image << ")";
+      ui_vp_desk->set_image(L_DEFAULT_FRONT);
+    }
   }
 
   ui_vp_background->set_image(f_background);
   if (!ui_vp_background->is_valid())
-    ui_vp_background->set_image(f_default_background);
+  {
+    qWarning() << "warning: background missing file (" << m_background.background << f_side << f_background << ")";
+    ui_vp_background->set_image(L_DEFAULT_BACK);
+  }
 }
 
 DRAreaBackground Courtroom::get_background()

--- a/src/drmovie.cpp
+++ b/src/drmovie.cpp
@@ -103,7 +103,7 @@ void DRMovie::start()
   m_movie.setFileName(m_file_name);
   m_frame_count = m_movie.frameCount();
   m_frame_number = m_movie.currentFrameNumber();
-  if (m_movie.isValid())
+  if (is_valid())
   {
     m_movie.start();
     m_movie.setPaused(true);
@@ -203,4 +203,9 @@ void DRMovie::jump_next_frame()
   {
     m_movie.jumpToNextFrame();
   }
+}
+
+bool DRMovie::is_valid()
+{
+  return !m_movie.fileName().isEmpty() && m_movie.isValid();
 }

--- a/src/drmovie.cpp
+++ b/src/drmovie.cpp
@@ -1,6 +1,7 @@
 #include "drmovie.h"
 
 #include <QDebug>
+#include <QFile>
 
 DRMovie::DRMovie(QWidget *parent) : QLabel(parent)
 {
@@ -31,6 +32,7 @@ void DRMovie::set_file_name(QString p_file_name)
 {
   stop();
   m_file_name = p_file_name;
+  m_file_exists = QFile::exists(m_file_name);
 }
 
 /**
@@ -135,7 +137,6 @@ void DRMovie::stop()
 void DRMovie::resizeEvent(QResizeEvent *event)
 {
   QLabel::resizeEvent(event);
-
   paint_frame();
 }
 
@@ -207,5 +208,5 @@ void DRMovie::jump_next_frame()
 
 bool DRMovie::is_valid()
 {
-  return !m_movie.fileName().isEmpty() && m_movie.isValid();
+  return m_file_exists && m_movie.isValid();
 }

--- a/src/drscenemovie.cpp
+++ b/src/drscenemovie.cpp
@@ -1,3 +1,4 @@
+#include "commondefs.h"
 #include "drscenemovie.h"
 
 #include "aoapplication.h"

--- a/src/drscenemovie.cpp
+++ b/src/drscenemovie.cpp
@@ -1,4 +1,3 @@
-#include "commondefs.h"
 #include "drscenemovie.h"
 
 #include "aoapplication.h"


### PR DESCRIPTION
This is useful for background folders where by design all positional images are the same, as it reduces 5x the amount of files required for such a background folder.