### PR TITLE
Added dynamic scaling to animated images

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -252,14 +252,13 @@ void Courtroom::set_window_title(QString p_title)
 
 void Courtroom::update_background_scene()
 {
-  const QString l_new_background_name = ao_app->get_current_background();
+  const QString l_prev_background_name = m_current_background_name;
+  m_current_background_name = ao_app->get_current_background();
 
-  m_is_legacy_background = false;
   // see TOD background list for why this method is called here
-  if (m_current_background_name.isEmpty() || m_current_background_name != l_new_background_name)
+  if (l_prev_background_name.isEmpty() || l_prev_background_name != m_current_background_name)
   {
-    m_current_background_name = l_new_background_name;
-
+    m_is_legacy_background = false;
     const QString l_positions_ini =
         ao_app->find_asset_path(ao_app->get_background_path(m_current_background_name) + "/" + "positions.ini");
     if (!l_positions_ini.isEmpty())
@@ -341,7 +340,12 @@ void Courtroom::update_legacy_background_scene()
 
   ui_vp_background->show();
   ui_vp_background->set_file_name(l_back_image);
+  ui_vp_background->set_play_once(false);
   ui_vp_background->start();
+  if (!ui_vp_background->is_valid())
+  {
+    ui_vp_background->hide();
+  }
 
   if (m_chatmessage[CMDeskModifier] == "0")
   {
@@ -351,7 +355,12 @@ void Courtroom::update_legacy_background_scene()
   {
     ui_vp_desk->show();
     ui_vp_desk->set_file_name(l_front_image);
+    ui_vp_desk->set_play_once(false);
     ui_vp_desk->start();
+    if (!ui_vp_desk->is_valid())
+    {
+      ui_vp_desk->hide();
+    }
   }
 }
 

--- a/src/drcharactermovie.cpp
+++ b/src/drcharactermovie.cpp
@@ -8,7 +8,7 @@
 DRCharacterMovie::DRCharacterMovie(QWidget *parent) : DRMovie(parent), ao_app(dynamic_cast<AOApplication *>(qApp))
 {
   Q_ASSERT(ao_app);
-  set_scale_to_height(true);
+  set_scale_mode(DRMovie::HeightScaling);
 }
 
 DRCharacterMovie::~DRCharacterMovie()

--- a/src/drmovie.cpp
+++ b/src/drmovie.cpp
@@ -145,8 +145,10 @@ void DRMovie::paint_frame()
   ScalingMode l_mode = m_scaling_mode;
   if (l_mode == DynamicScaling)
   {
-    const qreal l_width_factor = (qreal)m_current_pixmap.width() / qMax(width(), 1);
-    const qreal l_height_factor = (qreal)m_current_pixmap.height() / qMax(height(), 1);
+    const qreal l_width_factor =
+        (qreal)qMax(m_current_pixmap.width(), width()) / qMax(qMin(m_current_pixmap.width(), width()), 1);
+    const qreal l_height_factor =
+        (qreal)qMax(m_current_pixmap.height(), height()) / qMax(qMin(m_current_pixmap.height(), height()), 1);
 
     if (l_width_factor < l_height_factor)
     {

--- a/src/drmovie.cpp
+++ b/src/drmovie.cpp
@@ -2,7 +2,6 @@
 
 #include <QDebug>
 #include <QFile>
-#include <QTransform>
 
 DRMovie::DRMovie(QWidget *parent) : QLabel(parent)
 {

--- a/src/drmovie.h
+++ b/src/drmovie.h
@@ -9,6 +9,14 @@ class DRMovie : public QLabel
   Q_OBJECT
 
 public:
+  enum ScalingMode
+  {
+    NoScaling,
+    WidthScaling,
+    HeightScaling,
+    DynamicScaling,
+  };
+
   explicit DRMovie(QWidget *parent = nullptr);
   ~DRMovie();
 
@@ -17,7 +25,7 @@ public:
 
   void set_play_once(bool);
   void set_mirrored(bool);
-  void set_scale_to_height(bool);
+  void set_scale_mode(ScalingMode);
   void set_hide_on_done(bool);
 
   bool is_running();
@@ -34,7 +42,7 @@ protected:
 private:
   bool m_play_once = false;
   bool m_mirrored = false;
-  bool m_scale_to_height = false;
+  ScalingMode m_scaling_mode = NoScaling;
   bool m_hide_when_done = false;
 
   QString m_file_name;

--- a/src/drmovie.h
+++ b/src/drmovie.h
@@ -11,11 +11,12 @@ class DRMovie : public QLabel
 public:
   enum ScalingMode
   {
-    NoScaling,
+    StretchScaling,
     WidthScaling,
     HeightScaling,
     DynamicScaling,
   };
+  Q_ENUM(ScalingMode)
 
   explicit DRMovie(QWidget *parent = nullptr);
   ~DRMovie();
@@ -42,7 +43,7 @@ protected:
 private:
   bool m_play_once = false;
   bool m_mirrored = false;
-  ScalingMode m_scaling_mode = NoScaling;
+  ScalingMode m_scaling_mode = StretchScaling;
   bool m_hide_when_done = false;
 
   QString m_file_name;

--- a/src/drscenemovie.cpp
+++ b/src/drscenemovie.cpp
@@ -6,7 +6,7 @@
 DRSceneMovie::DRSceneMovie(QWidget *parent) : DRMovie(parent), ao_app(dynamic_cast<AOApplication *>(qApp))
 {
   Q_ASSERT(ao_app);
-  set_scale_to_height(true);
+  set_scale_mode(DRMovie::DynamicScaling);
 }
 
 DRSceneMovie::~DRSceneMovie()


### PR DESCRIPTION
This should resolve the issue of background pictures either being too large in width or height, now dynamically pick either or depending on what would fit the viewport best.