### PR TITLE
Assume v110 server compatible

### DIFF
--- a/dronline-client.pro
+++ b/dronline-client.pro
@@ -11,9 +11,6 @@ RC_ICONS = icon.ico
 INCLUDEPATH += $$PWD/include $$PWD/3rd
 DEPENDPATH += $$PWD/include $$PWD/3rd
 
-DEFINES += DRO_ACKMS
-CONFIG(debug, debug|release):DEFINES += DR_DEV
-
 HEADERS += \
   src/aoapplication.h \
   src/aoblipplayer.h \

--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>487</width>
-    <height>439</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,7 +32,7 @@
    <item>
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -118,17 +118,41 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="server_alerts">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Server alerts</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QCheckBox" name="server_alerts">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Server alerts</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clear_notifications">
+           <property name="text">
+            <string>Reset Notifications</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_2">

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -154,34 +154,9 @@ DRDiscord *AOApplication::get_discord() const
   return dr_discord;
 }
 
-bool AOApplication::has_message_acknowledgement_feature() const
+bool AOApplication::is_server_compatible() const
 {
-  return feature_ackMS;
-}
-
-bool AOApplication::has_character_declaration_feature() const
-{
-  return feature_chrini;
-}
-
-bool AOApplication::has_showname_declaration_feature() const
-{
-  return feature_showname;
-}
-
-bool AOApplication::has_chat_speed_feature() const
-{
-  return feature_chat_speed;
-}
-
-bool AOApplication::has_character_availability_request_feature() const
-{
-  return feature_charscheck;
-}
-
-bool AOApplication::has_playable_video_feature() const
-{
-  return feature_playable_video;
+  return feature_version_compatible;
 }
 
 void AOApplication::handle_theme_modification()

--- a/src/aoapplication.h
+++ b/src/aoapplication.h
@@ -48,12 +48,7 @@ public:
 
   DRDiscord *get_discord() const;
 
-  bool has_message_acknowledgement_feature() const;
-  bool has_character_declaration_feature() const;
-  bool has_showname_declaration_feature() const;
-  bool has_chat_speed_feature() const;
-  bool has_character_availability_request_feature() const;
-  bool has_playable_video_feature() const;
+  bool is_server_compatible() const;
 
   ///////////////////////////////////////////
 
@@ -228,14 +223,7 @@ private:
   bool is_courtroom_loaded = false;
 
   ///////////////server metadata////////////////
-#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
-  bool feature_ackMS = false;
-#endif
-  bool feature_showname = false;
-  bool feature_chrini = false;
-  bool feature_chat_speed = false;
-  bool feature_charscheck = false;
-  bool feature_playable_video = false;
+  bool feature_version_compatible = false;
 
   ///////////////loading info///////////////////
   // player number, it's hardly used but might be needed for some old servers

--- a/src/aoconfig.h
+++ b/src/aoconfig.h
@@ -22,6 +22,7 @@ public:
 
   // getters
   bool autosave() const;
+  bool display_notification(QString message) const;
   QString username() const;
   QString showname() const;
   QString showname_placeholder() const;
@@ -75,6 +76,8 @@ public slots:
   // setters
 public slots:
   void set_autosave(bool p_enabled);
+  void clear_notification_filter();
+  void filter_notification(QString message);
   void set_username(QString p_string);
   void set_showname(QString p_string);
   void set_showname_placeholder(QString p_string);

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -41,6 +41,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_close = AO_GUI_WIDGET(QPushButton, "close");
   ui_autosave = AO_GUI_WIDGET(QCheckBox, "autosave");
 
+  // notifications
+  ui_clear_notifications = AO_GUI_WIDGET(QPushButton, "clear_notifications");
+
   // general
   ui_username = AO_GUI_WIDGET(QLineEdit, "username");
   ui_callwords = AO_GUI_WIDGET(QLineEdit, "callwords");
@@ -112,6 +115,9 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   // input
   // meta
   connect(m_config, SIGNAL(autosave_changed(bool)), ui_autosave, SLOT(setChecked(bool)));
