### PR TITLE
Change syntax of audio track loop points files so file name is a key

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -462,9 +462,9 @@ void Courtroom::list_music()
   {
     DRAudiotrackMetadata l_track(i_song);
     QListWidgetItem *l_item = new QListWidgetItem(l_track.title(), ui_music_list);
-    l_item->setData(Qt::UserRole, l_track.file_name());
-    if (l_track.title() != l_track.file_name())
-      l_item->setToolTip(l_track.file_name());
+    l_item->setData(Qt::UserRole, l_track.filename());
+    if (l_track.title() != l_track.filename())
+      l_item->setToolTip(l_track.filename());
     const QString l_song_path = ao_app->find_asset_path({ao_app->get_music_path(i_song)}, audio_extensions());
     l_item->setBackground(l_song_path.isEmpty() ? l_missing_song_brush : l_song_brush);
   }
@@ -1603,7 +1603,7 @@ void Courtroom::handle_song(QStringList p_contents)
 
     if (ao_config->log_is_recording_enabled())
     {
-      save_textlog(l_showname + " has played a song: " + l_song_meta.file_name());
+      save_textlog(l_showname + " has played a song: " + l_song_meta.filename());
     }
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1603,7 +1603,7 @@ void Courtroom::handle_song(QStringList p_contents)
 
     if (ao_config->log_is_recording_enabled())
     {
-      save_textlog(l_showname + " has played a song: " + l_song_meta.title());
+      save_textlog(l_showname + " has played a song: " + l_song_meta.filename());
     }
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1603,7 +1603,7 @@ void Courtroom::handle_song(QStringList p_contents)
 
     if (ao_config->log_is_recording_enabled())
     {
-      save_textlog(l_showname + " has played a song: " + l_song_meta.filename());
+      save_textlog(l_showname + " has played a song: " + l_song_meta.title());
     }
   }
 

--- a/src/draudiotrackmetadata.cpp
+++ b/src/draudiotrackmetadata.cpp
@@ -49,11 +49,21 @@ void DRAudiotrackMetadata::update_cache()
     utils::QSettingsKeyFetcher l_fetcher(l_settings);
 
     const QStringList l_audiotrack_name_list = l_settings.childGroups();
-    for (const QString &i_track_name : l_audiotrack_name_list)
+    for (const QString &i_section_name : l_audiotrack_name_list)
     {
+      l_settings.beginGroup(i_section_name);
+
+      QString i_track_name = l_settings.value(l_fetcher.lookup_value("file_name")).toString();
+      if (i_track_name.isEmpty())
+      {
+        qWarning() << "error: empty file name in section" << i_section_name;
+        l_settings.endGroup();
+        continue;
+      }
       if (!QFileInfo::exists(ao_app->get_music_path(i_track_name)))
       {
         qWarning() << "error: audiotrack not found" << i_track_name;
+        l_settings.endGroup();
         continue;
       }
 
@@ -65,7 +75,6 @@ void DRAudiotrackMetadata::update_cache()
       }
       l_new_audiotrack_origin.insert(l_lower_track_name, l_ini_path);
 
-      l_settings.beginGroup(i_track_name);
       DRAudiotrackMetadata l_audiotrack;
       l_audiotrack.m_file_name = i_track_name;
       l_audiotrack.m_title = l_settings.value(l_fetcher.lookup_value("title")).toString();

--- a/src/draudiotrackmetadata.cpp
+++ b/src/draudiotrackmetadata.cpp
@@ -54,13 +54,13 @@ void DRAudiotrackMetadata::update_cache()
       l_settings.beginGroup(i_group);
       DRAudiotrackMetadata l_audiotrack;
       l_audiotrack.m_title = l_settings.value(l_fetcher.lookup_value("title")).toString();
-      l_audiotrack.m_file_name = l_settings.value(l_fetcher.lookup_value("file_name")).toString();
+      l_audiotrack.m_filename = l_settings.value(l_fetcher.lookup_value("filename")).toString();
       l_audiotrack.m_play_once = l_settings.value(l_fetcher.lookup_value("play_once")).toBool();
       l_audiotrack.m_loop_start = l_settings.value(l_fetcher.lookup_value("loop_start")).toULongLong();
       l_audiotrack.m_loop_end = l_settings.value(l_fetcher.lookup_value("loop_end")).toULongLong();
       l_settings.endGroup();
 
-      const QString l_track_name = l_audiotrack.m_file_name;
+      const QString l_track_name = l_audiotrack.m_filename;
       if (l_track_name.isEmpty())
       {
         qWarning() << "error: empty file name in section" << i_group;
@@ -88,7 +88,7 @@ void DRAudiotrackMetadata::update_cache()
 DRAudiotrackMetadata::DRAudiotrackMetadata()
 {}
 
-DRAudiotrackMetadata::DRAudiotrackMetadata(QString p_file_name) : m_file_name(p_file_name)
+DRAudiotrackMetadata::DRAudiotrackMetadata(QString p_file_name) : m_filename(p_file_name)
 {
   const QString l_lower_file_name = p_file_name.toLower();
   if (s_audiotrack_cache.contains(l_lower_file_name))
@@ -100,14 +100,14 @@ DRAudiotrackMetadata::DRAudiotrackMetadata(QString p_file_name) : m_file_name(p_
 DRAudiotrackMetadata::~DRAudiotrackMetadata()
 {}
 
-QString DRAudiotrackMetadata::file_name()
+QString DRAudiotrackMetadata::filename()
 {
-  return m_file_name;
+  return m_filename;
 }
 
 QString DRAudiotrackMetadata::title()
 {
-  return m_title.isEmpty() ? m_file_name : m_title;
+  return m_title.isEmpty() ? m_filename : m_title;
 }
 
 bool DRAudiotrackMetadata::play_once()

--- a/src/draudiotrackmetadata.h
+++ b/src/draudiotrackmetadata.h
@@ -11,14 +11,14 @@ public:
   DRAudiotrackMetadata(QString file_name);
   ~DRAudiotrackMetadata();
 
-  QString file_name();
+  QString filename();
   QString title();
   bool play_once();
   quint64 loop_start();
   quint64 loop_end();
 
 private:
-  QString m_file_name;
+  QString m_filename;
   QString m_title;
   bool m_play_once = false;
   quint64 m_loop_start = 0;


### PR DESCRIPTION
This prevents the issue of having to have filenames that do not have `[ ] /`