+
+  // notifications
+  connect(ui_clear_notifications, SIGNAL(clicked()), m_config, SLOT(clear_notification_filter()));
 
   // general
   connect(m_config, SIGNAL(username_changed(QString)), ui_username, SLOT(setText(QString)));

--- a/src/aoconfigpanel.h
+++ b/src/aoconfigpanel.h
@@ -80,6 +80,9 @@ private:
   QPushButton *ui_close = nullptr;
   QCheckBox *ui_autosave = nullptr;
 
+  // notifications
+  QPushButton *ui_clear_notifications = nullptr;
+
   // general
   QLineEdit *ui_username = nullptr;
   QLineEdit *ui_callwords = nullptr;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -673,9 +673,7 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   for (int i = 0; i < MESSAGE_SIZE; ++i)
     m_chatmessage[i] = p_contents[i];
 
-  // TODO: Remove the second part of the OR by 1.2.0
-  m_hide_character = (m_chatmessage[CMShowCharacter].toInt()
-                      || m_chatmessage[CMEmote] == "../../misc/blank");
+  m_hide_character = m_chatmessage[CMShowCharacter].toInt();
   m_play_pre = false;
   m_play_zoom = false;
   const int l_emote_mod = m_chatmessage[CMEmoteModifier].toInt();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -673,7 +673,9 @@ void Courtroom::handle_chatmessage(QStringList p_contents)
   for (int i = 0; i < MESSAGE_SIZE; ++i)
     m_chatmessage[i] = p_contents[i];
 
-  m_hide_character = m_chatmessage[CMShowCharacter].toInt();
+  // TODO: Remove the second part of the OR by 1.2.0
+  m_hide_character = (m_chatmessage[CMShowCharacter].toInt()
+                      || m_chatmessage[CMEmote] == "../../misc/blank");
   m_play_pre = false;
   m_play_zoom = false;
   const int l_emote_mod = m_chatmessage[CMEmoteModifier].toInt();

--- a/src/debug_functions.cpp
+++ b/src/debug_functions.cpp
@@ -6,20 +6,20 @@
 void drMessageBox(QString p_message, bool p_error)
 {
   QMessageBox l_box;
-  l_box.setWindowTitle(p_error ? "Error" : "Notice");
-  l_box.setIcon(p_error ? QMessageBox::Critical : QMessageBox::Information);
+  l_box.setWindowTitle(p_error ? "Warning" : "Notice");
+  l_box.setIcon(p_error ? QMessageBox::Warning : QMessageBox::Information);
   l_box.setText(p_message);
   l_box.exec();
-}
-
-void call_error(QString p_message)
-{
-  drMessageBox(p_message, true);
-  qWarning() << "ERROR" << p_message;
 }
 
 void call_notice(QString p_message)
 {
   drMessageBox(p_message, false);
   qInfo() << p_message;
+}
+
+void call_warning(QString p_message)
+{
+  drMessageBox(p_message, true);
+  qWarning() << "error:" << p_message;
 }

--- a/src/debug_functions.cpp
+++ b/src/debug_functions.cpp
@@ -1,25 +1,39 @@
 #include "debug_functions.h"
 
+#include <QCheckBox>
 #include <QDebug>
 #include <QMessageBox>
 
-void drMessageBox(QString p_message, bool p_error)
+#include "aoconfig.h"
+
+void drMessageBox(QString p_message, bool p_is_warning)
 {
-  QMessageBox l_box;
-  l_box.setWindowTitle(p_error ? "Warning" : "Notice");
-  l_box.setIcon(p_error ? QMessageBox::Warning : QMessageBox::Information);
-  l_box.setText(p_message);
-  l_box.exec();
+  AOConfig config;
+  if (p_is_warning && !config.display_notification(p_message))
+    return;
+
+  QMessageBox message;
+  message.setWindowTitle(p_is_warning ? "Warning" : "Notice");
+  message.setIcon(p_is_warning ? QMessageBox::Warning : QMessageBox::Information);
+  message.setText(p_message);
+  QCheckBox *show_again = new QCheckBox(&message);
+  show_again->setText(QObject::tr("&Show this message again"));
+  show_again->setChecked(true);
+  message.setCheckBox(show_again);
+  message.exec();
+
+  if (!show_again->isChecked())
+    config.filter_notification(p_message);
 }
 
 void call_notice(QString p_message)
 {
-  drMessageBox(p_message, false);
   qInfo() << p_message;
+  drMessageBox(p_message, false);
 }
 
 void call_warning(QString p_message)
 {
-  drMessageBox(p_message, true);
   qWarning() << "error:" << p_message;
+  drMessageBox(p_message, true);
 }

--- a/src/debug_functions.h
+++ b/src/debug_functions.h
@@ -3,7 +3,7 @@
 
 class QString;
 
-void call_error(QString message);
 void call_notice(QString message);
+void call_warning(QString message);
 
 #endif // DEBUG_FUNCTIONS_H

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -301,6 +301,12 @@ void Lobby::on_connect_pressed()
 
 void Lobby::on_connect_released()
 {
+  if (!ao_app->is_server_compatible())
+  {
+    call_warning("You are connecting to an <b>incompatible</b> DRO server.<br />"
+                 "The client may not work properly, if at all.");
+  }
+
   ui_connect->set_image("connect.png");
   ao_app->send_server_packet(DRPacket("askchaa"));
 }

--- a/src/master_socket.cpp
+++ b/src/master_socket.cpp
@@ -114,35 +114,5 @@ void AOApplication::_p_handle_master_packet(DRPacket p_packet)
   {
     send_master_packet(DRPacket("ID", {"DRO", get_version_string()}));
     send_master_packet(DRPacket("HI", {get_hdid()}));
-
-    if (l_content.size() < 1)
-      return;
-
-    QStringList version_contents = l_content.at(0).split(".");
-
-    if (version_contents.size() < 3)
-      return;
-
-    int f_release = version_contents.at(0).toInt();
-    int f_major = version_contents.at(1).toInt();
-    int f_minor = version_contents.at(2).toInt();
-
-    if (get_release_version() > f_release)
-      return;
-    else if (get_release_version() == f_release)
-    {
-      if (get_major_version() > f_major)
-        return;
-      else if (get_major_version() == f_major)
-      {
-        if (get_minor_version() >= f_minor)
-          return;
-      }
-    }
-
-    call_notice("Outdated version! Your version: " + get_version_string() +
-                "\nPlease go to aceattorneyonline.com to update.");
-    destruct_courtroom();
-    destruct_lobby();
   }
 }

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -55,14 +55,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     if (l_content.size() == 0)
       return;
 
-#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
-    feature_ackMS = false;
-#endif
-    feature_showname = false;
-    feature_chrini = false;
-    feature_chat_speed = false;
-    feature_charscheck = false;
-    feature_playable_video = false;
+    feature_version_compatible = false;
 
     send_server_packet(DRPacket("HI", {get_hdid()}));
   }
@@ -86,14 +79,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
   }
   else if (l_header == "FL")
   {
-#ifdef DRO_ACKMS // TODO WARNING remove entire block on 1.0.0 release
-    feature_ackMS = l_content.contains("ackMS", Qt::CaseInsensitive);
-#endif
-    feature_showname = l_content.contains("showname", Qt::CaseInsensitive);
-    feature_chrini = l_content.contains("chrini", Qt::CaseInsensitive);
-    feature_chat_speed = l_content.contains("chat_speed", Qt::CaseInsensitive);
-    feature_charscheck = l_content.contains("charscheck", Qt::CaseInsensitive);
-    feature_playable_video = l_content.contains("playable_video", Qt::CaseInsensitive);
+    feature_version_compatible = l_content.contains("v110", Qt::CaseInsensitive);
   }
   else if (l_header == "PN")
   {


### PR DESCRIPTION
Resolve #283, #284

As issued, this removes multiple checks that the server should be assumed to be compatible with. If the server is not considered compatible, then it will warn the user as they attempt to join said server.

### FL
New argument(s): `v110`
`v110` The version that the server needs to support.